### PR TITLE
Private error messages. Methods for conversion of exceptions to result.

### DIFF
--- a/CSharpFunctionalExtensions.Tests/ResultTests/CombineMethodTests.cs
+++ b/CSharpFunctionalExtensions.Tests/ResultTests/CombineMethodTests.cs
@@ -35,13 +35,14 @@ namespace CSharpFunctionalExtensions.Tests.ResultTests
         public void Combine_combines_all_errors_together()
         {
             Result result1 = Result.Ok();
-            Result result2 = Result.Fail("Failure 1");
-            Result result3 = Result.Fail("Failure 2");
+            Result result2 = Result.Fail("Failure 1", "Private failure 1");
+            Result result3 = Result.Fail("Failure 2", "Private failure 2");
 
             Result result = Result.Combine(";", result1, result2, result3);
 
             result.IsSuccess.Should().BeFalse();
             result.Error.Should().Be("Failure 1;Failure 2");
+            result.PrivateError.Should().Be("Private failure 1;Private failure 2");
         }
 
         [Fact]

--- a/CSharpFunctionalExtensions.Tests/ResultTests/FailedResultTests.cs
+++ b/CSharpFunctionalExtensions.Tests/ResultTests/FailedResultTests.cs
@@ -13,6 +13,31 @@ namespace CSharpFunctionalExtensions.Tests.ResultTests
             Result result = Result.Fail("Error message");
 
             result.Error.Should().Be("Error message");
+            result.PrivateError.Should().Be("Error message");
+            result.IsFailure.Should().Be(true);
+            result.IsSuccess.Should().Be(false);
+        }
+
+        [Fact]
+        public void Can_create_a_non_generic_version_with_different_private_error()
+        {
+            Result result = Result.Fail("Error message", "Private error message");
+
+            result.Error.Should().Be("Error message");
+            result.PrivateError.Should().Be("Private error message");
+            result.IsFailure.Should().Be(true);
+            result.IsSuccess.Should().Be(false);
+        }
+
+        [Fact]
+        public void Can_create_a_non_generic_version_from_exception()
+        {
+            var ex = new Exception("Exception message");
+
+            Result result = Result.Fail(ex);
+
+            result.Error.Should().Be("Exception message");
+            result.PrivateError.Should().Be(ex.ToString());
             result.IsFailure.Should().Be(true);
             result.IsSuccess.Should().Be(false);
         }
@@ -23,6 +48,31 @@ namespace CSharpFunctionalExtensions.Tests.ResultTests
             Result<MyClass> result = Result.Fail<MyClass>("Error message");
 
             result.Error.Should().Be("Error message");
+            result.PrivateError.Should().Be("Error message");
+            result.IsFailure.Should().Be(true);
+            result.IsSuccess.Should().Be(false);
+        }
+
+        [Fact]
+        public void Can_create_a_generic_version_with_different_private_error()
+        {
+            Result<MyClass> result = Result.Fail<MyClass>("Error message", "Private error message");
+
+            result.Error.Should().Be("Error message");
+            result.PrivateError.Should().Be("Private error message");
+            result.IsFailure.Should().Be(true);
+            result.IsSuccess.Should().Be(false);
+        }
+
+        [Fact]
+        public void Can_create_a_generic_version_from_exception()
+        {
+            var ex = new Exception("Exception message");
+
+            Result<MyClass> result = Result.Fail<MyClass>(ex);
+
+            result.Error.Should().Be("Exception message");
+            result.PrivateError.Should().Be(ex.ToString());
             result.IsFailure.Should().Be(true);
             result.IsSuccess.Should().Be(false);
         }
@@ -40,9 +90,9 @@ namespace CSharpFunctionalExtensions.Tests.ResultTests
         [Fact]
         public void Cannot_create_without_error_message()
         {
-            Action action1 = () => { Result.Fail(null); };
+            Action action1 = () => { Result.Fail((string)null); };
             Action action2 = () => { Result.Fail(string.Empty); };
-            Action action3 = () => { Result.Fail<MyClass>(null); };
+            Action action3 = () => { Result.Fail<MyClass>((string)null); };
             Action action4 = () => { Result.Fail<MyClass>(string.Empty); };
 
             action1.ShouldThrow<ArgumentNullException>();
@@ -51,6 +101,35 @@ namespace CSharpFunctionalExtensions.Tests.ResultTests
             action4.ShouldThrow<ArgumentNullException>();
         }
 
