### PR TITLE
Add more missing onfailure overloads

### DIFF
--- a/CSharpFunctionalExtensions/AsyncResultExtensionsLeftOperand.cs
+++ b/CSharpFunctionalExtensions/AsyncResultExtensionsLeftOperand.cs
@@ -117,7 +117,7 @@ namespace CSharpFunctionalExtensions
             return result.OnFailure(action);
         }
 
-        public static async Task<Result> OnFailureExt(this Task<Result> resultTask, Action<string> action)
+        public static async Task<Result> OnFailure(this Task<Result> resultTask, Action<string> action)
         {
             Result result = await resultTask.ConfigureAwait(false);
             return result.OnFailure(action);

--- a/CSharpFunctionalExtensions/AsyncResultExtensionsLeftOperand.cs
+++ b/CSharpFunctionalExtensions/AsyncResultExtensionsLeftOperand.cs
@@ -116,5 +116,11 @@ namespace CSharpFunctionalExtensions
             Result<T> result = await resultTask.ConfigureAwait(false);
             return result.OnFailure(action);
         }
+
+        public static async Task<Result> OnFailureExt(this Task<Result> resultTask, Action<string> action)
+        {
+            Result result = await resultTask.ConfigureAwait(false);
+            return result.OnFailure(action);
+        }
     }
 }

--- a/CSharpFunctionalExtensions/ResultExtensions.cs
+++ b/CSharpFunctionalExtensions/ResultExtensions.cs
@@ -157,5 +157,15 @@ namespace CSharpFunctionalExtensions
 
             return result;
         }
+
+        public static Result OnFailure(this Result result, Action<string> action)
+        {
+            if (result.IsFailure)
+            {
+                action(result.Error);
+            }
+
+            return result;
+        }
     }
 }


### PR DESCRIPTION
There are so many permutations of method signatures for sync and async on these methods, this was just one i found that was missed: 

public static async Task<Result> OnFailure(this Task<Result> resultTask, Action<string> action)

The modification to ResultExtensions.cs just supports the above method call following the conventions of the others.