### PR TITLE
Added a Net4.0 project to allow use of Microsoft.Bcl.Async

### DIFF
--- a/CSharpFunctionalExtensions.sln
+++ b/CSharpFunctionalExtensions.sln
@@ -13,13 +13,15 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LinkTest.4.5", "LinkTest.4.
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LinkTest.4.6.1", "LinkTest.4.6.1\LinkTest.4.6.1.csproj", "{A90FBD60-EEBE-4B70-951D-B5BE5C53AECF}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LinkTest.Standard.1.3", "LinkTest.Standard.1.3\LinkTest.Standard.1.3.csproj", "{9583EB4B-3183-4FDE-AD1F-2637676308AE}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "LinkTest.Standard.1.3", "LinkTest.Standard.1.3\LinkTest.Standard.1.3.csproj", "{9583EB4B-3183-4FDE-AD1F-2637676308AE}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LinkTest.Standard.2.0", "LinkTest.Standard.2.0\LinkTest.Standard.2.0.csproj", "{CACEF620-87C0-4179-AC00-AC134224B27E}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "LinkTest.Standard.2.0", "LinkTest.Standard.2.0\LinkTest.Standard.2.0.csproj", "{CACEF620-87C0-4179-AC00-AC134224B27E}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CSharpFunctionalExtensions.Examples", "CSharpFunctionalExtensions.Examples\CSharpFunctionalExtensions.Examples.csproj", "{C05C3261-447D-40F6-B516-791A01BA5052}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CSharpFunctionalExtensions.Tests", "CSharpFunctionalExtensions.Tests\CSharpFunctionalExtensions.Tests.csproj", "{AAC59D01-6546-4366-B990-4A765EF4D796}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CSharpFunctionalExtensionsNet4.0", "CSharpFunctionalExtensionsNet4.0\CSharpFunctionalExtensionsNet4.0.csproj", "{B5FCFC35-FD02-41AB-8B3F-F39E7AE1B009}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -59,6 +61,10 @@ Global
 		{AAC59D01-6546-4366-B990-4A765EF4D796}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{AAC59D01-6546-4366-B990-4A765EF4D796}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{AAC59D01-6546-4366-B990-4A765EF4D796}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B5FCFC35-FD02-41AB-8B3F-F39E7AE1B009}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B5FCFC35-FD02-41AB-8B3F-F39E7AE1B009}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B5FCFC35-FD02-41AB-8B3F-F39E7AE1B009}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B5FCFC35-FD02-41AB-8B3F-F39E7AE1B009}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/CSharpFunctionalExtensions/CSharpFunctionalExtensions.csproj
+++ b/CSharpFunctionalExtensions/CSharpFunctionalExtensions.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard1.3;net40;net45;net461</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard1.3;net45;net461</TargetFrameworks>
     <PackageId>CSharpFunctionalExtensions</PackageId>
     <PackageVersion>1.13.0</PackageVersion>
     <Authors>Vladimir Khorikov</Authors>
@@ -21,7 +21,7 @@
        between it's dependency chain and the multi-framework build. Howver the AsyncTargetingPack does. -->
   <ItemGroup Condition="'$(TargetFramework)' == 'net40'">
     <PackageReference Include="Microsoft.Bcl.Async">
-      <Version>1.0.168</Version>
+      <Version>1.0.165</Version>
     </PackageReference>
   </ItemGroup>
 

--- a/CSharpFunctionalExtensions/CSharpFunctionalExtensions.csproj
+++ b/CSharpFunctionalExtensions/CSharpFunctionalExtensions.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;netstandard1.3;net45;net461</TargetFrameworks>
     <PackageId>CSharpFunctionalExtensions</PackageId>
-    <PackageVersion>1.13.0</PackageVersion>
+    <PackageVersion>1.13.1</PackageVersion>
     <Authors>Vladimir Khorikov</Authors>
     <Description>CSharpFunctionalExtensions - functional extensions for C#.</Description>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
