### PR TITLE
multiframework support: .net standard 2.0, .net standard 1.3, .net 4, .net 4.5, .net 4.6.1

### DIFF
--- a/CSharpFunctionalExtensions.Tests/CSharpFunctionalExtensions.Tests.csproj
+++ b/CSharpFunctionalExtensions.Tests/CSharpFunctionalExtensions.Tests.csproj
@@ -1,14 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>    
-    <TargetFramework>netcoreapp1.1</TargetFramework>
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="4.19.2" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
-    <PackageReference Include="xunit" Version="2.2.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
+    <PackageReference Include="FluentAssertions" Version="4.19.4" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
+    <PackageReference Include="xunit" Version="2.3.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/CSharpFunctionalExtensions.sln
+++ b/CSharpFunctionalExtensions.sln
@@ -1,13 +1,25 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.26228.9
+VisualStudioVersion = 15.0.27004.2002
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CSharpFunctionalExtensions", "CSharpFunctionalExtensions\CSharpFunctionalExtensions.csproj", "{9598EC2B-2119-4FC4-9AC0-9AD5E41CA6A0}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CSharpFunctionalExtensions", "CSharpFunctionalExtensions\CSharpFunctionalExtensions.csproj", "{9598EC2B-2119-4FC4-9AC0-9AD5E41CA6A0}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CSharpFunctionalExtensions.Examples", "CSharpFunctionalExtensions.Examples\CSharpFunctionalExtensions.Examples.csproj", "{5703A8C7-77D1-42E9-ABB4-3AAE7FEF3C06}"
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Tests", "Tests", "{FBDA8B35-373E-4D4A-BB91-40568665D6A5}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CSharpFunctionalExtensions.Tests", "CSharpFunctionalExtensions.Tests\CSharpFunctionalExtensions.Tests.csproj", "{B3FC78DA-AFF2-4A34-9F79-B00F890FBEA4}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LinkTest.4.0", "LinkTest.4.0\LinkTest.4.0.csproj", "{2A4731E2-6728-4B94-8039-1635FA53760C}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LinkTest.4.5", "LinkTest.4.5\LinkTest.4.5.csproj", "{22C8D704-916C-41E7-9495-3AEDEEDA8E2E}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LinkTest.4.6.1", "LinkTest.4.6.1\LinkTest.4.6.1.csproj", "{A90FBD60-EEBE-4B70-951D-B5BE5C53AECF}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LinkTest.Standard.1.3", "LinkTest.Standard.1.3\LinkTest.Standard.1.3.csproj", "{9583EB4B-3183-4FDE-AD1F-2637676308AE}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LinkTest.Standard.2.0", "LinkTest.Standard.2.0\LinkTest.Standard.2.0.csproj", "{CACEF620-87C0-4179-AC00-AC134224B27E}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CSharpFunctionalExtensions.Examples", "CSharpFunctionalExtensions.Examples\CSharpFunctionalExtensions.Examples.csproj", "{C05C3261-447D-40F6-B516-791A01BA5052}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CSharpFunctionalExtensions.Tests", "CSharpFunctionalExtensions.Tests\CSharpFunctionalExtensions.Tests.csproj", "{AAC59D01-6546-4366-B990-4A765EF4D796}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -19,16 +31,47 @@ Global
 		{9598EC2B-2119-4FC4-9AC0-9AD5E41CA6A0}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{9598EC2B-2119-4FC4-9AC0-9AD5E41CA6A0}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{9598EC2B-2119-4FC4-9AC0-9AD5E41CA6A0}.Release|Any CPU.Build.0 = Release|Any CPU
