### PR TITLE
Add OnFailureCompensate extension methods with tests and example

### DIFF
--- a/CSharpFunctionalExtensions.Examples/ResultExtensions/AsyncUsageExamples.cs
+++ b/CSharpFunctionalExtensions.Examples/ResultExtensions/AsyncUsageExamples.cs
@@ -28,6 +28,30 @@ namespace CSharpFunctionalExtensions.Examples.ResultExtensions
                 .OnBoth(result => result.IsSuccess ? "Ok" : result.Error);
         }
 
+        public async Task<string> Promote_with_async_methods_in_the_beginning_and_in_the_middle_of_the_chain_using_compensate(long id)
+        {
+            var gateway = new EmailGateway();
+
+            return await GetByIdAsync(id)
+                .ToResult("Customer with such Id is not found: " + id)
+                .Ensure(customer => customer.CanBePromoted(), "Need to ask manager")
+                .OnFailure(error => Log(error))
+                .OnFailureCompensate(() => AskManager(id))
+                .OnSuccess(customer => Log("Manager approved promotion"))
+                .OnSuccess(customer => customer.PromoteAsync())
+                .OnSuccess(customer => gateway.SendPromotionNotificationAsync(customer.Email))
+                .OnBoth(result => result.IsSuccess ? "Ok" : result.Error);
+        }
+
+        void Log(string message)
+        {
+        }
+
+        Task<Result<Customer>> AskManager(long id)
+        {
+            return Task.FromResult(Result.Ok(new Customer()));
+        }
+
         public Task<Maybe<Customer>> GetByIdAsync(long id)
         {
             return Task.FromResult((Maybe<Customer>)new Customer());

--- a/CSharpFunctionalExtensions.Tests/ResultTests/ExtensionTests.cs
+++ b/CSharpFunctionalExtensions.Tests/ResultTests/ExtensionTests.cs
@@ -50,7 +50,52 @@ namespace CSharpFunctionalExtensions.Tests.ResultTests
 
             myError.Should().Be(_errorMessage);
         }
-        
+
+        [Fact]
+        public void Should_execute_compensate_func_on_failure_returns_Ok()
+        {
+            var myResult = Result.Fail(_errorMessage);
+            var newResult = myResult.OnFailureCompensate(() => Result.Ok());
+
+            newResult.IsSuccess.Should().Be(true);
+        }
+
+        [Fact]
+        public void Should_execute_compensate_func_on_generic_failure_returns_Ok()
+        {
+            var expectedValue = new MyClass();
+
+            var myResult = Result.Fail<MyClass>(_errorMessage);
+            var newResult = myResult.OnFailureCompensate(() => Result.Ok(expectedValue));
+
+            newResult.IsSuccess.Should().BeTrue();
+            newResult.Value.Should().Be(expectedValue);
+        }
+
+        [Fact]
+        public void Should_execute_compensate_func_with_result_on_generic_failure_returns_Ok()
+        {
+            var expectedValue = new MyClass();
+
+            var myResult = Result.Fail<MyClass>(_errorMessage);
+            var newResult = myResult.OnFailureCompensate(error => Result.Ok(expectedValue));
+
+            newResult.IsSuccess.Should().BeTrue();
+            newResult.Value.Should().Be(expectedValue);
+        }
+
+        [Fact]
+        public void Should_execute_compensate_func_with_error_object_on_generic_failure_returns_Ok()
+        {
+            var expectedValue = new MyClass();
+
+            var myResult = Result.Fail<MyClass, MyClass>(new MyClass {Property = _errorMessage});
+            var newResult = myResult.OnFailureCompensate(error => Result.Ok<MyClass, MyClass>(expectedValue));
+
+            newResult.IsSuccess.Should().BeTrue();
+            newResult.Value.Should().Be(expectedValue);
+        }
+
         private class MyClass
         {
             public string Property { get; set; }

--- a/CSharpFunctionalExtensions/AsyncResultExtensionsBothOperands.cs
+++ b/CSharpFunctionalExtensions/AsyncResultExtensionsBothOperands.cs
@@ -312,5 +312,67 @@ namespace CSharpFunctionalExtensions
 
             return result;
         }
