### PR TITLE
Add Func<> equivalent to Execute Action<> Maybe extension

### DIFF
--- a/CSharpFunctionalExtensions.Tests/MaybeTests/ExtensionsTests.cs
+++ b/CSharpFunctionalExtensions.Tests/MaybeTests/ExtensionsTests.cs
@@ -156,6 +156,15 @@ namespace CSharpFunctionalExtensions.Tests.MaybeTests
             property.Should().Be("Some value");
         }
 
+        [Fact]
+        public void Execute_returns_func_result()
+        {
+            Maybe<MyClass> maybe = new MyClass { Property = "Some value" };
+
+            string property = maybe.Execute(x => x.Property);
+
+            property.Should().Be("Some value");
+        }
 
         private static Maybe<string> GetPropertyIfExists(MyClass myClass)
         {

--- a/CSharpFunctionalExtensions/MaybeExtensions.cs
+++ b/CSharpFunctionalExtensions/MaybeExtensions.cs
@@ -69,5 +69,14 @@ namespace CSharpFunctionalExtensions
 
             action(maybe.Value);
         }
+
+        public static TOut Execute<T, TOut>(this Maybe<T> maybe, Func<T, TOut> func)
+            where T : class
+        {
+            if (maybe.HasNoValue)
+                return default(TOut);
+
+            return func(maybe.Value);
+        }
     }
 }


### PR DESCRIPTION
Great library, love the approach and your Enterprise Craftsmanship series 😊 

When using the library in my own project I found that I sometimes wanted to return a value from the Maybe<>.Execute() extension method, so I've added a Func<> overload in this PR in the hope that it might be of use to others.