### PR TITLE
Added flatmap methods, unit tests, and examples

### DIFF
--- a/CSharpFunctionalExtensions.Examples/CSharpFunctionalExtensions.Examples.csproj
+++ b/CSharpFunctionalExtensions.Examples/CSharpFunctionalExtensions.Examples.csproj
@@ -40,6 +40,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="ResultExtensions\FlatMapUsageExamples.cs" />
     <Compile Include="ResultExtensions\AsyncUsageExamples.cs" />
     <Compile Include="ResultExtensions\ExampleFromPluralsightCourse.cs" />
     <Compile Include="ResultExtensions\ExampleWithOnFailureMethod.cs" />

--- a/CSharpFunctionalExtensions.Examples/ResultExtensions/FlatMapUsageExamples.cs
+++ b/CSharpFunctionalExtensions.Examples/ResultExtensions/FlatMapUsageExamples.cs
@@ -1,0 +1,56 @@
+﻿using System;
+using System.Threading.Tasks;
+using System.IO;
+
+namespace CSharpFunctionalExtensions.Examples.ResultExtensions
+{
+    public class FlatMapUsageExamples
+    {
+        //"TryParseInt" is a common example of wrapping a native unsafe function into a result
+        //
+        //When using TryParseInt inside Map(), would end up with a nested result (Result<Result<int>>)
+        //This creates a challenge when chaining the next function with OnSuccess or OnFailure
+        //Instead, we can use FlatMap to "lift" the inner Result out of the enclosing Result
+
+        public static void Main()
+        {
+            //In many cases, we might start off with a Result of some primitive type
+            Result<string> NumberInAString = Result.Ok("123");
+            Result<string> NotANumberInAString = Result.Ok("abc");
+
+            //Flatmap ensures the OnFailure logic works as expected in these scenarios
+            Result<int> ResultOfInt = NumberInAString
+                .FlatMap(myNumStr => TryParseInt(myNumStr));
+            
+            ResultOfInt
+                .OnFailure(message => { /*message is the message from TryParseInt*/})
+                .OnSuccess(actualInt => { /*actualInt is the raw value we wanted*/});
+
+            //Here's what Map would have returned:
+            Result<Result<int>> NestedResult = NumberInAString
+                .Map(myNumStr => TryParseInt(myNumStr));
+
+            //Chaining this would require nested OnSuccess, which undermines the OnFailure logic
+            NestedResult
+                .OnSuccess(resultOfInt => resultOfInt
+                    .OnFailure(message => { /*message is the message from TryParseInt*/})
+                    .OnSuccess(actualInt => { /*actualInt is the raw value we wanted*/}));
+
+            //We can't get back to the top level pipeline with our inner result effectively
+            //This is one of the reasons FlatMap exists in Functional Programming
+        }
+
+        public static Result<int> TryParseInt(string value)
+        {
+            bool Status = Int32.TryParse(value, out int Number);
+            if (Status)
+            {
+                return Result.Ok(Number);
+            }
+            else
+            {
+                return Result.Fail<int>("Could not parse string as number");
+            }
+        }
+    }
+}

--- a/CSharpFunctionalExtensions.Tests/ResultTests/ExtensionTests.cs
+++ b/CSharpFunctionalExtensions.Tests/ResultTests/ExtensionTests.cs
@@ -1,4 +1,5 @@
 ﻿using FluentAssertions;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace CSharpFunctionalExtensions.Tests.ResultTests
@@ -38,6 +39,24 @@ namespace CSharpFunctionalExtensions.Tests.ResultTests
             myResult.OnFailure(error => myError = error);
 
             myError.Should().Be(_errorMessage);
+        }
+
+        [Fact]
+        public void Can_return_inner_result_type_synchronous()
+        {
+            Result<string> combinedString = Result.Ok("string")
+                .FlatMap(str => Result.Ok($"{str} appended"));
+
+            combinedString.Value.Should().BeEquivalentTo("string appended");
+        }
+
+        [Fact]
+        public async Task Can_return_inner_result_type_asynchronous()
+        {
+            Result<string> combinedString = await Task.Run(() => Result.Ok("string"))
+                .FlatMap(str => Task.Run(() => Result.Ok($"{str} appended")));
+
+            combinedString.Value.Should().BeEquivalentTo("string appended");
         }
 
 

--- a/CSharpFunctionalExtensions/AsyncResultExtensionsBothOperands.cs
+++ b/CSharpFunctionalExtensions/AsyncResultExtensionsBothOperands.cs
@@ -204,5 +204,32 @@ namespace CSharpFunctionalExtensions
 
             return result;
         }
+
+        public static async Task<Result<K>> FlatMap<T, K>(this Task<Result<T>> resultTask, Func<T, Result<K>> func)
+        {
+            Result<T> result = await resultTask.ConfigureAwait(false);
+
+            if (result.IsFailure)
+                return Result.Fail<K>(result.Error);
+
+            Result<K> newResult = func(result.Value);
+
+            if (newResult.IsFailure)
+                return newResult;
+
+            return Result.Ok(newResult.Value);
+        }
+
+        public static async Task<Result<K>> FlatMap<T, K>(this Task<Result<T>> resultTask, Func<T, Task<Result<K>>> func)
+        {
+            Result<T> result = await resultTask.ConfigureAwait(false);
+
+            if (result.IsFailure)
+                return Result.Fail<K>(result.Error);
+
+            Result<K> newResult = await func(result.Value).ConfigureAwait(false);
+
+            return Result.Ok(newResult.Value);
+        }
     }
 }

--- a/CSharpFunctionalExtensions/AsyncResultExtensionsRightOperand.cs
+++ b/CSharpFunctionalExtensions/AsyncResultExtensionsRightOperand.cs
@@ -169,5 +169,18 @@ namespace CSharpFunctionalExtensions
 
             return result;
         }
+
+        public static async Task<Result<K>> FlatMap<T, K>(this Result<T> result, Func<T, Task<Result<K>>> func)
+        {
+            if (result.IsFailure)
+                return Result.Fail<K>(result.Error);
+
+            Result<K> newResult = await func(result.Value).ConfigureAwait(false);
+
+            if (newResult.IsFailure)
+                return newResult;
+
+            return Result.Ok(newResult.Value);
+        }
     }
 }

--- a/CSharpFunctionalExtensions/ResultExtensions.cs
+++ b/CSharpFunctionalExtensions/ResultExtensions.cs
@@ -157,5 +157,18 @@ namespace CSharpFunctionalExtensions
 
             return result;
         }
+
+        public static Result<K> FlatMap<T, K>(this Result<T> result, Func<T, Result<K>> func)
+        {
+            if (result.IsFailure)
+                return Result.Fail<K>(result.Error);
+
+            Result<K> newResult = func(result.Value);
+
+            if (newResult.IsFailure)
+                return newResult;
+
+            return Result.Ok(newResult.Value);
+        }
     }
 }


### PR DESCRIPTION
I think this is a major fundamental addition to the library, which is present in most functional languages for constructs like Optional, Result, Either, Etc. 

I see attempts to work around the lack of FlatMap with this kind of technique, which I also used for a time:
```
.OnSuccess(customer => gateway.SendPromotionNotification(customer.Email))
.OnBoth(result => result.IsSuccess ? "Ok" : result.Error);
```

Taken from here:
https://github.com/vkhorikov/CSharpFunctionalExtensions/blob/master/CSharpFunctionalExtensions.Examples/ResultExtensions/AsyncUsageExamples.cs

Beyond just being more concise, there are significant challenges with the previous workaround did not solve, and FlatMap does. 