+        [Fact]
+        public void Cannot_create_without_exception()
+        {
+            Action action1 = () => { Result.Fail((Exception)null); };
+            Action action2 = () => { Result.Fail<MyClass>((Exception)null); };
+
+            action1.ShouldThrow<ArgumentNullException>();
+            action2.ShouldThrow<ArgumentNullException>();
+        }
+
+        [Fact]
+        public void Can_create_a_non_generic_version_from_action_throwing_exception()
+        {
+            Result result = Result.FailOnException(() => { throw new Exception("Exception message"); });
+
+            result.Error.Should().Be("Exception message");
+            result.IsFailure.Should().Be(true);
+            result.IsSuccess.Should().Be(false);
+        }
+
+        [Fact]
+        public void Can_create_a_generic_version_from_function_throwing_exception()
+        {
+            Result<MyClass> result = Result.FailOnException<MyClass>(() => { throw new Exception("Exception message"); });
+
+            result.Error.Should().Be("Exception message");
+            result.IsFailure.Should().Be(true);
+            result.IsSuccess.Should().Be(false);
+        }
 
         private class MyClass
         {

--- a/CSharpFunctionalExtensions.Tests/ResultTests/SucceededResultTests.cs
+++ b/CSharpFunctionalExtensions.Tests/ResultTests/SucceededResultTests.cs
@@ -37,31 +37,49 @@ namespace CSharpFunctionalExtensions.Tests.ResultTests
         }
 
         [Fact]
-        public void Cannot_access_Error_non_generic_version()
+        public void Cannot_access_Errors_non_generic_version()
         {
             Result result = Result.Ok();
 
-            Action action = () =>
-            {
-                string error = result.Error;
-            };
+            Action action1 = () => { string error = result.Error; };
+            Action action2 = () => { string error = result.PrivateError; };
 
-            action.ShouldThrow<InvalidOperationException>();
+            action1.ShouldThrow<InvalidOperationException>();
+            action2.ShouldThrow<InvalidOperationException>();
         }
 
         [Fact]
-        public void Cannot_access_Error_generic_version()
+        public void Cannot_access_Errors_generic_version()
         {
             Result<MyClass> result = Result.Ok(new MyClass());
 
-            Action action = () =>
-            {
-                string error = result.Error;
-            };
+            Action action1 = () => { string error = result.Error; };
+            Action action2 = () => { string error = result.PrivateError; };
 
-            action.ShouldThrow<InvalidOperationException>();
+            action1.ShouldThrow<InvalidOperationException>();
+            action2.ShouldThrow<InvalidOperationException>();
         }
 
+        [Fact]
+        public void Can_create_a_non_generic_version_from_Action()
+        {
+            Result result = Result.FailOnException(() => { });
+
+            result.IsFailure.Should().Be(false);
+            result.IsSuccess.Should().Be(true);
+        }
+
+        [Fact]
+        public void Can_create_a_generic_version_from_function()
+        {
+            var myClass = new MyClass();
+
+            Result<MyClass> result = Result.FailOnException(() => myClass);
+
+            result.IsFailure.Should().Be(false);
+            result.IsSuccess.Should().Be(true);
+            result.Value.Should().Be(myClass);
+        }
 
         private class MyClass
         {

--- a/CSharpFunctionalExtensions/Result.cs
+++ b/CSharpFunctionalExtensions/Result.cs
@@ -11,6 +11,8 @@ namespace CSharpFunctionalExtensions
         bool IsFailure { get; }
         bool IsSuccess { get; }
         string Error { get; }
+
+        string PrivateError { get; }
     }
 
 
@@ -24,6 +26,8 @@ namespace CSharpFunctionalExtensions
     {
         [DebuggerBrowsable(DebuggerBrowsableState.Never)]
         private readonly string _error;
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        private readonly string _privateError;
 
         public bool IsFailure { get; }
         public bool IsSuccess => !IsFailure;
@@ -40,8 +44,21 @@ namespace CSharpFunctionalExtensions
             }
         }
 
+        public string PrivateError
+        {
+            [DebuggerStepThrough]
+            get
+            {
+                if (IsSuccess)
+                    throw new InvalidOperationException("There is no private error message for success.");
+
+                return _privateError;
+            }
+        }
+
+
         [DebuggerStepThrough]
-        public ResultCommonLogic(bool isFailure, string error)
+        public ResultCommonLogic(bool isFailure, string error, string privateError = null)
         {
             if (isFailure)
             {
@@ -52,10 +69,13 @@ namespace CSharpFunctionalExtensions
             {
                 if (error != null)
                     throw new ArgumentException("There should be no error message for success.", nameof(error));
+                if (privateError != null)
+                    throw new ArgumentException("There should be no private error message for success.", nameof(privateError));
             }
 
             IsFailure = isFailure;
             _error = error;
+            _privateError = privateError ?? error;
         }
     }
 
