### PR TITLE
Rebase on #55 + Extensions

### DIFF
--- a/CSharpFunctionalExtensions.Tests/ResultTests/ExtensionTests.cs
+++ b/CSharpFunctionalExtensions.Tests/ResultTests/ExtensionTests.cs
@@ -40,7 +40,17 @@ namespace CSharpFunctionalExtensions.Tests.ResultTests
             myError.Should().Be(_errorMessage);
         }
 
+        [Fact]
+        public void Should_exexcute_action_with_error_object_on_generic_failure()
+        {
+            string myError = string.Empty;
 
+            Result<MyClass, MyClass> myResult = Result.Fail<MyClass, MyClass>(new MyClass {Property = _errorMessage});
+            myResult.OnFailure(error => myError = error.Property);
+
+            myError.Should().Be(_errorMessage);
+        }
+        
         private class MyClass
         {
             public string Property { get; set; }

--- a/CSharpFunctionalExtensions.Tests/ResultTests/SerializationTests.cs
+++ b/CSharpFunctionalExtensions.Tests/ResultTests/SerializationTests.cs
@@ -59,9 +59,24 @@ namespace CSharpFunctionalExtensions.Tests.ResultTests
             serializationInfo.GetValue(nameof(Result<SerializationTestObject>.Value), typeof(SerializationTestObject))
                 .Should().Be(language);
         }
+
+        [Fact]
+        public void GetObjectData_adds_error_object_in_serialization_context_when_failure_result()
+        {
+            SerializationTestObject errorObject = new SerializationTestObject { Number = 500, String = "Error message" };
+            Result<object, SerializationTestObject> failResult = Result.Fail<object, SerializationTestObject>(errorObject);
+            ISerializable serializableObject = failResult;
+
+            var serializationInfo = new SerializationInfo(typeof(Result), new FormatterConverter());
+            serializableObject.GetObjectData(serializationInfo, new StreamingContext());
+
+            serializationInfo
+                .GetValue(nameof(Result<object, SerializationTestObject>.Error), typeof(SerializationTestObject))
+                .Should().Be(errorObject);
+        }
     }
 
-    public struct SerializationTestObject
+    public class SerializationTestObject
     {
         public string String { get; set; }
         public int Number { get; set; }

--- a/CSharpFunctionalExtensions.Tests/ResultTests/SucceededResultTests.cs
+++ b/CSharpFunctionalExtensions.Tests/ResultTests/SucceededResultTests.cs
@@ -29,6 +29,18 @@ namespace CSharpFunctionalExtensions.Tests.ResultTests
         }
 
         [Fact]