-		{5703A8C7-77D1-42E9-ABB4-3AAE7FEF3C06}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{5703A8C7-77D1-42E9-ABB4-3AAE7FEF3C06}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{5703A8C7-77D1-42E9-ABB4-3AAE7FEF3C06}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{5703A8C7-77D1-42E9-ABB4-3AAE7FEF3C06}.Release|Any CPU.Build.0 = Release|Any CPU
-		{B3FC78DA-AFF2-4A34-9F79-B00F890FBEA4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{B3FC78DA-AFF2-4A34-9F79-B00F890FBEA4}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{B3FC78DA-AFF2-4A34-9F79-B00F890FBEA4}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{B3FC78DA-AFF2-4A34-9F79-B00F890FBEA4}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2A4731E2-6728-4B94-8039-1635FA53760C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2A4731E2-6728-4B94-8039-1635FA53760C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2A4731E2-6728-4B94-8039-1635FA53760C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2A4731E2-6728-4B94-8039-1635FA53760C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{22C8D704-916C-41E7-9495-3AEDEEDA8E2E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{22C8D704-916C-41E7-9495-3AEDEEDA8E2E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{22C8D704-916C-41E7-9495-3AEDEEDA8E2E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{22C8D704-916C-41E7-9495-3AEDEEDA8E2E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A90FBD60-EEBE-4B70-951D-B5BE5C53AECF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A90FBD60-EEBE-4B70-951D-B5BE5C53AECF}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A90FBD60-EEBE-4B70-951D-B5BE5C53AECF}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A90FBD60-EEBE-4B70-951D-B5BE5C53AECF}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9583EB4B-3183-4FDE-AD1F-2637676308AE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9583EB4B-3183-4FDE-AD1F-2637676308AE}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9583EB4B-3183-4FDE-AD1F-2637676308AE}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9583EB4B-3183-4FDE-AD1F-2637676308AE}.Release|Any CPU.Build.0 = Release|Any CPU
+		{CACEF620-87C0-4179-AC00-AC134224B27E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{CACEF620-87C0-4179-AC00-AC134224B27E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{CACEF620-87C0-4179-AC00-AC134224B27E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{CACEF620-87C0-4179-AC00-AC134224B27E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C05C3261-447D-40F6-B516-791A01BA5052}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C05C3261-447D-40F6-B516-791A01BA5052}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C05C3261-447D-40F6-B516-791A01BA5052}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C05C3261-447D-40F6-B516-791A01BA5052}.Release|Any CPU.Build.0 = Release|Any CPU
+		{AAC59D01-6546-4366-B990-4A765EF4D796}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{AAC59D01-6546-4366-B990-4A765EF4D796}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{AAC59D01-6546-4366-B990-4A765EF4D796}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{AAC59D01-6546-4366-B990-4A765EF4D796}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{2A4731E2-6728-4B94-8039-1635FA53760C} = {FBDA8B35-373E-4D4A-BB91-40568665D6A5}
+		{22C8D704-916C-41E7-9495-3AEDEEDA8E2E} = {FBDA8B35-373E-4D4A-BB91-40568665D6A5}
+		{A90FBD60-EEBE-4B70-951D-B5BE5C53AECF} = {FBDA8B35-373E-4D4A-BB91-40568665D6A5}
+		{9583EB4B-3183-4FDE-AD1F-2637676308AE} = {FBDA8B35-373E-4D4A-BB91-40568665D6A5}
+		{CACEF620-87C0-4179-AC00-AC134224B27E} = {FBDA8B35-373E-4D4A-BB91-40568665D6A5}
+		{AAC59D01-6546-4366-B990-4A765EF4D796} = {FBDA8B35-373E-4D4A-BB91-40568665D6A5}
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {24983D81-8FE6-4B71-A64C-6F86C7DFB0B8}
 	EndGlobalSection
 EndGlobal

--- a/CSharpFunctionalExtensions/CSharpFunctionalExtensions.csproj
+++ b/CSharpFunctionalExtensions/CSharpFunctionalExtensions.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard1.3</TargetFramework>
+    <TargetFrameworks>netstandard2.0;netstandard1.3;net40;net45;net461</TargetFrameworks>
     <PackageId>CSharpFunctionalExtensions</PackageId>
     <PackageVersion>1.8.0</PackageVersion>
     <Authors>Vladimir Khorikov</Authors>
@@ -15,8 +15,32 @@
     <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
   </PropertyGroup>
 
