### PR TITLE
GetObjectData logic can be moved to ResultCommonLogic

### DIFF
--- a/CSharpFunctionalExtensions.Tests/ResultTests/SerializationTests.cs
+++ b/CSharpFunctionalExtensions.Tests/ResultTests/SerializationTests.cs
@@ -1,0 +1,69 @@
+﻿using System.Runtime.Serialization;
+using FluentAssertions;
+using Xunit;
+
+namespace CSharpFunctionalExtensions.Tests.ResultTests
+{
+    public class SerializationTests
+    {
+        private static readonly string _errorMessage = "this failed";
+
+        [Fact]
+        public void GetObjectData_sets_correct_statuses_on_success_result()
+        {
+            Result okResult = Result.Ok();
+            ISerializable serializableObject = okResult;
+
+            var serializationInfo = new SerializationInfo(typeof(Result), new FormatterConverter());
+            serializableObject.GetObjectData(serializationInfo, new StreamingContext());
+
+            serializationInfo.GetBoolean(nameof(Result.IsSuccess)).Should().BeTrue();
+            serializationInfo.GetBoolean(nameof(Result.IsFailure)).Should().BeFalse();
+        }
+
+        [Fact]
+        public void GetObjectData_sets_correct_statuses_on_failure_result()
+        {
+            Result okResult = Result.Fail(_errorMessage);
+            ISerializable serializableObject = okResult;
+
+            var serializationInfo = new SerializationInfo(typeof(Result), new FormatterConverter());
+            serializableObject.GetObjectData(serializationInfo, new StreamingContext());
+
+            serializationInfo.GetBoolean(nameof(Result.IsSuccess)).Should().BeFalse();
+            serializationInfo.GetBoolean(nameof(Result.IsFailure)).Should().BeTrue();
+        }
+
+        [Fact]
+        public void GetObjectData_adds_message_in_context_on_failure_result()
+        {
+            Result okResult = Result.Fail(_errorMessage);
+            ISerializable serializableObject = okResult;
+
+            var serializationInfo = new SerializationInfo(typeof(Result), new FormatterConverter());
+            serializableObject.GetObjectData(serializationInfo, new StreamingContext());
+
+            serializationInfo.GetString(nameof(Result.Error)).Should().Be(_errorMessage);
+        }
+
+        [Fact]
+        public void GetObjectData_of_generic_result_adds_object_in_context_when_success_result()
+        {
+            SerializationTestObject language = new SerializationTestObject { Number = 232, String = "C#" };
+            Result<SerializationTestObject> okResult = Result.Ok(language);
+            ISerializable serializableObject = okResult;
+
+            var serializationInfo = new SerializationInfo(typeof(Result), new FormatterConverter());
+            serializableObject.GetObjectData(serializationInfo, new StreamingContext());
+
+            serializationInfo.GetValue(nameof(Result<SerializationTestObject>.Value), typeof(SerializationTestObject))
+                .Should().Be(language);
+        }
+    }
+
+    public struct SerializationTestObject
+    {
+        public string String { get; set; }
+        public int Number { get; set; }
+    }
+}

--- a/CSharpFunctionalExtensions/Result.cs
+++ b/CSharpFunctionalExtensions/Result.cs
@@ -43,14 +43,8 @@ namespace CSharpFunctionalExtensions
             IsFailure = isFailure;
             _error = error;
         }
-    }
 
-
-    public struct Result : ISerializable
-    {
-        private static readonly Result OkResult = new Result(false, null);
-
-        void ISerializable.GetObjectData(SerializationInfo oInfo, StreamingContext oContext)
+        public void GetObjectData(SerializationInfo oInfo, StreamingContext oContext)
         {
             oInfo.AddValue("IsFailure", IsFailure);
             oInfo.AddValue("IsSuccess", IsSuccess);
@@ -58,6 +52,16 @@ namespace CSharpFunctionalExtensions
             {
                 oInfo.AddValue("Error", Error);
             }
+        }
+    }
+    
+    public struct Result : ISerializable
+    {
+        private static readonly Result OkResult = new Result(false, null);
+
+        void ISerializable.GetObjectData(SerializationInfo oInfo, StreamingContext oContext)
+        {
+            _logic.GetObjectData(oInfo, oContext);
         }
 
         [DebuggerBrowsable(DebuggerBrowsableState.Never)]
@@ -163,13 +167,9 @@ namespace CSharpFunctionalExtensions
 
         void ISerializable.GetObjectData(SerializationInfo oInfo, StreamingContext oContext)
         {
-            oInfo.AddValue("IsFailure", IsFailure);
-            oInfo.AddValue("IsSuccess", IsSuccess);
-            if (IsFailure)
-            {
-                oInfo.AddValue("Error", Error);
-            }
-            else
+            _logic.GetObjectData(oInfo, oContext);
+
+            if (IsSuccess)
             {
                 oInfo.AddValue("Value", Value);
             }


### PR DESCRIPTION
Hello Vladimir, 

I mentioned that you're using a `ResultCommonLogic` class and I though it would be a good idea to move a serialization logic there. There were also added several simple tests, just to check, that serialization works as expected after changes. 

Regards