### PR TITLE
Added basic overloads for Result<T, TError>

### DIFF
--- a/CSharpFunctionalExtensions.Tests/MaybeTests/ExtensionsTests.cs
+++ b/CSharpFunctionalExtensions.Tests/MaybeTests/ExtensionsTests.cs
@@ -71,6 +71,30 @@ namespace CSharpFunctionalExtensions.Tests.MaybeTests
         }
 
         [Fact]
+        public void ToResult_with_custom_error_type_returns_success_if_value_exists()
+        {
+            var instance = new MyClass();
+            Maybe<MyClass> maybe = instance;
+
+            Result<MyClass, MyErrorClass> result = maybe.ToResult(new MyErrorClass());
+
+            result.IsSuccess.Should().BeTrue();
+            result.Value.Should().Be(instance);
+        }
+
+        [Fact]
+        public void ToResult_with_custom_error_type_returns_custom_failure_if_no_value()
+        {
+            Maybe<MyClass> maybe = null;
+
+            var errorInstance = new MyErrorClass();
+            Result<MyClass, MyErrorClass> result = maybe.ToResult(errorInstance);
+
+            result.IsSuccess.Should().BeFalse();
+            result.Error.Should().Be(errorInstance);
+        }
+
+        [Fact]
         public void Where_returns_value_if_predicate_returns_true()
         {
             var instance = new MyClass { Property = "Some value" };
@@ -187,6 +211,10 @@ namespace CSharpFunctionalExtensions.Tests.MaybeTests
         {
             public string Property { get; set; }
             public int IntProperty { get; set; }
+        }
+
+        private class MyErrorClass
+        {
         }
     }
 }

--- a/CSharpFunctionalExtensions/AsyncMaybeExtensions.cs
+++ b/CSharpFunctionalExtensions/AsyncMaybeExtensions.cs
@@ -11,5 +11,12 @@ namespace CSharpFunctionalExtensions
             Maybe<T> maybe = await maybeTask.ConfigureAwait(continueOnCapturedContext);
             return maybe.ToResult(errorMessage);
         }
+
+        public static async Task<Result<T, TError>> ToResult<T, TError>(this Task<Maybe<T>> maybeTask, TError error,
+            bool continueOnCapturedContext = true) where T : class where TError : class
+        {
+            Maybe<T> maybe = await maybeTask.ConfigureAwait(continueOnCapturedContext);
+            return maybe.ToResult(error);
+        }
     }
 }

--- a/CSharpFunctionalExtensions/AsyncResultExtensionsBothOperands.cs
+++ b/CSharpFunctionalExtensions/AsyncResultExtensionsBothOperands.cs
@@ -17,7 +17,7 @@ namespace CSharpFunctionalExtensions
             if (result.IsFailure)
                 return Result.Fail<K, TError>(result.Error);
 
-            K value = await func(result.Value);
+            K value = await func(result.Value).ConfigureAwait(continueOnCapturedContext);
 
             return Result.Ok<K, TError>(value);
         }
@@ -29,7 +29,7 @@ namespace CSharpFunctionalExtensions
             if (result.IsFailure)
                 return Result.Fail<K>(result.Error);
 
-            K value = await func(result.Value);
+            K value = await func(result.Value).ConfigureAwait(continueOnCapturedContext);
 
             return Result.Ok(value);
         }

