### PR TITLE
Revert "Update to netstandard 1.3, added ISerializable"

### DIFF
--- a/CSharpFunctionalExtensions.Examples/CSharpFunctionalExtensions.Examples.csproj
+++ b/CSharpFunctionalExtensions.Examples/CSharpFunctionalExtensions.Examples.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard1.0</TargetFramework>
+    <TargetFramework>netstandard1.3</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/CSharpFunctionalExtensions/CSharpFunctionalExtensions.csproj
+++ b/CSharpFunctionalExtensions/CSharpFunctionalExtensions.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard1.0</TargetFramework>
+    <TargetFramework>netstandard1.3</TargetFramework>
     <PackageId>CSharpFunctionalExtensions</PackageId>
     <PackageVersion>1.8.0</PackageVersion>
     <Authors>Vladimir Khorikov</Authors>
@@ -14,5 +14,9 @@
     <Version>1.8.0</Version>
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
   </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="System.Runtime.Serialization.Formatters" Version="4.3.0" />
+  </ItemGroup>
 
 </Project>

--- a/CSharpFunctionalExtensions/Result.cs
+++ b/CSharpFunctionalExtensions/Result.cs
@@ -2,7 +2,7 @@
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
-
+using System.Runtime.Serialization;
 
 namespace CSharpFunctionalExtensions
 {
@@ -46,9 +46,19 @@ namespace CSharpFunctionalExtensions
     }
 
 
-    public struct Result
+    public struct Result : ISerializable
     {
         private static readonly Result OkResult = new Result(false, null);
+
+        void ISerializable.GetObjectData(SerializationInfo oInfo, StreamingContext oContext)
+        {
+            oInfo.AddValue("IsFailure", IsFailure);
+            oInfo.AddValue("IsSuccess", IsSuccess);
+            if (IsFailure)
+            {
+                oInfo.AddValue("Error", Error);
+            }
+        }
 
         [DebuggerBrowsable(DebuggerBrowsableState.Never)]
         private readonly ResultCommonLogic _logic;
@@ -142,7 +152,7 @@ namespace CSharpFunctionalExtensions
     }
 
 
-    public struct Result<T>
+    public struct Result<T> : ISerializable
     {
         [DebuggerBrowsable(DebuggerBrowsableState.Never)]
         private readonly ResultCommonLogic _logic;
@@ -150,6 +160,20 @@ namespace CSharpFunctionalExtensions
         public bool IsFailure => _logic.IsFailure;
         public bool IsSuccess => _logic.IsSuccess;
         public string Error => _logic.Error;
+
+        void ISerializable.GetObjectData(SerializationInfo oInfo, StreamingContext oContext)
+        {
+            oInfo.AddValue("IsFailure", IsFailure);
+            oInfo.AddValue("IsSuccess", IsSuccess);
+            if (IsFailure)
+            {
+                oInfo.AddValue("Error", Error);
+            }
+            else
+            {
+                oInfo.AddValue("Value", Value);
+            }
+        }
 
         [DebuggerBrowsable(DebuggerBrowsableState.Never)]
         private readonly T _value;


### PR DESCRIPTION
Waiting 6 days until netstandard 2.0 comes out to add tests.  Netstandard 2.0 contains the necessary BinaryFormatter not currently available in netstandard 1.x