@@ -68,11 +88,12 @@ namespace CSharpFunctionalExtensions
         public bool IsFailure => _logic.IsFailure;
         public bool IsSuccess => _logic.IsSuccess;
         public string Error => _logic.Error;
+        public string PrivateError => _logic.PrivateError;
 
         [DebuggerStepThrough]
-        private Result(bool isFailure, string error)
+        private Result(bool isFailure, string error, string privateError = null)
         {
-            _logic = new ResultCommonLogic(isFailure, error);
+            _logic = new ResultCommonLogic(isFailure, error, privateError);
         }
 
         [DebuggerStepThrough]
@@ -82,9 +103,17 @@ namespace CSharpFunctionalExtensions
         }
 
         [DebuggerStepThrough]
-        public static Result Fail(string error)
+        public static Result Fail(string error, string privateError = null)
         {
-            return new Result(true, error);
+            return new Result(true, error, privateError);
+        }
+
+        [DebuggerStepThrough]
+        public static Result Fail(Exception ex)
+        {
+            if (ex == null) throw new ArgumentNullException(nameof(ex), "Exception can't be null");
+
+            return new Result(true, ex.Message, ex.ToString());
         }
 
         [DebuggerStepThrough]
@@ -94,9 +123,17 @@ namespace CSharpFunctionalExtensions
         }
 
         [DebuggerStepThrough]
-        public static Result<T> Fail<T>(string error)
+        public static Result<T> Fail<T>(string error, string privateError = null)
         {
-            return new Result<T>(true, default(T), error);
+            return new Result<T>(true, default(T), error, privateError);
+        }
+
+        [DebuggerStepThrough]
+        public static Result<T> Fail<T>(Exception ex)
+        {
+            if (ex == null) throw new ArgumentNullException(nameof(ex), "Exception can't be null");
+
+            return new Result<T>(true, default(T), ex.Message, ex.ToString());
         }
 
         /// <summary>
@@ -130,13 +167,43 @@ namespace CSharpFunctionalExtensions
                 return Ok();
 
             string errorMessage = string.Join(errorMessagesSeparator, failedResults.Select(x => x.Error).ToArray());
-            return Fail(errorMessage);
+            string privateErrorMessage = string.Join(errorMessagesSeparator, failedResults.Select(x => x.PrivateError).ToArray());
+            return Fail(errorMessage, privateErrorMessage);
         }
 
         [DebuggerStepThrough]
         public static Result Combine(params IResult[] results)
         {
             return Combine(",", results);
+        }
+
+        public static Result FailOnException(Action action)
+        {
+            if (action == null) throw new ArgumentNullException(nameof(action));
+
+            try
+            {
+                action();
+                return Ok();
+            }
+            catch (Exception ex)
+            {
+                return Fail(ex);
+            }
+        }
+
+        public static Result<T> FailOnException<T>(Func<T> func)
+        {
+            if (func == null) throw new ArgumentNullException(nameof(func));
+
+            try
+            {
+                return Ok(func());
+            }
+            catch (Exception ex)
+            {
+                return Fail<T>(ex);
+            }
         }
     }
 
@@ -149,6 +216,7 @@ namespace CSharpFunctionalExtensions
         public bool IsFailure => _logic.IsFailure;
         public bool IsSuccess => _logic.IsSuccess;
         public string Error => _logic.Error;
+        public string PrivateError => _logic.PrivateError;
 
         [DebuggerBrowsable(DebuggerBrowsableState.Never)]
         private readonly T _value;
@@ -166,12 +234,12 @@ namespace CSharpFunctionalExtensions
         }
 
         [DebuggerStepThrough]
-        internal Result(bool isFailure, T value, string error)
+        internal Result(bool isFailure, T value, string error, string privateError = null)
         {
             if (!isFailure && value == null)
                 throw new ArgumentNullException(nameof(value));
 
-            _logic = new ResultCommonLogic(isFailure, error);
+            _logic = new ResultCommonLogic(isFailure, error, privateError);
             _value = value;
         }
     }


### PR DESCRIPTION
Frequently there are two types of error messages:

* Public error messages that should be displayed to user.
* Private error messages that should be stored into logs and analyzed by developers.

The simplest example of this separation comes from exceptions. Message of exception sometimes can be shown to user. But exception also contains stack trace which should not be displayed to user but has a great value for developer.

This pull request adds support of private error messages into Result. If private error message is not set explicitly then it will be the same as public error message.

Also several methods for creation of Result from exceptions are added.