+        public void Can_create_a_generic_version_with_a_generic_error()
+        {
+            var myClass = new MyClass();
+
+            Result<MyClass, MyClass> result = Result.Ok<MyClass, MyClass>(myClass);
+
+            result.IsFailure.Should().Be(false);
+            result.IsSuccess.Should().Be(true);
+            result.Value.Should().Be(myClass);
+        }
+
+        [Fact]
         public void Cannot_create_without_Value()
         {
             Action action = () => { Result.Ok((MyClass)null); };

--- a/CSharpFunctionalExtensions/Result.cs
+++ b/CSharpFunctionalExtensions/Result.cs
@@ -6,15 +6,15 @@ using System.Runtime.Serialization;
 
 namespace CSharpFunctionalExtensions
 {
-    internal sealed class ResultCommonLogic
+    internal sealed class ResultCommonLogic<TError> where TError : class
     {
         public bool IsFailure { get; }
         public bool IsSuccess => !IsFailure;
 
         [DebuggerBrowsable(DebuggerBrowsableState.Never)]
-        private readonly string _error;
+        private readonly TError _error;
 
-        public string Error
+        public TError Error
         {
             [DebuggerStepThrough]
             get
@@ -27,17 +27,17 @@ namespace CSharpFunctionalExtensions
         }
 
         [DebuggerStepThrough]
-        public ResultCommonLogic(bool isFailure, string error)
+        public ResultCommonLogic(bool isFailure, TError error)
         {
             if (isFailure)
             {
-                if (string.IsNullOrEmpty(error))
-                    throw new ArgumentNullException(nameof(error), "There must be error message for failure.");
+                if (error == null)
+                    throw new ArgumentNullException(nameof(error), ResultMessages.ErrorObjectIsNotProvidedForFailure);
             }
             else
             {
                 if (error != null)
-                    throw new ArgumentException("There should be no error message for success.", nameof(error));
+                    throw new ArgumentException(nameof(error), ResultMessages.ErrorObjectIsProvidedForSuccess);
             }
 
             IsFailure = isFailure;
@@ -54,7 +54,41 @@ namespace CSharpFunctionalExtensions
             }
         }
     }
-    
+
+    internal static class ResultCommonLogic
+    {
+        [DebuggerStepThrough]
+        public static ResultCommonLogic<string> Create(bool isFailure, string error)
+        {
+            if (isFailure)
+            {
+                if (string.IsNullOrEmpty(error))
+                    throw new ArgumentNullException(nameof(error), ResultMessages.ErrorMessageIsNotProvidedForFailure);
+            }
+            else
+            {
+                if (error != null)
+                    throw new ArgumentException(nameof(error), ResultMessages.ErrorMessageIsProvidedForSuccess);
+            }
+
+            return new ResultCommonLogic<string>(isFailure, error);
+        }
+    }
+
+    internal static class ResultMessages
+    {
+        public static readonly string ErrorObjectIsNotProvidedForFailure =
+            "You have tried to create a failure result, but error object appeared to be null, please review the code, generating error object.";
+
+        public static readonly string ErrorObjectIsProvidedForSuccess =
+            "You have tried to create a success result, but error object was also passed to the constructor, please try to review the code, creating a success result.";
+
+        public static readonly string ErrorMessageIsNotProvidedForFailure = "There must be error message for failure.";
+
+        public static readonly string ErrorMessageIsProvidedForSuccess = "There should be no error message for success.";
+    }
+
+
     public struct Result : ISerializable
     {
         private static readonly Result OkResult = new Result(false, null);
@@ -65,7 +99,7 @@ namespace CSharpFunctionalExtensions
         }
 
         [DebuggerBrowsable(DebuggerBrowsableState.Never)]
-        private readonly ResultCommonLogic _logic;
+        private readonly ResultCommonLogic<string> _logic;
 
         public bool IsFailure => _logic.IsFailure;
         public bool IsSuccess => _logic.IsSuccess;
@@ -74,7 +108,7 @@ namespace CSharpFunctionalExtensions
         [DebuggerStepThrough]
         private Result(bool isFailure, string error)
         {
-            _logic = new ResultCommonLogic(isFailure, error);
+            _logic = ResultCommonLogic.Create(isFailure, error);
         }
 
         [DebuggerStepThrough]
@@ -99,6 +133,18 @@ namespace CSharpFunctionalExtensions
         public static Result<T> Fail<T>(string error)
         {
             return new Result<T>(true, default(T), error);
+        }
+
+        [DebuggerStepThrough]
+        public static Result<TValue, TError> Ok<TValue, TError>(TValue value) where TError : class
+        {
+            return new Result<TValue, TError>(false, value, default(TError));
+        }
+
+        [DebuggerStepThrough]
+        public static Result<TValue, TError> Fail<TValue, TError>(TError error) where TError : class
+        {
+            return new Result<TValue, TError>(true, default(TValue), error);
         }
 
         /// <summary>
@@ -154,12 +200,11 @@ namespace CSharpFunctionalExtensions
             return Combine(errorMessagesSeparator, untyped);
         }
     }
-
-
+    
     public struct Result<T> : ISerializable
     {
         [DebuggerBrowsable(DebuggerBrowsableState.Never)]
-        private readonly ResultCommonLogic _logic;
+        private readonly ResultCommonLogic<string> _logic;
 
         public bool IsFailure => _logic.IsFailure;
         public bool IsSuccess => _logic.IsSuccess;
@@ -196,7 +241,7 @@ namespace CSharpFunctionalExtensions
             if (!isFailure && value == null)
                 throw new ArgumentNullException(nameof(value));
 
-            _logic = new ResultCommonLogic(isFailure, error);
+            _logic = ResultCommonLogic.Create(isFailure, error);
             _value = value;
         }
 
