### PR TITLE
ValueObject.Equals returns false in case of different types

### DIFF
--- a/CSharpFunctionalExtensions.Tests/ValueObjectTests/BasicTests.cs
+++ b/CSharpFunctionalExtensions.Tests/ValueObjectTests/BasicTests.cs
@@ -38,13 +38,12 @@ namespace CSharpFunctionalExtensions.Tests.ValueObjectTests
         }
 
         [Fact]
-        public void Comparing_value_objects_of_different_types_throws_an_exception()
+        public void Comparing_value_objects_of_different_types_returns_false()
         {
             var vo1 = new VO1("1");
             var vo2 = new VO2("2");
 
-            Action action = () => vo1.Equals(vo2);
-            action.ShouldThrow<ArgumentException>();
+            vo1.Equals(vo2).Should().BeFalse();
         }
 
         public class VO1 : ValueObject

--- a/CSharpFunctionalExtensions/ValueObject.cs
+++ b/CSharpFunctionalExtensions/ValueObject.cs
@@ -58,7 +58,7 @@ namespace CSharpFunctionalExtensions
                 return false;
 
             if (GetType() != obj.GetType())
-                throw new ArgumentException($"Invalid comparison of Value Objects of different types: {GetType()} and {obj.GetType()}");
+                return false;
 
             var valueObject = (ValueObject)obj;
 


### PR DESCRIPTION
`ValueObject.Equals(object other)` returns now false on different types instead of throwing ArgumentNullException.
The test was adopted as well.

The main benefit is we are closer to the expectation what `ValueObject.Equals` does.
See: [msdn](https://docs.microsoft.com/en-us/dotnet/api/system.object.equals?view=netframework-4.7.2)
Furthermore now you can use JsonSerializer without risking to get an exception.