### PR TITLE
Replace reference to Microsoft.CompilerServices.AsyncTargetingPack

### DIFF
--- a/CSharpFunctionalExtensions/CSharpFunctionalExtensions.csproj
+++ b/CSharpFunctionalExtensions/CSharpFunctionalExtensions.csproj
@@ -20,7 +20,9 @@
   <!-- .net 4.0 doesn't have async support and Microsoft.Bcl.Async doesn't work because of the interactions 
        between it's dependency chain and the multi-framework build. Howver the AsyncTargetingPack does. -->
   <ItemGroup Condition="'$(TargetFramework)' == 'net40'">
-    <PackageReference Include="Microsoft.CompilerServices.AsyncTargetingPack" />
+    <PackageReference Include="Microsoft.Bcl.Async">
+      <Version>1.0.168</Version>
+    </PackageReference>
   </ItemGroup>
 
   <!-- Standard1.3 doesn't have ISerializable and needs an additional reference -->


### PR DESCRIPTION
Microsoft.CompilerServices.AsyncTargetingPack has been unlisted on nuget and has been replaced by Microsoft.Bcl.Async.  