+
+        public static async Task<Result<T, TError>> OnFailureCompensate<T, TError>(this Task<Result<T, TError>> resultTask,
+            Func<Task<Result<T, TError>>> func, bool continueOnCapturedContext = true)
+        {
+            Result<T, TError> result = await resultTask.ConfigureAwait(continueOnCapturedContext);
+
+            if (result.IsFailure)
+            {
+                await func().ConfigureAwait(continueOnCapturedContext);
+            }
+
+            return result;
+        }
+
+        public static async Task<Result<T>> OnFailureCompensate<T>(this Task<Result<T>> resultTask, Func<Task<Result<T>>> func, bool continueOnCapturedContext = true)
+        {
+            Result<T> result = await resultTask.ConfigureAwait(continueOnCapturedContext);
+
+            if (result.IsFailure)
+            {
+                await func().ConfigureAwait(continueOnCapturedContext);
+            }
+
+            return result;
+        }
+
+        public static async Task<Result> OnFailureCompensate(this Task<Result> resultTask, Func<Task<Result>> func, bool continueOnCapturedContext = true)
+        {
+            Result result = await resultTask.ConfigureAwait(continueOnCapturedContext);
+
+            if (result.IsFailure)
+            {
+                await func().ConfigureAwait(continueOnCapturedContext);
+            }
+
+            return result;
+        }
+
+        public static async Task<Result<T>> OnFailureCompensate<T>(this Task<Result<T>> resultTask, Func<string, Task<Result<T>>> func, bool continueOnCapturedContext = true)
+        {
+            Result<T> result = await resultTask.ConfigureAwait(continueOnCapturedContext);
+
+            if (result.IsFailure)
+            {
+                await func(result.Error).ConfigureAwait(continueOnCapturedContext);
+            }
+
+            return result;
+        }
+
+        public static async Task<Result<T, TError>> OnFailureCompensate<T, TError>(this Task<Result<T, TError>> resultTask,
+            Func<TError, Task<Result<T, TError>>> func, bool continueOnCapturedContext = true)
+        {
+            Result<T, TError> result = await resultTask.ConfigureAwait(continueOnCapturedContext);
+
+            if (result.IsFailure)
+            {
+                await func(result.Error).ConfigureAwait(continueOnCapturedContext);
+            }
+
+            return result;
+        }
     }
 }

--- a/CSharpFunctionalExtensions/AsyncResultExtensionsLeftOperand.cs
+++ b/CSharpFunctionalExtensions/AsyncResultExtensionsLeftOperand.cs
@@ -171,5 +171,36 @@ namespace CSharpFunctionalExtensions
             Result result = await resultTask.ConfigureAwait(continueOnCapturedContext);
             return result.OnFailure(action);
         }
+
+        public static async Task<Result<T>> OnFailureCompensate<T>(this Task<Result<T>> resultTask, Func<Result<T>> func, bool continueOnCapturedContext = true)
+        {
+            Result<T> result = await resultTask.ConfigureAwait(continueOnCapturedContext);
+            return result.OnFailureCompensate(func);
+        }
+
+        public static async Task<Result> OnFailureCompensate(this Task<Result> resultTask, Func<Result> func, bool continueOnCapturedContext = true)
+        {
+            Result result = await resultTask.ConfigureAwait(continueOnCapturedContext);
+            return result.OnFailureCompensate(func);
+        }
+
+        public static async Task<Result<T>> OnFailureCompensate<T>(this Task<Result<T>> resultTask, Func<string, Result<T>> func, bool continueOnCapturedContext = true)
+        {
+            Result<T> result = await resultTask.ConfigureAwait(continueOnCapturedContext);
+            return result.OnFailureCompensate(func);
+        }
+
+        public static async Task<Result<T, TError>> OnFailureCompensate<T, TError>(this Task<Result<T, TError>> resultTask,
+            Func<TError, Result<T, TError>> func, bool continueOnCapturedContext = true) where TError : class
+        {
+            Result<T, TError> result = await resultTask.ConfigureAwait(continueOnCapturedContext);
+            return result.OnFailureCompensate(func);
+        }
+
+        public static async Task<Result> OnFailureCompensate(this Task<Result> resultTask, Func<string, Result> func, bool continueOnCapturedContext = true)
+        {
+            Result result = await resultTask.ConfigureAwait(continueOnCapturedContext);
+            return result.OnFailureCompensate(func);
+        }
     }
 }

