### PR TITLE
Make Result a structure instead of class

### DIFF
--- a/CSharpFunctionalExtensions/Result.cs
+++ b/CSharpFunctionalExtensions/Result.cs
@@ -1,77 +1,188 @@
 ﻿using System;
+using System.Diagnostics;
+using System.Text;
 
 
 namespace CSharpFunctionalExtensions
 {
-    public class Result
+    public interface IResult
     {
-        public bool IsSuccess { get; }
-        public string Error { get; }
-        public bool IsFailure => !IsSuccess;
+        bool IsFailure { get; }
+        bool IsSuccess { get; }
+        string Error { get; }
+    }
 
-        protected Result(bool isSuccess, string error)
+    public interface IResult<out T> : IResult
+    {
+        T Value { get; }
+    }
+
+
+    internal sealed class ResultCommonLogic
+    {
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        private readonly string _error;
+
+        public bool IsFailure { get; }
+
+        public bool IsSuccess => !IsFailure;
+
+        public string Error
         {
-            if (error == null)
-                throw new ArgumentNullException(nameof(error));
-            if (isSuccess && error != string.Empty)
-                throw new InvalidOperationException();
-            if (!isSuccess && error == string.Empty)
-                throw new InvalidOperationException();
+            [DebuggerStepThrough]
+            get
+            {
+                if (IsSuccess)
+                    throw new InvalidOperationException("There is no error message for success.");
 
-            IsSuccess = isSuccess;
-            Error = error;
+                return _error;
+            }
         }
 
-        public static Result Fail(string message)
+        [DebuggerStepThrough]
+        public ResultCommonLogic(bool isFailure, string error)
         {
-            return new Result(false, message);
+            if (isFailure)
+            {
+                if (string.IsNullOrWhiteSpace(error))
+                    throw new ArgumentNullException(nameof(error), "There must be error message for failure.");
+            }
+            else
+            {
+                if (error != null)
+                    throw new ArgumentException("There should be no error message for success.", nameof(error));
+            }
+
+            IsFailure = isFailure;
+            _error = error;
+        }
+    }
+
+    public struct Result : IResult
+    {
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        private readonly ResultCommonLogic _logic;
+
+        public bool IsFailure => _logic.IsFailure;
+
+        public bool IsSuccess => _logic.IsSuccess;
+
+        public string Error => _logic.Error;
+
+        [DebuggerStepThrough]
+        private Result(bool isFailure, string error)
+        {
+            _logic = new ResultCommonLogic(isFailure, error);
         }
 
-        public static Result<T> Fail<T>(string message)
-        {
-            return new Result<T>(default(T), false, message);
-        }
-
+        [DebuggerStepThrough]
         public static Result Ok()
         {
-            return new Result(true, string.Empty);
+            return new Result(false, null);
         }
 
+        [DebuggerStepThrough]
+        public static Result Fail(string error)
+        {
+            return new Result(true, error);
+        }
+
+        [DebuggerStepThrough]
         public static Result<T> Ok<T>(T value)
         {
-            return new Result<T>(value, true, string.Empty);
+            return new Result<T>(false, value, null);
         }
 
-        public static Result Combine(params Result[] results)
+        [DebuggerStepThrough]
+        public static Result<T> Fail<T>(string error)
         {
-            foreach (Result result in results)
+            return new Result<T>(true, default(T), error);
+        }
+
+        /// <summary>
+        /// Returns first failure in the list of <paramref name="results"/>. If there is no failure returns success.
+        /// </summary>
+        /// <param name="results">List of results.</param>
+        [DebuggerStepThrough]
+        public static Result FirstFailureOrSuccess(params IResult[] results)
+        {
+            foreach (var result in results)
             {
                 if (result.IsFailure)
-                    return result;
+                    return Fail(result.Error);
             }
 
             return Ok();
         }
+
+        /// <summary>
+        /// Returns failure which combined from all failures in the <paramref name="results"/> list. Error messages are separated by <paramref name="errorMessagesSeparator"/>. 
+        /// If there is no failure returns success.
+        /// </summary>
+        /// <param name="errorMessagesSeparator">Separator for error messages.</param>
+        /// <param name="results">List of results.</param>
+        [DebuggerStepThrough]
+        public static Result Combine(string errorMessagesSeparator, params IResult[] results)
+        {
+            StringBuilder errorMessageBuilder = null;
+
+            foreach (var result in results)
+            {
+                if (result.IsFailure)
+                {
+                    if (errorMessageBuilder == null)
+                    { errorMessageBuilder = new StringBuilder(); }
+
+                    if (errorMessageBuilder.Length > 0)
+                    { errorMessageBuilder.Append(errorMessagesSeparator); }
+
+                    errorMessageBuilder.Append(result.Error);
+                }
+            }
+
+            if (errorMessageBuilder == null)
+            { return Ok(); }
+
+            return Fail(errorMessageBuilder.ToString());
+        }
     }
 
-
-    public sealed class Result<T> : Result
+    public struct Result<T> : IResult<T>
     {
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        private readonly ResultCommonLogic _logic;
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
         private readonly T _value;
+
+        public bool IsFailure => _logic.IsFailure;
+
+        public bool IsSuccess => _logic.IsSuccess;
+
+        public string Error => _logic.Error;
+
         public T Value
         {
+            [DebuggerStepThrough]
             get
             {
                 if (!IsSuccess)
-                    throw new InvalidOperationException();
+                    throw new InvalidOperationException("There is no value for failure.");
 
                 return _value;
             }
         }
 
-        internal Result(T value, bool isSuccess, string error)
-            : base(isSuccess, error)
+        [DebuggerStepThrough]
+        internal Result(bool isFailure, T value, string error)
         {
+            _logic = new ResultCommonLogic(isFailure, error);
+
+            if (!isFailure)
+            {
+                if (value == null)
+                    throw new ArgumentNullException(nameof(value));
+            }
+
             _value = value;
         }
     }


### PR DESCRIPTION
I suggest to make the Result to be a structure instead of class. In this case there is no really a way to return null where Result is expected.