### PR TITLE
Add OnSuccessWithTransactionScope

### DIFF
--- a/CSharpFunctionalExtensions/IResult.cs
+++ b/CSharpFunctionalExtensions/IResult.cs
@@ -1,0 +1,10 @@
+﻿using System.Collections.Generic;
+
+namespace CSharpFunctionalExtensions
+{
+    public interface IResult
+    {
+        bool IsFailure { get; }
+        bool IsSuccess  { get; }
+    }
+}

--- a/CSharpFunctionalExtensions/Result.cs
+++ b/CSharpFunctionalExtensions/Result.cs
@@ -93,7 +93,7 @@ namespace CSharpFunctionalExtensions
     }
 
 
-    public struct Result : ISerializable
+    public struct Result : IResult, ISerializable
     {
         private static readonly Result OkResult = new Result(false, null);
 
@@ -205,7 +205,7 @@ namespace CSharpFunctionalExtensions
         }
     }
     
-    public struct Result<T> : ISerializable
+    public struct Result<T> : IResult, ISerializable
     {
         [DebuggerBrowsable(DebuggerBrowsableState.Never)]
         private readonly ResultCommonLogic _logic;
@@ -258,7 +258,7 @@ namespace CSharpFunctionalExtensions
         }
     }
 
-    public struct Result<TValue, TError> : ISerializable
+    public struct Result<TValue, TError> : IResult, ISerializable
     {
         [DebuggerBrowsable(DebuggerBrowsableState.Never)]
         private readonly ResultCommonLogic<TError> _logic;

--- a/CSharpFunctionalExtensions/ResultExtensions-TransactionScope.cs
+++ b/CSharpFunctionalExtensions/ResultExtensions-TransactionScope.cs
@@ -1,0 +1,169 @@
+#if NETSTANDARD2_0
+using System;
+using System.Diagnostics;
+using System.Threading.Tasks;
+using System.Transactions;
+
+namespace CSharpFunctionalExtensions
+{
+    public static partial class ResultExtensions
+    {
+        // Non-async extensions
+        [DebuggerStepThrough]
+        public static Result<K> OnSuccessWithTransactionScope<T, K>(this Result<T> self, Func<T, K> f) =>
+            WithTransactionScope(() => self.OnSuccess(f));
+
+        [DebuggerStepThrough]
+        public static Result<T> OnSuccessWithTransactionScope<T>(this Result self, Func<T> f) =>
+            WithTransactionScope(() => self.OnSuccess(f));
+
+        [DebuggerStepThrough]
+        public static Result<K> OnSuccessWithTransactionScope<T, K>(this Result<T> self, Func<T, Result<K>> f) =>
+            WithTransactionScope(() => self.OnSuccess(f));
+
+        [DebuggerStepThrough]
+        public static Result<T> OnSuccessWithTransactionScope<T>(this Result self, Func<Result<T>> f) =>
+            WithTransactionScope(() => self.OnSuccess(f));
+
+        [DebuggerStepThrough]
+        public static Result<K> OnSuccessWithTransactionScope<T, K>(this Result<T> self, Func<Result<K>> f) =>
+            WithTransactionScope(() => self.OnSuccess(f));
+
+        [DebuggerStepThrough]
+        public static Result OnSuccessWithTransactionScope<T>(this Result<T> self, Func<T, Result> f) =>
+            WithTransactionScope(() => self.OnSuccess(f));
+
+        [DebuggerStepThrough]
+        public static Result OnSuccessWithTransactionScope(this Result self, Func<Result> f) =>
+            WithTransactionScope(() => self.OnSuccess(f));
+
+        // Async - Both Operands
+        [DebuggerStepThrough]
+        public static Task<Result<K>> OnSuccessWithTransactionScope<T, K>(this Task<Result<T>> self, Func<T, Task<K>> f, bool continueOnCapturedContext = true) =>
+            WithTransactionScope(() => self.OnSuccess(f, continueOnCapturedContext));
+
+        [DebuggerStepThrough]
+        public static Task<Result<T>> OnSuccessWithTransactionScope<T>(this Task<Result> self, Func<Task<T>> f, bool continueOnCapturedContext = true) =>
+            WithTransactionScope(() => self.OnSuccess(f, continueOnCapturedContext));
+
+        [DebuggerStepThrough]
+        public static Task<Result<K>> OnSuccessWithTransactionScope<T, K>(this Task<Result<T>> self, Func<T, Task<Result<K>>> f, bool continueOnCapturedContext = true) =>
+            WithTransactionScope(() => self.OnSuccess(f, continueOnCapturedContext));
+
+        [DebuggerStepThrough]
+        public static Task<Result<T>> OnSuccessWithTransactionScope<T>(this Task<Result> self, Func<Task<Result<T>>> f, bool continueOnCapturedContext = true) =>
+            WithTransactionScope(() => self.OnSuccess(f, continueOnCapturedContext));
+
+        [DebuggerStepThrough]
+        public static Task<Result<K>> OnSuccessWithTransactionScope<T, K>(this Task<Result<T>> self, Func<Task<Result<K>>> f, bool continueOnCapturedContext = true) =>
+            WithTransactionScope(() => self.OnSuccess(f, continueOnCapturedContext));
+
+        [DebuggerStepThrough]
+        public static Task<Result> OnSuccessWithTransactionScope<T>(this Task<Result<T>> self, Func<T, Task<Result>> f, bool continueOnCapturedContext = true) =>
+            WithTransactionScope(() => self.OnSuccess(f, continueOnCapturedContext));
+
+        [DebuggerStepThrough]
+        public static Task<Result> OnSuccessWithTransactionScope(this Task<Result> self, Func<Task<Result>> f, bool continueOnCapturedContext = true) =>
+            WithTransactionScope(() => self.OnSuccess(f, continueOnCapturedContext));
+
+
+        // Async - Left Operands
+        [DebuggerStepThrough]
+        public static Task<Result<K>> OnSuccessWithTransactionScope<T, K>(this Task<Result<T>> self, Func<T, K> f, bool continueOnCapturedContext = true) =>
+            WithTransactionScope(() => self.OnSuccess(f, continueOnCapturedContext));
+
+        [DebuggerStepThrough]
+        public static Task<Result<T>> OnSuccessWithTransactionScope<T>(this Task<Result> self, Func<T> f, bool continueOnCapturedContext = true) =>
+            WithTransactionScope(() => self.OnSuccess(f, continueOnCapturedContext));
+
+        [DebuggerStepThrough]
+        public static Task<Result<K>> OnSuccessWithTransactionScope<T, K>(this Task<Result<T>> self, Func<T, Result<K>> f, bool continueOnCapturedContext = true) =>
+            WithTransactionScope(() => self.OnSuccess(f, continueOnCapturedContext));
+
+        [DebuggerStepThrough]
+        public static Task<Result<T>> OnSuccessWithTransactionScope<T>(this Task<Result> self, Func<Result<T>> f, bool continueOnCapturedContext = true) =>
+            WithTransactionScope(() => self.OnSuccess(f, continueOnCapturedContext));
+
+        [DebuggerStepThrough]
+        public static Task<Result<K>> OnSuccessWithTransactionScope<T, K>(this Task<Result<T>> self, Func<Result<K>> f, bool continueOnCapturedContext = true) =>
+            WithTransactionScope(() => self.OnSuccess(f, continueOnCapturedContext));
+
+        [DebuggerStepThrough]
+        public static Task<Result> OnSuccessWithTransactionScope<T>(this Task<Result<T>> self, Func<T, Result> f, bool continueOnCapturedContext = true) =>
+            WithTransactionScope(() => self.OnSuccess(f, continueOnCapturedContext));
+
+        [DebuggerStepThrough]
+        public static Task<Result> OnSuccessWithTransactionScope(this Task<Result> self, Func<Result> f, bool continueOnCapturedContext = true) =>
+            WithTransactionScope(() => self.OnSuccess(f, continueOnCapturedContext));
+
+        [DebuggerStepThrough]
+        public static Task<Result<K>> Map<T, K>(this Task<Result<T>> self, Func<T, K> f, bool continueOnCapturedContext = true) =>
+            WithTransactionScope(() => self.OnSuccess(f, continueOnCapturedContext));
+
+        [DebuggerStepThrough]
+        public static Task<Result<T>> Map<T>(this Task<Result> self, Func<T> f, bool continueOnCapturedContext = true) =>
+            WithTransactionScope(() => self.OnSuccess(f, continueOnCapturedContext));
+
+
+        // Async - Right Operands
+        [DebuggerStepThrough]
+        public static Task<Result<K>> OnSuccessWithTransactionScope<T, K>(this Result<T> self, Func<T, Task<K>> f, bool continueOnCapturedContext = true) =>
+            WithTransactionScope(() => self.OnSuccess(f, continueOnCapturedContext));
+
+        [DebuggerStepThrough]
+        public static Task<Result<T>> OnSuccessWithTransactionScope<T>(this Result self, Func<Task<T>> f, bool continueOnCapturedContext = true) =>
+            WithTransactionScope(() => self.OnSuccess(f, continueOnCapturedContext));
+
+        [DebuggerStepThrough]
+        public static Task<Result<K>> OnSuccessWithTransactionScope<T, K>(this Result<T> self, Func<T, Task<Result<K>>> f, bool continueOnCapturedContext = true) =>
+            WithTransactionScope(() => self.OnSuccess(f, continueOnCapturedContext));
+
+        [DebuggerStepThrough]
+        public static Task<Result<T>> OnSuccessWithTransactionScope<T>(this Result self, Func<Task<Result<T>>> f, bool continueOnCapturedContext = true) =>
+            WithTransactionScope(() => self.OnSuccess(f, continueOnCapturedContext));
+
+        [DebuggerStepThrough]
+        public static Task<Result<K>> OnSuccessWithTransactionScope<T, K>(this Result<T> self, Func<Task<Result<K>>> f, bool continueOnCapturedContext = true) =>
+            WithTransactionScope(() => self.OnSuccess(f, continueOnCapturedContext));
+
+        [DebuggerStepThrough]
+        public static Task<Result> OnSuccessWithTransactionScope<T>(this Result<T> self, Func<T, Task<Result>> f, bool continueOnCapturedContext = true) =>
+            WithTransactionScope(() => self.OnSuccess(f, continueOnCapturedContext));
+
+        [DebuggerStepThrough]
+        public static Task<Result> OnSuccessWithTransactionScope(this Result self, Func<Task<Result>> f, bool continueOnCapturedContext = true) =>
+            WithTransactionScope(() => self.OnSuccess(f, continueOnCapturedContext));
+
+
+
+
+        static T WithTransactionScope<T>(Func<T> f)
+            where T : IResult
+        {
+            using (var trans = new TransactionScope(TransactionScopeAsyncFlowOption.Enabled))
+            {
+                var result = f();
+                if (result.IsSuccess)
+                {
+                    trans.Complete();
+                }
+                return result;
+            }
+        }
+
+        async static Task<T> WithTransactionScope<T>(Func<Task<T>> f)
+            where T : IResult
+        {
+            using (var trans = new TransactionScope(TransactionScopeAsyncFlowOption.Enabled))
+            {
+                var result = await f();
+                if (result.IsSuccess)
+                {
+                    trans.Complete();
+                }
+                return result;
+            }
+        }
+    }
+}
+#endif

--- a/CSharpFunctionalExtensions/ResultExtensions.cs
+++ b/CSharpFunctionalExtensions/ResultExtensions.cs
@@ -2,7 +2,7 @@
 
 namespace CSharpFunctionalExtensions
 {
-    public static class ResultExtensions
+    public static partial class ResultExtensions
     {
         public static Result<TNewValue, TError> OnSuccess<TValue, TNewValue, TError>(this Result<TValue, TError> result,
             Func<TValue, TNewValue> func) where TError : class

--- a/README.md
+++ b/README.md
@@ -43,6 +43,19 @@ return _customerRepository.GetById(id)
     .OnBoth(result => result.IsSuccess ? Ok() : Error(result.Error));
 ```
 
+## Wrap multiple operations in a TransactionScope
+
+```csharp
+return _customerRepository.GetById(id)
+    .ToResult("Customer with such Id is not found: " + id)
+    .Ensure(customer => customer.CanBePromoted(), "The customer has the highest status possible")
+    .OnSuccessWithTransactionScope(customer => Result.Ok(customer)
+        .OnSuccess(customer => customer.Promote())
+        .OnSuccess(customer => customer.ClearAppointments()))
+    .OnSuccess(customer => _emailGateway.SendPromotionNotification(customer.PrimaryEmail, customer.Status))
+    .OnBoth(result => result.IsSuccess ? Ok() : Error(result.Error));
+```
+
 ## Readings and watchings
 
  * [Functional C#: Primitive obsession](http://enterprisecraftsmanship.com/2015/03/07/functional-c-primitive-obsession/)


### PR DESCRIPTION
This adds some extensions to `Result` and `Result<T>` that act just like `OnSuccess` but wrap their continuation in a `TransactionScope`, only committing the transaction if the inner result is successful.

### Motivation

This has proven to be a useful pattern on some internal projects where we were able to make use of the distributed transaction manager for automatic rollbacks rather than forcing a rollback with an `OnFailure()` handler.

### Limitations

This PR does not cover the `Result<TOk, TErr>` class yet - I noticed there were a number of incomplete extensions on that variation of `Result` and was not sure of its future. If this proves useful, perhaps I could amend the PR with variations on top of `Result<TOk, TErr>`.