--- a/CSharpFunctionalExtensions/AsyncResultExtensionsRightOperand.cs
+++ b/CSharpFunctionalExtensions/AsyncResultExtensionsRightOperand.cs
@@ -260,5 +260,47 @@ namespace CSharpFunctionalExtensions
 
             return result;
         }
+
+        public static async Task<Result<T>> OnFailureCompensate<T>(this Result<T> result, Func<Task<Result<T>>> func, bool continueOnCapturedContext = true)
+        {
+            if (result.IsFailure)
+                return await func().ConfigureAwait(continueOnCapturedContext);
+
+            return result;
+        }
+
+        public static async Task<Result<T, TError>> OnFailureCompensate<T, TError>(this Result<T, TError> result, Func<Task<Result<T, TError>>> func,
+            bool continueOnCapturedContext = true)
+        {
+            if (result.IsFailure)
+                return await func().ConfigureAwait(continueOnCapturedContext);
+
+            return result;
+        }
+
+        public static async Task<Result> OnFailureCompensate(this Result result, Func<Task<Result>> func, bool continueOnCapturedContext = true)
+        {
+            if (result.IsFailure)
+                return await func().ConfigureAwait(continueOnCapturedContext);
+
+            return result;
+        }
+
+        public static async Task<Result<T>> OnFailureCompensate<T>(this Result<T> result, Func<string, Task<Result<T>>> func, bool continueOnCapturedContext = true)
+        {
+            if (result.IsFailure)
+                return await func(result.Error).ConfigureAwait(continueOnCapturedContext);
+
+            return result;
+        }
+
+        public static async Task<Result<T, TError>> OnFailureCompensate<T, TError>(this Result<T, TError> result,
+            Func<TError, Task<Result<T, TError>>> func, bool continueOnCapturedContext = true)
+        {
+            if (result.IsFailure)
+                return await func(result.Error).ConfigureAwait(continueOnCapturedContext);
+
+            return result;
+        }
     }
 }

--- a/CSharpFunctionalExtensions/ResultExtensions.cs
+++ b/CSharpFunctionalExtensions/ResultExtensions.cs
@@ -277,5 +277,55 @@ namespace CSharpFunctionalExtensions
 
             return result;
         }
+
+        public static Result<TValue, TError> OnFailureCompensate<TValue, TError>(this Result<TValue, TError> result,
+            Func<Result<TValue, TError>> func) where TError : class
+        {
+            if (result.IsFailure)
+                return func();
+
+            return result;
+        }
+
+        public static Result<T> OnFailureCompensate<T>(this Result<T> result, Func<Result<T>> func)
+        {
+            if (result.IsFailure)
+                return func();
+
+            return result;
+        }
+
+        public static Result OnFailureCompensate(this Result result, Func<Result> func)
+        {
+            if (result.IsFailure)
+                return func();
+
+            return result;
+        }
+
+        public static Result<TValue, TError> OnFailureCompensate<TValue, TError>(this Result<TValue, TError> result,
+            Func<TError, Result<TValue, TError>> func) where TError : class
+        {
+            if (result.IsFailure)
+                return func(result.Error);
+
+            return result;
+        }
+
+        public static Result<T> OnFailureCompensate<T>(this Result<T> result, Func<string, Result<T>> func)
+        {
+            if (result.IsFailure)
+                return func(result.Error);
+
+            return result;
+        }
+
+        public static Result OnFailureCompensate(this Result result, Func<string, Result> func)
+        {
+            if (result.IsFailure)
+                return func(result.Error);
+
+            return result;
+        }
     }
 }


### PR DESCRIPTION
I'v been playing with this library for few days after watching your pluralshight course which is awesome BTW.
I noticed that something is missing, w/o it i found myself having to fallback to imperative style within OnBoth to achieve what i needed.
I don't know if it's part of the ROP(Railway oriented programming) approach or not but i tried to find material on web... i didn't find.
In ROP you have two track model, success and failure.
They are connected by blocks(functions), in each function you can switch from success track to failure track.
Once you are on the failure track your journey is ended and only OnFailure or OnBoth chains are going to be executed.
What i'm trying to do is to switch back from the failure track to success track, i called it compensate(OnFailureCompensate).
By adding compensate i was able to stick with the functional style.


[gist example](https://gist.github.com/golavr/5f0f55da6a3b60dea1e365d3420bac9b)