@@ -12,9 +12,9 @@
     <PackageProjectUrl>https://www.pluralsight.com/courses/csharp-applying-functional-principles</PackageProjectUrl>
     <NeutralLanguage>en-US</NeutralLanguage>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
-    <Version>1.13.0</Version>
-    <AssemblyVersion>1.13.0.0</AssemblyVersion>
-    <FileVersion>1.13.0.0</FileVersion>
+    <Version>1.13.1</Version>
+    <AssemblyVersion>1.13.1.0</AssemblyVersion>
+    <FileVersion>1.13.1.0</FileVersion>
   </PropertyGroup>
 
   <!-- Standard1.3 doesn't have ISerializable and needs an additional reference -->

--- a/CSharpFunctionalExtensions/CSharpFunctionalExtensions.csproj
+++ b/CSharpFunctionalExtensions/CSharpFunctionalExtensions.csproj
@@ -17,23 +17,11 @@
     <FileVersion>1.13.0.0</FileVersion>
   </PropertyGroup>
 
-  <!-- .net 4.0 doesn't have async support and Microsoft.Bcl.Async doesn't work because of the interactions 
-       between it's dependency chain and the multi-framework build. Howver the AsyncTargetingPack does. -->
-  <ItemGroup Condition="'$(TargetFramework)' == 'net40'">
-    <PackageReference Include="Microsoft.Bcl.Async">
-      <Version>1.0.165</Version>
-    </PackageReference>
-  </ItemGroup>
-
   <!-- Standard1.3 doesn't have ISerializable and needs an additional reference -->
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.3'">
     <PackageReference Include="System.Runtime.Serialization.Formatters" Version="4.3.0" />
   </ItemGroup>
 
-  <!-- Set titles so the dlls are distinguishable from each other -->
-  <PropertyGroup Condition="'$(TargetFramework)'=='net40'">
-    <AssemblyTitle>CSharpFunctionalExtensions .NET 4.0</AssemblyTitle>
-  </PropertyGroup>
   <PropertyGroup Condition="'$(TargetFramework)'=='net45'">
     <AssemblyTitle>CSharpFunctionalExtensions .NET 4.5</AssemblyTitle>
   </PropertyGroup>

--- a/CSharpFunctionalExtensionsNet4.0/CSharpFunctionalExtensionsNet4.0.csproj
+++ b/CSharpFunctionalExtensionsNet4.0/CSharpFunctionalExtensionsNet4.0.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net40</TargetFramework>
     <RootNamespace>CSharpFunctionalExtensions</RootNamespace>
-    <PackageId>CSharpFunctionalExtensions</PackageId>
+    <PackageId>CSharpFunctionalExtensionsNet4.0</PackageId>
     <PackageVersion>1.13.1</PackageVersion>
     <Authors>Vladimir Khorikov</Authors>
     <Description>CSharpFunctionalExtensions - functional extensions for C#.</Description>