--- a/CSharpFunctionalExtensions/AsyncResultExtensionsBothOperands.cs
+++ b/CSharpFunctionalExtensions/AsyncResultExtensionsBothOperands.cs
@@ -9,6 +9,19 @@ namespace CSharpFunctionalExtensions
     /// </summary>
     public static class AsyncResultExtensionsBothOperands
     {
+        public static async Task<Result<K, TError>> OnSuccess<T, K, TError>(this Task<Result<T, TError>> resultTask,
+            Func<T, Task<K>> func, bool continueOnCapturedContext = true) where TError : class
+        {
+            Result<T, TError> result = await resultTask.ConfigureAwait(continueOnCapturedContext);
+
+            if (result.IsFailure)
+                return Result.Fail<K, TError>(result.Error);
+
+            K value = await func(result.Value);
+
+            return Result.Ok<K, TError>(value);
+        }
+
         public static async Task<Result<K>> OnSuccess<T, K>(this Task<Result<T>> resultTask, Func<T, Task<K>> func, bool continueOnCapturedContext = true)
         {
             Result<T> result = await resultTask.ConfigureAwait(continueOnCapturedContext);
@@ -33,6 +46,17 @@ namespace CSharpFunctionalExtensions
             return Result.Ok(value);
         }
 
+        public static async Task<Result<K, TError>> OnSuccess<T, K, TError>(this Task<Result<T, TError>> resultTask,
+            Func<T, Task<Result<K, TError>>> func, bool continueOnCapturedContext = true) where TError : class
+        {
+            Result<T, TError> result = await resultTask.ConfigureAwait(continueOnCapturedContext);
+
+            if (result.IsFailure)
+                return Result.Fail<K, TError>(result.Error);
+
+            return await func(result.Value).ConfigureAwait(continueOnCapturedContext);
+        }
+
         public static async Task<Result<K>> OnSuccess<T, K>(this Task<Result<T>> resultTask, Func<T, Task<Result<K>>> func, bool continueOnCapturedContext = true)
         {
             Result<T> result = await resultTask.ConfigureAwait(continueOnCapturedContext);
@@ -40,7 +64,7 @@ namespace CSharpFunctionalExtensions
             if (result.IsFailure)
                 return Result.Fail<K>(result.Error);
 
-            return await func(result.Value);
+            return await func(result.Value).ConfigureAwait(continueOnCapturedContext);
         }
 
         public static async Task<Result<T>> OnSuccess<T>(this Task<Result> resultTask, Func<Task<Result<T>>> func, bool continueOnCapturedContext = true)
@@ -49,6 +73,17 @@ namespace CSharpFunctionalExtensions
 
             if (result.IsFailure)
                 return Result.Fail<T>(result.Error);
+
+            return await func().ConfigureAwait(continueOnCapturedContext);
+        }
+
+        public static async Task<Result<K, TError>> OnSuccess<T, K, TError>(this Task<Result<T, TError>> resultTask,
+            Func<Task<Result<K, TError>>> func, bool continueOnCapturedContext = true) where TError : class
+        {
+            Result<T, TError> result = await resultTask.ConfigureAwait(continueOnCapturedContext);
+
+            if (result.IsFailure)
+                return Result.Fail<K, TError>(result.Error);
 
             return await func().ConfigureAwait(continueOnCapturedContext);
         }
@@ -96,6 +131,20 @@ namespace CSharpFunctionalExtensions
             return Result.Ok(result.Value);
         }
 
+        public static async Task<Result<T, TError>> Ensure<T, TError>(this Task<Result<T, TError>> resultTask,
+            Func<T, Task<bool>> predicate, TError error, bool continueOnCapturedContext = true) where TError : class
+        {
+            Result<T, TError> result = await resultTask.ConfigureAwait(continueOnCapturedContext);
+
+            if (result.IsFailure)
+                return Result.Fail<T, TError>(result.Error);
+
+            if (!await predicate(result.Value).ConfigureAwait(continueOnCapturedContext))
+                return Result.Fail<T, TError>(error);
+
+            return Result.Ok<T, TError>(result.Value);
+        }
+
         public static async Task<Result> Ensure(this Task<Result> resultTask, Func<Task<bool>> predicate, string errorMessage, bool continueOnCapturedContext = true)
         {
             Result result = await resultTask.ConfigureAwait(continueOnCapturedContext);
@@ -107,6 +156,19 @@ namespace CSharpFunctionalExtensions
                 return Result.Fail(errorMessage);
 
             return Result.Ok();
+        }
+
+        public static async Task<Result<K>> Map<T, K, TError>(this Task<Result<T, TError>> resultTask,
+            Func<T, Task<K>> func, bool continueOnCapturedContext = true) where TError : class
+        {
+            Result<T, TError> result = await resultTask.ConfigureAwait(continueOnCapturedContext);
+
+            if (result.IsFailure)
+                return Result.Fail<K, TError>(result.Error);
+
+            K value = await func(result.Value).ConfigureAwait(continueOnCapturedContext);
+
+            return Result.Ok<K, TError>(value);
         }
 
         public static async Task<Result<K>> Map<T, K>(this Task<Result<T>> resultTask, Func<T, Task<K>> func, bool continueOnCapturedContext = true)