-  <ItemGroup>
+  <!-- .net 4.0 doesn't have async support and Microsoft.Bcl.Async doesn't work because of the interactions 
+       between it's dependency chain and the multi-framework build. Howver the AsyncTargetingPack does. -->
+  <ItemGroup Condition="'$(TargetFramework)' == 'net40'">
+    <PackageReference Include="Microsoft.CompilerServices.AsyncTargetingPack" />
+  </ItemGroup>
+
+  <!-- Standard1.3 doesn't have ISerializable and needs an additional reference -->
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.3'">
     <PackageReference Include="System.Runtime.Serialization.Formatters" Version="4.3.0" />
   </ItemGroup>
+
+  <!-- Set titles so the dlls are distinguishable from each other -->
+  <PropertyGroup Condition="'$(TargetFramework)'=='net40'">
+    <AssemblyTitle>CSharpFunctionalExtensions .NET 4.0</AssemblyTitle>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(TargetFramework)'=='net45'">
+    <AssemblyTitle>CSharpFunctionalExtensions .NET 4.5</AssemblyTitle>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(TargetFramework)'=='net461'">
+    <AssemblyTitle>CSharpFunctionalExtensions .NET 4.6.1</AssemblyTitle>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(TargetFramework)'=='netstandard1.3'">
+    <AssemblyTitle>CSharpFunctionalExtensions .NET Standard 1.3</AssemblyTitle>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(TargetFramework)'=='netstandard2.0'">
+    <AssemblyTitle>CSharpFunctionalExtensions .NET Standard 2.0</AssemblyTitle>
+  </PropertyGroup>
 
 </Project>

