### PR TITLE
Add generic combine method

### DIFF
--- a/CSharpFunctionalExtensions.Tests/ResultTests/CombineMethodTests.cs
+++ b/CSharpFunctionalExtensions.Tests/ResultTests/CombineMethodTests.cs
@@ -55,5 +55,26 @@ namespace CSharpFunctionalExtensions.Tests.ResultTests
 
             result.IsSuccess.Should().BeTrue();
         }
+
+        [Fact]
+        public void Combine_works_with_array_of_Generic_results_success()
+        {
+            Result<string>[] results = new Result<string>[]{ Result.Ok(""), Result.Ok("") };
+
+            Result result = Result.Combine(";", results);
+
+            result.IsSuccess.Should().BeTrue();
+        }
+
+
+        [Fact]
+        public void Combine_works_with_array_of_Generic_results_failure()
+        {
+            Result<string>[] results = new Result<string>[] { Result.Ok(""), Result.Fail<string>("m") };
+
+            Result result = Result.Combine(";", results);
+
+            result.IsSuccess.Should().BeFalse();
+        }
     }
 }

--- a/CSharpFunctionalExtensions/Result.cs
+++ b/CSharpFunctionalExtensions/Result.cs
@@ -126,6 +126,19 @@ namespace CSharpFunctionalExtensions
         {
             return Combine(", ", results);
         }
+
+        [DebuggerStepThrough]
+        public static Result Combine<T>(params Result<T>[] results)
+        {
+            return Combine(", ", results);
+        }
+
+        [DebuggerStepThrough]
+        public static Result Combine<T>(string errorMessagesSeparator, params Result<T>[] results)
+        {
+            Result[] untyped = results.Select(result => (Result)result).ToArray();
+            return Result.Combine(", ", untyped);
+        }
     }
 
 

--- a/CSharpFunctionalExtensions/Result.cs
+++ b/CSharpFunctionalExtensions/Result.cs
@@ -137,7 +137,7 @@ namespace CSharpFunctionalExtensions
         public static Result Combine<T>(string errorMessagesSeparator, params Result<T>[] results)
         {
             Result[] untyped = results.Select(result => (Result)result).ToArray();
-            return Result.Combine(", ", untyped);
+            return Combine(errorMessagesSeparator, untyped);
         }
     }
 


### PR DESCRIPTION
While there was a working test for combining a Result<T> with an untyped Result, surprisingly it was not possible to pass in a Result<T>[]. 

I could find no elegant way to pass a Result<T>[] off as a Result[].  If that exists, then let me know and this is unnecessary. 

If this is needed, then I'm also not sure if there's a more efficient way to implement.  I used Linq to cast each Result<T> back to Result and then passed the new array to the existing Result.Combine method. 