@@ -206,6 +251,71 @@ namespace CSharpFunctionalExtensions
                 return Result.Ok();
             else
                 return Result.Fail(result.Error);
+        }
+    }
+
+    public struct Result<TValue, TError> : ISerializable where TError : class
+    {
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        private readonly ResultCommonLogic<TError> _logic;
+
+        public bool IsFailure => _logic.IsFailure;
+        public bool IsSuccess => _logic.IsSuccess;
+        public TError Error => _logic.Error;
+
+        void ISerializable.GetObjectData(SerializationInfo oInfo, StreamingContext oContext)
+        {
+            oInfo.AddValue("IsFailure", IsFailure);
+            oInfo.AddValue("IsSuccess", IsSuccess);
+            if (IsFailure)
+            {
+                oInfo.AddValue("Error", Error);
+            }
+            else
+            {
+                oInfo.AddValue("Value", Value);
+            }
+        }
+
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        private readonly TValue _value;
+
+        public TValue Value
+        {
+            [DebuggerStepThrough]
+            get
+            {
+                if (!IsSuccess)
+                    throw new InvalidOperationException("There is no value for failure.");
+
+                return _value;
+            }
+        }
+
+        [DebuggerStepThrough]
+        internal Result(bool isFailure, TValue value, TError error)
+        {
+            if (!isFailure && value == null)
+                throw new ArgumentNullException(nameof(value));
+
+            _logic = new ResultCommonLogic<TError>(isFailure, error);
+            _value = value;
+        }
+
+        public static implicit operator Result(Result<TValue, TError> result)
+        {
+            if (result.IsSuccess)
+                return Result.Ok();
+            else
+                return Result.Fail(result.Error.ToString());
+        }
+
+        public static implicit operator Result<TValue>(Result<TValue, TError> result)
+        {
+            if (result.IsSuccess)
+                return Result.Ok(result.Value);
+            else
+                return Result.Fail<TValue>(result.Error.ToString());
         }
     }
 }

--- a/CSharpFunctionalExtensions/ResultExtensions.cs
+++ b/CSharpFunctionalExtensions/ResultExtensions.cs
@@ -4,6 +4,15 @@ namespace CSharpFunctionalExtensions
 {
     public static class ResultExtensions
     {
+        public static Result<TNewValue, TError> OnSuccess<TValue, TNewValue, TError>(this Result<TValue, TError> result,
+            Func<TValue, TNewValue> func) where TError : class
+        {
+            if (result.IsFailure)
+                return Result.Fail<TNewValue, TError>(result.Error);
+
+            return Result.Ok<TNewValue, TError>(func(result.Value));
+        }
+
         public static Result<K> OnSuccess<T, K>(this Result<T> result, Func<T, K> func)
         {
             if (result.IsFailure)
@@ -18,6 +27,15 @@ namespace CSharpFunctionalExtensions
                 return Result.Fail<T>(result.Error);
 
             return Result.Ok(func());
+        }
+
+        public static Result<TNewValue, TError> OnSuccess<TValue, TNewValue, TError>(this Result<TValue, TError> result,
+            Func<TValue, Result<TNewValue, TError>> func) where TError : class
+        {
+            if (result.IsFailure)
+                return Result.Fail<TNewValue, TError>(result.Error);
+
+            return func(result.Value);
         }
 
         public static Result<K> OnSuccess<T, K>(this Result<T> result, Func<T, Result<K>> func)
@@ -36,12 +54,39 @@ namespace CSharpFunctionalExtensions
             return func();
         }
 
+        public static Result<TNewValue, TError> OnSuccess<TValue, TNewValue, TError>(this Result<TValue, TError> result,
+            Func<Result<TNewValue, TError>> func) where TError : class
+        {
+            if (result.IsFailure)
+                return Result.Fail<TNewValue, TError>(result.Error);
+
+            return func();
+        }
+
         public static Result<K> OnSuccess<T, K>(this Result<T> result, Func<Result<K>> func)
         {
             if (result.IsFailure)
                 return Result.Fail<K>(result.Error);
 
             return func();
+        }
+
+        public static Result<TNewValue> OnSuccess<TValue, TNewValue, TError>(this Result<TValue, TError> result,
+            Func<TValue, Result<TNewValue>> func) where TError : class
+        {
+            if (result.IsFailure)
+                return Result.Fail<TNewValue, TError>(result.Error);
+
+            return func(result.Value);
+        }
+
+        public static Result OnSuccess<TValue, TNewValue, TError>(this Result<TValue, TError> result,
+            Func<TValue, Result> func) where TError : class
+        {
+            if (result.IsFailure)
+                return Result.Fail<TNewValue, TError>(result.Error);
+
+            return func(result.Value);
         }
 
         public static Result OnSuccess<T>(this Result<T> result, Func<T, Result> func)
@@ -58,6 +103,18 @@ namespace CSharpFunctionalExtensions
                 return result;
 
             return func();
+        }
+
+        public static Result<TValue, TError> Ensure<TValue, TError>(this Result<TValue, TError> result,
+            Func<TValue, bool> predicate, TError errorObject) where TError : class
+        {
+            if (result.IsFailure)
+                return Result.Fail<TValue, TError>(result.Error);
+
+            if (!predicate(result.Value))
+                return Result.Fail<TValue, TError>(errorObject);
+
+            return Result.Ok<TValue, TError>(result.Value);
         }
 
         public static Result<T> Ensure<T>(this Result<T> result, Func<T, bool> predicate, string errorMessage)