--- a/LinkTest.4.0/LinkTest.4.0.csproj
+++ b/LinkTest.4.0/LinkTest.4.0.csproj
@@ -1,0 +1,46 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{2A4731E2-6728-4B94-8039-1635FA53760C}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>LinkTest._4._0</RootNamespace>
+    <AssemblyName>LinkTest.4.0</AssemblyName>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Test.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\CSharpFunctionalExtensions\CSharpFunctionalExtensions.csproj">
+      <Project>{9598ec2b-2119-4fc4-9ac0-9ad5e41ca6a0}</Project>
+      <Name>CSharpFunctionalExtensions</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/LinkTest.4.0/Properties/AssemblyInfo.cs
+++ b/LinkTest.4.0/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("LinkTest.4.0")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("LinkTest.4.0")]
+[assembly: AssemblyCopyright("Copyright ©  2017")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("2a4731e2-6728-4b94-8039-1635fa53760c")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/LinkTest.4.0/Test.cs
+++ b/LinkTest.4.0/Test.cs
@@ -1,0 +1,14 @@
+﻿using CSharpFunctionalExtensions;
+
+namespace LinkTest
+{
+    class Test
+    {
+        static void ForceLink() // If the library isn't referenced, it doesn't actually get linked
+        {
+            Maybe<Test> maybe = null;
+
+            System.Diagnostics.Debug.WriteLine(string.Format("maybe HasValue: {0} hasNoValue {1}", maybe.HasValue, maybe.HasNoValue));
+        }
+    }
+}

--- a/LinkTest.4.5/LinkTest.4.5.csproj
+++ b/LinkTest.4.5/LinkTest.4.5.csproj
@@ -1,0 +1,47 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{22C8D704-916C-41E7-9495-3AEDEEDA8E2E}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>LinkTest._4._5</RootNamespace>
+    <AssemblyName>LinkTest.4.5</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="Microsoft.CSharp" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Test.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\CSharpFunctionalExtensions\CSharpFunctionalExtensions.csproj">
+      <Project>{9598ec2b-2119-4fc4-9ac0-9ad5e41ca6a0}</Project>
+      <Name>CSharpFunctionalExtensions</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/LinkTest.4.5/Properties/AssemblyInfo.cs
+++ b/LinkTest.4.5/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("LinkTest.4.5")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("LinkTest.4.5")]
+[assembly: AssemblyCopyright("Copyright ©  2017")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("22c8d704-916c-41e7-9495-3aedeeda8e2e")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/LinkTest.4.5/Test.cs
+++ b/LinkTest.4.5/Test.cs
@@ -1,0 +1,14 @@
+﻿using CSharpFunctionalExtensions;
+
+namespace LinkTest
+{
+    class Test
+    {
+        static void ForceLink() // If the library isn't referenced, it doesn't actually get linked
+        {
+            Maybe<Test> maybe = null;
+
+            System.Diagnostics.Debug.WriteLine(string.Format("maybe HasValue: {0} hasNoValue {1}", maybe.HasValue, maybe.HasNoValue));
+        }
+    }
+}

--- a/LinkTest.4.6.1/LinkTest.4.6.1.csproj
+++ b/LinkTest.4.6.1/LinkTest.4.6.1.csproj
@@ -1,0 +1,47 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{A90FBD60-EEBE-4B70-951D-B5BE5C53AECF}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>LinkTest._4._6._1</RootNamespace>
+    <AssemblyName>LinkTest.4.6.1</AssemblyName>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="Microsoft.CSharp" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Test.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\CSharpFunctionalExtensions\CSharpFunctionalExtensions.csproj">
+      <Project>{9598ec2b-2119-4fc4-9ac0-9ad5e41ca6a0}</Project>
+      <Name>CSharpFunctionalExtensions</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/LinkTest.4.6.1/Properties/AssemblyInfo.cs
+++ b/LinkTest.4.6.1/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("LinkTest.4.6.1")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("LinkTest.4.6.1")]
+[assembly: AssemblyCopyright("Copyright ©  2017")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("a90fbd60-eebe-4b70-951d-b5be5c53aecf")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/LinkTest.4.6.1/Test.cs
+++ b/LinkTest.4.6.1/Test.cs
@@ -1,0 +1,14 @@
+﻿using CSharpFunctionalExtensions;
+
+namespace LinkTest
+{
+    class Test
+    {
+        static void ForceLink() // If the library isn't referenced, it doesn't actually get linked
+        {
+            Maybe<Test> maybe = null;
+
+            System.Diagnostics.Debug.WriteLine(string.Format("maybe HasValue: {0} hasNoValue {1}", maybe.HasValue, maybe.HasNoValue));
+        }
+    }
+}

--- a/LinkTest.Standard.1.3/LinkTest.Standard.1.3.csproj
+++ b/LinkTest.Standard.1.3/LinkTest.Standard.1.3.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard1.3</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\CSharpFunctionalExtensions\CSharpFunctionalExtensions.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/LinkTest.Standard.1.3/Test.cs
+++ b/LinkTest.Standard.1.3/Test.cs
@@ -1,0 +1,14 @@
+﻿using CSharpFunctionalExtensions;
+
+namespace LinkTest
+{
+    class Test
+    {
+        static void ForceLink() // If the library isn't referenced, it doesn't actually get linked
+        {
+            Maybe<Test> maybe = null;
+
+            System.Diagnostics.Debug.WriteLine(string.Format("maybe HasValue: {0} hasNoValue {1}", maybe.HasValue, maybe.HasNoValue));
+        }
+    }
+}

--- a/LinkTest.Standard.2.0/LinkTest.Standard.2.0.csproj
+++ b/LinkTest.Standard.2.0/LinkTest.Standard.2.0.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\CSharpFunctionalExtensions\CSharpFunctionalExtensions.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/LinkTest.Standard.2.0/Test.cs
+++ b/LinkTest.Standard.2.0/Test.cs
@@ -1,0 +1,14 @@
+﻿using CSharpFunctionalExtensions;
+
+namespace LinkTest
+{
+    class Test
+    {
+        static void ForceLink() // If the library isn't referenced, it doesn't actually get linked
+        {
+            Maybe<Test> maybe = null;
+
+            System.Diagnostics.Debug.WriteLine(string.Format("maybe HasValue: {0} hasNoValue {1}", maybe.HasValue, maybe.HasNoValue));
+        }
+    }
+}


### PR DESCRIPTION
* default to Standard 2.0
* build netstandard2.0;netstandard1.3;net40;net45;net461
* added framework specific references where necessary
* labeled per-framework dll with which framework it uses
* added per-framework link tests to verify the package works with each version