@@ -131,6 +193,19 @@ namespace CSharpFunctionalExtensions
             T value = await func().ConfigureAwait(continueOnCapturedContext);
 
             return Result.Ok(value);
+        }
+
+        public static async Task<Result<T, TError>> OnSuccess<T, TError>(this Task<Result<T, TError>> resultTask,
+            Func<T, Task> action, bool continueOnCapturedContext = true)
+        {
+            Result<T, TError> result = await resultTask.ConfigureAwait(continueOnCapturedContext);
+
+            if (result.IsSuccess)
+            {
+                await action(result.Value).ConfigureAwait(continueOnCapturedContext);
+            }
+
+            return result;
         }
 
         public static async Task<Result<T>> OnSuccess<T>(this Task<Result<T>> resultTask, Func<T, Task> action, bool continueOnCapturedContext = true)
@@ -169,6 +244,26 @@ namespace CSharpFunctionalExtensions
             return await func(result).ConfigureAwait(continueOnCapturedContext);
         }
 
+        public static async Task<K> OnBoth<T, K, TError>(this Task<Result<T, TError>> resultTask,
+            Func<Result<T, TError>, Task<K>> func, bool continueOnCapturedContext = true)
+        {
+            Result<T, TError> result = await resultTask.ConfigureAwait(continueOnCapturedContext);
+            return await func(result).ConfigureAwait(continueOnCapturedContext);
+        }
+
+        public static async Task<Result<T, TError>> OnFailure<T, TError>(this Task<Result<T, TError>> resultTask,
+            Func<Task> func, bool continueOnCapturedContext = true)
+        {
+            Result<T, TError> result = await resultTask.ConfigureAwait(continueOnCapturedContext);
+
+            if (result.IsFailure)
+            {
+                await func().ConfigureAwait(continueOnCapturedContext);
+            }
+
+            return result;
+        }
+
         public static async Task<Result<T>> OnFailure<T>(this Task<Result<T>> resultTask, Func<Task> func, bool continueOnCapturedContext = true)
         {
             Result<T> result = await resultTask.ConfigureAwait(continueOnCapturedContext);
@@ -196,6 +291,19 @@ namespace CSharpFunctionalExtensions
         public static async Task<Result<T>> OnFailure<T>(this Task<Result<T>> resultTask, Func<string, Task> func, bool continueOnCapturedContext = true)
         {
             Result<T> result = await resultTask.ConfigureAwait(continueOnCapturedContext);
+
+            if (result.IsFailure)
+            {
+                await func(result.Error).ConfigureAwait(continueOnCapturedContext);
+            }
+
+            return result;
+        }
+
+        public static async Task<Result<T, TError>> OnFailure<T, TError>(this Task<Result<T, TError>> resultTask,
+            Func<TError, Task> func, bool continueOnCapturedContext = true)
+        {
+            Result<T, TError> result = await resultTask.ConfigureAwait(continueOnCapturedContext);
 
             if (result.IsFailure)
             {

--- a/CSharpFunctionalExtensions/AsyncResultExtensionsLeftOperand.cs
+++ b/CSharpFunctionalExtensions/AsyncResultExtensionsLeftOperand.cs
@@ -9,6 +9,13 @@ namespace CSharpFunctionalExtensions
     /// </summary>
     public static class AsyncResultExtensionsLeftOperand
     {
+        public static async Task<Result<K, TError>> OnSuccess<T, K, TError>(this Task<Result<T, TError>> resultTask,
+            Func<T, K> func, bool continueOnCapturedContext = true) where TError : class
+        {
+            Result<T, TError> result = await resultTask.ConfigureAwait(continueOnCapturedContext);
+            return result.OnSuccess(func);
+        }
+
         public static async Task<Result<K>> OnSuccess<T, K>(this Task<Result<T>> resultTask, Func<T, K> func, bool continueOnCapturedContext = true)
         {
             Result<T> result = await resultTask.ConfigureAwait(continueOnCapturedContext);
@@ -18,6 +25,13 @@ namespace CSharpFunctionalExtensions
         public static async Task<Result<T>> OnSuccess<T>(this Task<Result> resultTask, Func<T> func, bool continueOnCapturedContext = true)
         {
             Result result = await resultTask.ConfigureAwait(continueOnCapturedContext);
+            return result.OnSuccess(func);
+        }
+
+        public static async Task<Result<K, TError>> OnSuccess<T, K, TError>(this Task<Result<T, TError>> resultTask,
+            Func<T, Result<K, TError>> func, bool continueOnCapturedContext = true) where TError : class
+        {
+            Result<T, TError> result = await resultTask.ConfigureAwait(continueOnCapturedContext);
             return result.OnSuccess(func);
         }
 
@@ -39,6 +53,13 @@ namespace CSharpFunctionalExtensions
             return result.OnSuccess(func);
         }
 
+        public static async Task<Result<K, TError>> OnSuccess<T, K, TError>(this Task<Result<T, TError>> resultTask,
+            Func<Result<K, TError>> func, bool continueOnCapturedContext = true) where TError : class
+        {
+            Result<T, TError> result = await resultTask.ConfigureAwait(continueOnCapturedContext);
+            return result.OnSuccess(func);
+        }
+
         public static async Task<Result> OnSuccess<T>(this Task<Result<T>> resultTask, Func<T, Result> func, bool continueOnCapturedContext = true)
         {
             Result<T> result = await resultTask.ConfigureAwait(continueOnCapturedContext);
@@ -57,6 +78,13 @@ namespace CSharpFunctionalExtensions
             return result.Ensure(predicate, errorMessage);
         }
 
+        public static async Task<Result<T>> Ensure<T, TError>(this Task<Result<T, TError>> resultTask,
+            Func<T, bool> predicate, TError error, bool continueOnCapturedContext = true) where TError : class
+        {
+            Result<T, TError> result = await resultTask.ConfigureAwait(continueOnCapturedContext);
+            return result.Ensure(predicate, error);
+        }
+
         public static async Task<Result> Ensure(this Task<Result> resultTask, Func<bool> predicate, string errorMessage, bool continueOnCapturedContext = true)
         {
             Result result = await resultTask.ConfigureAwait(continueOnCapturedContext);
@@ -66,6 +94,13 @@ namespace CSharpFunctionalExtensions
         public static async Task<Result<K>> Map<T, K>(this Task<Result<T>> resultTask, Func<T, K> func, bool continueOnCapturedContext = true)
         {
             Result<T> result = await resultTask.ConfigureAwait(continueOnCapturedContext);
+            return result.Map(func);
+        }
+
+        public static async Task<Result<K, TError>> Map<T, K, TError>(this Task<Result<T, TError>> resultTask,
+            Func<T, K> func, bool continueOnCapturedContext = true) where TError : class
+        {
+            Result<T, TError> result = await resultTask.ConfigureAwait(continueOnCapturedContext);
             return result.Map(func);
         }
 
@@ -98,7 +133,14 @@ namespace CSharpFunctionalExtensions
             Result<T> result = await resultTask.ConfigureAwait(continueOnCapturedContext);
             return result.OnBoth(func);
         }
-        
+
+        public static async Task<K> OnBoth<T, K, TError>(this Task<Result<T, TError>> resultTask,
+            Func<Result<T, TError>, K> func, bool continueOnCapturedContext = true)
+        {
+            Result<T, TError> result = await resultTask.ConfigureAwait(continueOnCapturedContext);
+            return result.OnBoth(func);
+        }
+
         public static async Task<Result<T>> OnFailure<T>(this Task<Result<T>> resultTask, Action action, bool continueOnCapturedContext = true)
         {
             Result<T> result = await resultTask.ConfigureAwait(continueOnCapturedContext);
@@ -114,6 +156,13 @@ namespace CSharpFunctionalExtensions
         public static async Task<Result<T>> OnFailure<T>(this Task<Result<T>> resultTask, Action<string> action, bool continueOnCapturedContext = true)
         {
             Result<T> result = await resultTask.ConfigureAwait(continueOnCapturedContext);
+            return result.OnFailure(action);
+        }
+
+        public static async Task<Result<T, TError>> OnFailure<T, TError>(this Task<Result<T, TError>> resultTask,
+            Action<TError> action, bool continueOnCapturedContext = true) where TError : class
+        {
+            Result<T, TError> result = await resultTask.ConfigureAwait(continueOnCapturedContext);
             return result.OnFailure(action);
         }
 

--- a/CSharpFunctionalExtensions/AsyncResultExtensionsRightOperand.cs
+++ b/CSharpFunctionalExtensions/AsyncResultExtensionsRightOperand.cs
@@ -18,6 +18,17 @@ namespace CSharpFunctionalExtensions
             return Result.Ok(value);
         }
 
+        public static async Task<Result<K, TError>> OnSuccess<T, K, TError>(this Result<T, TError> result,
+            Func<T, Task<K>> func, bool continueOnCapturedContext = true) where TError : class
+        {
+            if (result.IsFailure)
+                return Result.Fail<K, TError>(result.Error);
+
+            K value = await func(result.Value).ConfigureAwait(continueOnCapturedContext);
+
+            return Result.Ok<K, TError>(value);
+        }
+
         public static async Task<Result<T>> OnSuccess<T>(this Result result, Func<Task<T>> func, bool continueOnCapturedContext = true)
         {
             if (result.IsFailure)
@@ -36,6 +47,15 @@ namespace CSharpFunctionalExtensions
             return await func(result.Value).ConfigureAwait(continueOnCapturedContext);
         }
 
+        public static async Task<Result<K, TError>> OnSuccess<T, K, TError>(this Result<T, TError> result,
+            Func<T, Task<Result<K, TError>>> func, bool continueOnCapturedContext = true) where TError : class
+        {
+            if (result.IsFailure)
+                return Result.Fail<K, TError>(result.Error);
+
+            return await func(result.Value).ConfigureAwait(continueOnCapturedContext);
+        }
+
         public static async Task<Result<T>> OnSuccess<T>(this Result result, Func<Task<Result<T>>> func, bool continueOnCapturedContext = true)
         {
             if (result.IsFailure)
@@ -48,6 +68,15 @@ namespace CSharpFunctionalExtensions
         {
             if (result.IsFailure)
                 return Result.Fail<K>(result.Error);
+
+            return await func().ConfigureAwait(continueOnCapturedContext);
+        }
+
+        public static async Task<Result<K, TError>> OnSuccess<T, K, TError>(this Result<T, TError> result,
+            Func<Task<Result<K, TError>>> func, bool continueOnCapturedContext = true) where TError : class
+        {
+            if (result.IsFailure)
+                return Result.Fail<K, TError>(result.Error);
 
             return await func().ConfigureAwait(continueOnCapturedContext);
         }
@@ -79,6 +108,18 @@ namespace CSharpFunctionalExtensions
             return Result.Ok(result.Value);
         }
 
+        public static async Task<Result<T, TError>> Ensure<T, TError>(this Result<T, TError> result,
+            Func<T, Task<bool>> predicate, TError error, bool continueOnCapturedContext = true) where TError : class
+        {
+            if (result.IsFailure)
+                return Result.Fail<T, TError>(result.Error);
+
+            if (!await predicate(result.Value).ConfigureAwait(continueOnCapturedContext))
+                return Result.Fail<T, TError>(error);
+
+            return Result.Ok<T, TError>(result.Value);
+        }
+
         public static async Task<Result> Ensure(this Result result, Func<Task<bool>> predicate, string errorMessage, bool continueOnCapturedContext = true)
         {
             if (result.IsFailure)
@@ -100,6 +141,17 @@ namespace CSharpFunctionalExtensions
             return Result.Ok(value);
         }
 
+        public static async Task<Result<K, TError>> Map<T, K, TError>(this Result<T, TError> result,
+            Func<T, Task<K>> func, bool continueOnCapturedContext = true) where TError : class
+        {
+            if (result.IsFailure)
+                return Result.Fail<K, TError>(result.Error);
+
+            K value = await func(result.Value).ConfigureAwait(continueOnCapturedContext);
+
+            return Result.Ok<K, TError>(value);
+        }
+
         public static async Task<Result<T>> Map<T>(this Result result, Func<Task<T>> func, bool continueOnCapturedContext = true)
         {
             if (result.IsFailure)
@@ -111,6 +163,17 @@ namespace CSharpFunctionalExtensions
         }
 
         public static async Task<Result<T>> OnSuccess<T>(this Result<T> result, Func<T, Task> action, bool continueOnCapturedContext = true)
+        {
+            if (result.IsSuccess)
+            {
+                await action(result.Value).ConfigureAwait(continueOnCapturedContext);
+            }
+
+            return result;
+        }
+
+        public static async Task<Result<T, TError>> OnSuccess<T, TError>(this Result<T, TError> result,
+            Func<T, Task> action, bool continueOnCapturedContext = true)
         {
             if (result.IsSuccess)
             {
@@ -140,7 +203,24 @@ namespace CSharpFunctionalExtensions
             return await func(result).ConfigureAwait(continueOnCapturedContext);
         }
 
+        public static async Task<K> OnBoth<T, K, TError>(this Result<T, TError> result, Func<Result<T>, Task<K>> func,
+            bool continueOnCapturedContext = true)
+        {
+            return await func(result).ConfigureAwait(continueOnCapturedContext);
+        }
+
         public static async Task<Result<T>> OnFailure<T>(this Result<T> result, Func<Task> func, bool continueOnCapturedContext = true)
+        {
+            if (result.IsFailure)
+            {
+                await func().ConfigureAwait(continueOnCapturedContext);
+            }
+
+            return result;
+        }
+
+        public static async Task<Result<T, TError>> OnFailure<T, TError>(this Result<T, TError> result, Func<Task> func,
+            bool continueOnCapturedContext = true)
         {
             if (result.IsFailure)
             {
@@ -161,6 +241,17 @@ namespace CSharpFunctionalExtensions
         }
 
         public static async Task<Result<T>> OnFailure<T>(this Result<T> result, Func<string, Task> func, bool continueOnCapturedContext = true)
+        {
+            if (result.IsFailure)
+            {
+                await func(result.Error).ConfigureAwait(continueOnCapturedContext);
+            }
+
+            return result;
+        }
+
+        public static async Task<Result<T, TError>> OnFailure<T, TError>(this Result<T, TError> result,
+            Func<TError, Task> func, bool continueOnCapturedContext = true)
         {
             if (result.IsFailure)
             {

--- a/CSharpFunctionalExtensions/MaybeExtensions.cs
+++ b/CSharpFunctionalExtensions/MaybeExtensions.cs
@@ -12,6 +12,14 @@ namespace CSharpFunctionalExtensions
             return Result.Ok(maybe.Value);
         }
 
+        public static Result<T, TError> ToResult<T, TError>(this Maybe<T> maybe, TError error) where TError : class
+        {
+            if (maybe.HasNoValue)
+                return Result.Fail<T, TError>(error);
+
+            return Result.Ok<T, TError>(maybe.Value);
+        }
+
         public static T Unwrap<T>(this Maybe<T> maybe, T defaultValue = default(T))
         {
             return maybe.Unwrap(x => x, defaultValue);

--- a/CSharpFunctionalExtensions/ResultExtensions.cs
+++ b/CSharpFunctionalExtensions/ResultExtensions.cs
@@ -205,6 +205,11 @@ namespace CSharpFunctionalExtensions
             return func(result);
         }
 
+        public static K OnBoth<T, K, TError>(this Result<T, TError> result, Func<Result<T, TError>, K> func)
+        {
+            return func(result);
+        }
+
         public static TValue OnBoth<TValue, TError>(this Result<TValue, TError> result,
             Func<Result<TValue, TError>, TValue> func) where TError : class
         {


### PR DESCRIPTION
Hi Vladimir, thank you for this awesome lib!

**Motivation**

We widely use it in our company but we faced problems with Result<T, TError> support. It's very poor now and we wrote our own extensions for our extensions :) that are dealing with Result<T, TError>. But since we have a lot of solutions (microservices architecture and such kind of staff) we should duplicate that code in all our solution. 

So I decided to create this PR to improve Result<T, TError> support.

**What is done:**

Added Maybe<T>.ToResult overload with custom error type (which produces Result<T, TError>).
Added basic overloads for Result<T, TError>
Improved ConfigureAwait where it was missed
Added 2 tests (for Maybe, because as I see we are not testing result extensions)