@@ -82,6 +139,15 @@ namespace CSharpFunctionalExtensions
             return Result.Ok();
         }
 
+        public static Result<TNewValue, TError> Map<TValue, TNewValue, TError>(this Result<TValue, TError> result,
+            Func<TValue, TNewValue> func) where TError : class
+        {
+            if (result.IsFailure)
+                return Result.Fail<TNewValue, TError>(result.Error);
+
+            return Result.Ok<TNewValue, TError>(func(result.Value));
+        }
+
         public static Result<K> Map<T, K>(this Result<T> result, Func<T, K> func)
         {
             if (result.IsFailure)
@@ -96,6 +162,17 @@ namespace CSharpFunctionalExtensions
                 return Result.Fail<T>(result.Error);
 
             return Result.Ok(func());
+        }
+
+        public static Result<TValue, TError> OnSuccess<TValue, TError>(this Result<TValue, TError> result,
+            Action<TValue> action) where TError : class
+        {
+            if (result.IsSuccess)
+            {
+                action(result.Value);
+            }
+
+            return result;
         }
 
         public static Result<T> OnSuccess<T>(this Result<T> result, Action<T> action)
@@ -128,6 +205,23 @@ namespace CSharpFunctionalExtensions
             return func(result);
         }
 
+        public static TValue OnBoth<TValue, TError>(this Result<TValue, TError> result,
+            Func<Result<TValue, TError>, TValue> func) where TError : class
+        {
+            return func(result);
+        }
+
+        public static Result<TValue, TError> OnFailure<TValue, TError>(this Result<TValue, TError> result,
+            Action action) where TError : class
+        {
+            if (result.IsFailure)
+            {
+                action();
+            }
+
+            return result;
+        }
+
         public static Result<T> OnFailure<T>(this Result<T> result, Action action)
         {
             if (result.IsFailure)
@@ -143,6 +237,17 @@ namespace CSharpFunctionalExtensions
             if (result.IsFailure)
             {
                 action();
+            }
+
+            return result;
+        }
+
+        public static Result<TValue, TError> OnFailure<TValue, TError>(this Result<TValue, TError> result,
+            Action<TError> action) where TError : class
+        {
+            if (result.IsFailure)
+            {
+                action(result.Error);
             }
 
             return result;


### PR DESCRIPTION
Hello Vladimir, 

According to our discussion in pull request #55 , I have rebased the branch and also added extension methods for `Result<TValue, TError>`. And, indeed it sounds reasonable to make `ResultCommonLogic` to be inherited from `ResultCommonLogic<string>`, so I added this. 

Regards