--- a/CSharpFunctionalExtensionsNet4.0/CSharpFunctionalExtensionsNet4.0.csproj
+++ b/CSharpFunctionalExtensionsNet4.0/CSharpFunctionalExtensionsNet4.0.csproj
@@ -1,0 +1,39 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net40</TargetFramework>
+    <RootNamespace>CSharpFunctionalExtensions</RootNamespace>
+    <PackageId>CSharpFunctionalExtensions</PackageId>
+    <PackageVersion>1.13.0</PackageVersion>
+    <Authors>Vladimir Khorikov</Authors>
+    <Description>CSharpFunctionalExtensions - functional extensions for C#.</Description>
+    <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
+    <PackageTags>C# Functional</PackageTags>
+    <PackageLicenseUrl>https://github.com/vkhorikov/CSharpFunctionalExtensions/blob/master/LICENSE</PackageLicenseUrl>
+    <PackageProjectUrl>https://www.pluralsight.com/courses/csharp-applying-functional-principles</PackageProjectUrl>
+    <NeutralLanguage>en-US</NeutralLanguage>
+    <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
+    <Version>1.13.0</Version>
+    <AssemblyVersion>1.13.0.0</AssemblyVersion>
+    <FileVersion>1.13.0.0</FileVersion>
+    <AssemblyName>CSharpFunctionalExtensions</AssemblyName>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="..\CSharpFunctionalExtensions\AsyncMaybeExtensions.cs" Link="AsyncMaybeExtensions.cs" />
+    <Compile Include="..\CSharpFunctionalExtensions\AsyncResultExtensionsBothOperands.cs" Link="AsyncResultExtensionsBothOperands.cs" />
+    <Compile Include="..\CSharpFunctionalExtensions\AsyncResultExtensionsLeftOperand.cs" Link="AsyncResultExtensionsLeftOperand.cs" />
+    <Compile Include="..\CSharpFunctionalExtensions\AsyncResultExtensionsRightOperand.cs" Link="AsyncResultExtensionsRightOperand.cs" />
+    <Compile Include="..\CSharpFunctionalExtensions\IResult.cs" Link="IResult.cs" />
+    <Compile Include="..\CSharpFunctionalExtensions\Maybe.cs" Link="Maybe.cs" />
+    <Compile Include="..\CSharpFunctionalExtensions\MaybeExtensions.cs" Link="MaybeExtensions.cs" />
+    <Compile Include="..\CSharpFunctionalExtensions\Result.cs" Link="Result.cs" />
+    <Compile Include="..\CSharpFunctionalExtensions\ResultExtensions.cs" Link="ResultExtensions.cs" />
+    <Compile Include="..\CSharpFunctionalExtensions\ValueObject.cs" Link="ValueObject.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Bcl.Async" Version="1.0.168" />
+  </ItemGroup>
+
+</Project>

--- a/CSharpFunctionalExtensionsNet4.0/CSharpFunctionalExtensionsNet4.0.csproj
+++ b/CSharpFunctionalExtensionsNet4.0/CSharpFunctionalExtensionsNet4.0.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>net40</TargetFramework>
     <RootNamespace>CSharpFunctionalExtensions</RootNamespace>
     <PackageId>CSharpFunctionalExtensions</PackageId>
-    <PackageVersion>1.13.0</PackageVersion>
+    <PackageVersion>1.13.1</PackageVersion>
     <Authors>Vladimir Khorikov</Authors>
     <Description>CSharpFunctionalExtensions - functional extensions for C#.</Description>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
@@ -13,9 +13,9 @@
     <PackageProjectUrl>https://www.pluralsight.com/courses/csharp-applying-functional-principles</PackageProjectUrl>
     <NeutralLanguage>en-US</NeutralLanguage>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
-    <Version>1.13.0</Version>
-    <AssemblyVersion>1.13.0.0</AssemblyVersion>
-    <FileVersion>1.13.0.0</FileVersion>
+    <Version>1.13.1</Version>
+    <AssemblyVersion>1.13.1.0</AssemblyVersion>
+    <FileVersion>1.13.1.0</FileVersion>
     <AssemblyName>CSharpFunctionalExtensions</AssemblyName>
   </PropertyGroup>
 

--- a/LinkTest.4.0/LinkTest.4.0.csproj
+++ b/LinkTest.4.0/LinkTest.4.0.csproj
@@ -37,9 +37,9 @@
     <Compile Include="Test.cs" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\CSharpFunctionalExtensions\CSharpFunctionalExtensions.csproj">
-      <Project>{9598ec2b-2119-4fc4-9ac0-9ad5e41ca6a0}</Project>
-      <Name>CSharpFunctionalExtensions</Name>
+    <ProjectReference Include="..\CSharpFunctionalExtensionsNet4.0\CSharpFunctionalExtensionsNet4.0.csproj">
+      <Project>{b5fcfc35-fd02-41ab-8b3f-f39e7ae1b009}</Project>
+      <Name>CSharpFunctionalExtensionsNet4.0</Name>
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />


### PR DESCRIPTION
Resolves issue with LinkTest4.0.  Due to the issues with Microsoft.Bcl.Async in a multi target project, a separate .Net4.0 project has been created.  This will need to be released to nuget as a separate package.

I have also bumped the version to 1.13.1