### PR TITLE
DefaultConfigureAwait property, tidy up Map() passthrough to OnSuccess()

### DIFF
--- a/CSharpFunctionalExtensions/AsyncMaybeExtensions.cs
+++ b/CSharpFunctionalExtensions/AsyncMaybeExtensions.cs
@@ -8,13 +8,13 @@ namespace CSharpFunctionalExtensions
         public static async Task<Result<T>> ToResult<T>(this Task<Maybe<T>> maybeTask, string errorMessage)
             where T : class
         {
-            Maybe<T> maybe = await maybeTask.ConfigureAwait(false);
+            Maybe<T> maybe = await maybeTask.ConfigureAwait(Result.DefaultConfigureAwait);
             return maybe.ToResult(errorMessage);
         }
 
         public static async Task<Result<T, TError>> ToResult<T, TError>(this Task<Maybe<T>> maybeTask, TError error) where T : class where TError : class
         {
-            Maybe<T> maybe = await maybeTask.ConfigureAwait(false);
+            Maybe<T> maybe = await maybeTask.ConfigureAwait(Result.DefaultConfigureAwait);
             return maybe.ToResult(error);
         }
     }

--- a/CSharpFunctionalExtensions/AsyncResultExtensionsBothOperands.cs
+++ b/CSharpFunctionalExtensions/AsyncResultExtensionsBothOperands.cs
@@ -12,36 +12,36 @@ namespace CSharpFunctionalExtensions
         public static async Task<Result<K, TError>> OnSuccess<T, K, TError>(this Task<Result<T, TError>> resultTask,
             Func<T, Task<K>> func) where TError : class
         {
-            Result<T, TError> result = await resultTask.ConfigureAwait(false);
+            Result<T, TError> result = await resultTask.ConfigureAwait(Result.DefaultConfigureAwait);
 
             if (result.IsFailure)
                 return Result.Fail<K, TError>(result.Error);
 
-            K value = await func(result.Value).ConfigureAwait(false);
+            K value = await func(result.Value).ConfigureAwait(Result.DefaultConfigureAwait);
 
             return Result.Ok<K, TError>(value);
         }
 
         public static async Task<Result<K>> OnSuccess<T, K>(this Task<Result<T>> resultTask, Func<T, Task<K>> func)
         {
-            Result<T> result = await resultTask.ConfigureAwait(false);
+            Result<T> result = await resultTask.ConfigureAwait(Result.DefaultConfigureAwait);
 
             if (result.IsFailure)
                 return Result.Fail<K>(result.Error);
 
-            K value = await func(result.Value).ConfigureAwait(false);
+            K value = await func(result.Value).ConfigureAwait(Result.DefaultConfigureAwait);
 
             return Result.Ok(value);
         }
 
         public static async Task<Result<T>> OnSuccess<T>(this Task<Result> resultTask, Func<Task<T>> func)
         {
-            Result result = await resultTask.ConfigureAwait(false);
+            Result result = await resultTask.ConfigureAwait(Result.DefaultConfigureAwait);
 
             if (result.IsFailure)
                 return Result.Fail<T>(result.Error);
 
-            T value = await func().ConfigureAwait(false);
+            T value = await func().ConfigureAwait(Result.DefaultConfigureAwait);
 
             return Result.Ok(value);
         }
@@ -49,83 +49,83 @@ namespace CSharpFunctionalExtensions
         public static async Task<Result<K, TError>> OnSuccess<T, K, TError>(this Task<Result<T, TError>> resultTask,
             Func<T, Task<Result<K, TError>>> func) where TError : class
         {
-            Result<T, TError> result = await resultTask.ConfigureAwait(false);
+            Result<T, TError> result = await resultTask.ConfigureAwait(Result.DefaultConfigureAwait);
 
             if (result.IsFailure)
                 return Result.Fail<K, TError>(result.Error);
 
-            return await func(result.Value).ConfigureAwait(false);
+            return await func(result.Value).ConfigureAwait(Result.DefaultConfigureAwait);
         }
 
         public static async Task<Result<K>> OnSuccess<T, K>(this Task<Result<T>> resultTask, Func<T, Task<Result<K>>> func)
         {
-            Result<T> result = await resultTask.ConfigureAwait(false);
+            Result<T> result = await resultTask.ConfigureAwait(Result.DefaultConfigureAwait);
 
             if (result.IsFailure)
                 return Result.Fail<K>(result.Error);
 
-            return await func(result.Value).ConfigureAwait(false);
+            return await func(result.Value).ConfigureAwait(Result.DefaultConfigureAwait);
         }
 
         public static async Task<Result<T>> OnSuccess<T>(this Task<Result> resultTask, Func<Task<Result<T>>> func)
         {
-            Result result = await resultTask.ConfigureAwait(false);
+            Result result = await resultTask.ConfigureAwait(Result.DefaultConfigureAwait);
 
             if (result.IsFailure)
                 return Result.Fail<T>(result.Error);
 
-            return await func().ConfigureAwait(false);
+            return await func().ConfigureAwait(Result.DefaultConfigureAwait);
         }
 
         public static async Task<Result<K, TError>> OnSuccess<T, K, TError>(this Task<Result<T, TError>> resultTask,
             Func<Task<Result<K, TError>>> func) where TError : class
         {
-            Result<T, TError> result = await resultTask.ConfigureAwait(false);
+            Result<T, TError> result = await resultTask.ConfigureAwait(Result.DefaultConfigureAwait);
 
             if (result.IsFailure)
                 return Result.Fail<K, TError>(result.Error);
 
-            return await func().ConfigureAwait(false);
+            return await func().ConfigureAwait(Result.DefaultConfigureAwait);
         }
 
         public static async Task<Result<K>> OnSuccess<T, K>(this Task<Result<T>> resultTask, Func<Task<Result<K>>> func)
         {
-            Result<T> result = await resultTask.ConfigureAwait(false);
+            Result<T> result = await resultTask.ConfigureAwait(Result.DefaultConfigureAwait);
 
             if (result.IsFailure)
                 return Result.Fail<K>(result.Error);
 
-            return await func().ConfigureAwait(false);
+            return await func().ConfigureAwait(Result.DefaultConfigureAwait);
         }
 
         public static async Task<Result> OnSuccess<T>(this Task<Result<T>> resultTask, Func<T, Task<Result>> func)
         {
-            Result<T> result = await resultTask.ConfigureAwait(false);
+            Result<T> result = await resultTask.ConfigureAwait(Result.DefaultConfigureAwait);
 
             if (result.IsFailure)
                 return Result.Fail(result.Error);
 
-            return await func(result.Value).ConfigureAwait(false);
+            return await func(result.Value).ConfigureAwait(Result.DefaultConfigureAwait);
         }
 
         public static async Task<Result> OnSuccess(this Task<Result> resultTask, Func<Task<Result>> func)
         {
-            Result result = await resultTask.ConfigureAwait(false);
+            Result result = await resultTask.ConfigureAwait(Result.DefaultConfigureAwait);
 
             if (result.IsFailure)
                 return result;
 
-            return await func().ConfigureAwait(false);
+            return await func().ConfigureAwait(Result.DefaultConfigureAwait);
         }
 
         public static async Task<Result<T>> Ensure<T>(this Task<Result<T>> resultTask, Func<T, Task<bool>> predicate, string errorMessage)
         {
-            Result<T> result = await resultTask.ConfigureAwait(false);
+            Result<T> result = await resultTask.ConfigureAwait(Result.DefaultConfigureAwait);
 
             if (result.IsFailure)
                 return result;
 
-            if (!await predicate(result.Value).ConfigureAwait(false))
+            if (!await predicate(result.Value).ConfigureAwait(Result.DefaultConfigureAwait))
                 return Result.Fail<T>(errorMessage);
 
             return result;
@@ -134,12 +134,12 @@ namespace CSharpFunctionalExtensions
         public static async Task<Result<T, TError>> Ensure<T, TError>(this Task<Result<T, TError>> resultTask,
             Func<T, Task<bool>> predicate, TError error) where TError : class
         {
-            Result<T, TError> result = await resultTask.ConfigureAwait(false);
+            Result<T, TError> result = await resultTask.ConfigureAwait(Result.DefaultConfigureAwait);
 
             if (result.IsFailure)
                 return result;
 
-            if (!await predicate(result.Value).ConfigureAwait(false))
+            if (!await predicate(result.Value).ConfigureAwait(Result.DefaultConfigureAwait))
                 return Result.Fail<T, TError>(error);
 
             return result;
@@ -147,12 +147,12 @@ namespace CSharpFunctionalExtensions
 
         public static async Task<Result> Ensure(this Task<Result> resultTask, Func<Task<bool>> predicate, string errorMessage)
         {
-            Result result = await resultTask.ConfigureAwait(false);
+            Result result = await resultTask.ConfigureAwait(Result.DefaultConfigureAwait);
 
             if (result.IsFailure)
                 return result;
 
-            if (!await predicate().ConfigureAwait(false))
+            if (!await predicate().ConfigureAwait(Result.DefaultConfigureAwait))
                 return Result.Fail(errorMessage);
 
             return result;
@@ -172,11 +172,11 @@ namespace CSharpFunctionalExtensions
         public static async Task<Result<T, TError>> OnSuccess<T, TError>(this Task<Result<T, TError>> resultTask,
             Func<T, Task> action)
         {
-            Result<T, TError> result = await resultTask.ConfigureAwait(false);
+            Result<T, TError> result = await resultTask.ConfigureAwait(Result.DefaultConfigureAwait);
 
             if (result.IsSuccess)
             {
-                await action(result.Value).ConfigureAwait(false);
+                await action(result.Value).ConfigureAwait(Result.DefaultConfigureAwait);
             }
 
             return result;
@@ -184,11 +184,11 @@ namespace CSharpFunctionalExtensions
 
         public static async Task<Result<T>> OnSuccess<T>(this Task<Result<T>> resultTask, Func<T, Task> action)
         {
-            Result<T> result = await resultTask.ConfigureAwait(false);
+            Result<T> result = await resultTask.ConfigureAwait(Result.DefaultConfigureAwait);
 
             if (result.IsSuccess)
             {
-                await action(result.Value).ConfigureAwait(false);
+                await action(result.Value).ConfigureAwait(Result.DefaultConfigureAwait);
             }
 
             return result;
@@ -196,11 +196,11 @@ namespace CSharpFunctionalExtensions
 
         public static async Task<Result> OnSuccess(this Task<Result> resultTask, Func<Task> action)
         {
-            Result result = await resultTask.ConfigureAwait(false);
+            Result result = await resultTask.ConfigureAwait(Result.DefaultConfigureAwait);
 
             if (result.IsSuccess)
             {
-                await action().ConfigureAwait(false);
+                await action().ConfigureAwait(Result.DefaultConfigureAwait);
             }
 
             return result;
@@ -208,31 +208,31 @@ namespace CSharpFunctionalExtensions
 
         public static async Task<T> OnBoth<T>(this Task<Result> resultTask, Func<Result, Task<T>> func)
         {
-            Result result = await resultTask.ConfigureAwait(false);
-            return await func(result).ConfigureAwait(false);
+            Result result = await resultTask.ConfigureAwait(Result.DefaultConfigureAwait);
+            return await func(result).ConfigureAwait(Result.DefaultConfigureAwait);
         }
 
         public static async Task<K> OnBoth<T, K>(this Task<Result<T>> resultTask, Func<Result<T>, Task<K>> func)
         {
-            Result<T> result = await resultTask.ConfigureAwait(false);
-            return await func(result).ConfigureAwait(false);
+            Result<T> result = await resultTask.ConfigureAwait(Result.DefaultConfigureAwait);
+            return await func(result).ConfigureAwait(Result.DefaultConfigureAwait);
         }
 
         public static async Task<K> OnBoth<T, K, TError>(this Task<Result<T, TError>> resultTask,
             Func<Result<T, TError>, Task<K>> func)
         {
-            Result<T, TError> result = await resultTask.ConfigureAwait(false);
-            return await func(result).ConfigureAwait(false);
+            Result<T, TError> result = await resultTask.ConfigureAwait(Result.DefaultConfigureAwait);
+            return await func(result).ConfigureAwait(Result.DefaultConfigureAwait);
         }
 
         public static async Task<Result<T, TError>> OnFailure<T, TError>(this Task<Result<T, TError>> resultTask,
             Func<Task> func)
         {
-            Result<T, TError> result = await resultTask.ConfigureAwait(false);
+            Result<T, TError> result = await resultTask.ConfigureAwait(Result.DefaultConfigureAwait);
 
             if (result.IsFailure)
             {
-                await func().ConfigureAwait(false);
+                await func().ConfigureAwait(Result.DefaultConfigureAwait);
             }
 
             return result;
@@ -240,11 +240,11 @@ namespace CSharpFunctionalExtensions
 
         public static async Task<Result<T>> OnFailure<T>(this Task<Result<T>> resultTask, Func<Task> func)
         {
-            Result<T> result = await resultTask.ConfigureAwait(false);
+            Result<T> result = await resultTask.ConfigureAwait(Result.DefaultConfigureAwait);
 
             if (result.IsFailure)
             {
-                await func().ConfigureAwait(false);
+                await func().ConfigureAwait(Result.DefaultConfigureAwait);
             }
 
             return result;
@@ -252,11 +252,11 @@ namespace CSharpFunctionalExtensions
 
         public static async Task<Result> OnFailure(this Task<Result> resultTask, Func<Task> func)
         {
-            Result result = await resultTask.ConfigureAwait(false);
+            Result result = await resultTask.ConfigureAwait(Result.DefaultConfigureAwait);
 
             if (result.IsFailure)
             {
-                await func().ConfigureAwait(false);
+                await func().ConfigureAwait(Result.DefaultConfigureAwait);
             }
 
             return result;
@@ -264,11 +264,11 @@ namespace CSharpFunctionalExtensions
 
         public static async Task<Result<T>> OnFailure<T>(this Task<Result<T>> resultTask, Func<string, Task> func)
         {
-            Result<T> result = await resultTask.ConfigureAwait(false);
+            Result<T> result = await resultTask.ConfigureAwait(Result.DefaultConfigureAwait);
 
             if (result.IsFailure)
             {
-                await func(result.Error).ConfigureAwait(false);
+                await func(result.Error).ConfigureAwait(Result.DefaultConfigureAwait);
             }
 
             return result;
@@ -277,11 +277,11 @@ namespace CSharpFunctionalExtensions
         public static async Task<Result<T, TError>> OnFailure<T, TError>(this Task<Result<T, TError>> resultTask,
             Func<TError, Task> func)
         {
-            Result<T, TError> result = await resultTask.ConfigureAwait(false);
+            Result<T, TError> result = await resultTask.ConfigureAwait(Result.DefaultConfigureAwait);
 
             if (result.IsFailure)
             {
-                await func(result.Error).ConfigureAwait(false);
+                await func(result.Error).ConfigureAwait(Result.DefaultConfigureAwait);
             }
 
             return result;
@@ -290,40 +290,40 @@ namespace CSharpFunctionalExtensions
         public static async Task<Result<T, TError>> OnFailureCompensate<T, TError>(this Task<Result<T, TError>> resultTask,
             Func<Task<Result<T, TError>>> func)
         {
-            Result<T, TError> result = await resultTask.ConfigureAwait(false);
+            Result<T, TError> result = await resultTask.ConfigureAwait(Result.DefaultConfigureAwait);
 
             if (result.IsFailure)
-                return await func().ConfigureAwait(false);
+                return await func().ConfigureAwait(Result.DefaultConfigureAwait);
 
             return result;
         }
 
         public static async Task<Result<T>> OnFailureCompensate<T>(this Task<Result<T>> resultTask, Func<Task<Result<T>>> func)
         {
-            Result<T> result = await resultTask.ConfigureAwait(false);
+            Result<T> result = await resultTask.ConfigureAwait(Result.DefaultConfigureAwait);
 
             if (result.IsFailure)
-                return await func().ConfigureAwait(false);
+                return await func().ConfigureAwait(Result.DefaultConfigureAwait);
 
             return result;
         }
 
         public static async Task<Result> OnFailureCompensate(this Task<Result> resultTask, Func<Task<Result>> func)
         {
-            Result result = await resultTask.ConfigureAwait(false);
+            Result result = await resultTask.ConfigureAwait(Result.DefaultConfigureAwait);
 
             if (result.IsFailure)
-                return await func().ConfigureAwait(false);
+                return await func().ConfigureAwait(Result.DefaultConfigureAwait);
 
             return result;
         }
 
         public static async Task<Result<T>> OnFailureCompensate<T>(this Task<Result<T>> resultTask, Func<string, Task<Result<T>>> func)
         {
-            Result<T> result = await resultTask.ConfigureAwait(false);
+            Result<T> result = await resultTask.ConfigureAwait(Result.DefaultConfigureAwait);
 
             if (result.IsFailure)
-                return await func(result.Error).ConfigureAwait(false);
+                return await func(result.Error).ConfigureAwait(Result.DefaultConfigureAwait);
 
             return result;
         }
@@ -331,10 +331,10 @@ namespace CSharpFunctionalExtensions
         public static async Task<Result<T, TError>> OnFailureCompensate<T, TError>(this Task<Result<T, TError>> resultTask,
             Func<TError, Task<Result<T, TError>>> func)
         {
-            Result<T, TError> result = await resultTask.ConfigureAwait(false);
+            Result<T, TError> result = await resultTask.ConfigureAwait(Result.DefaultConfigureAwait);
 
             if (result.IsFailure)
-                return await func(result.Error).ConfigureAwait(false);
+                return await func(result.Error).ConfigureAwait(Result.DefaultConfigureAwait);
 
             return result;
         }

--- a/CSharpFunctionalExtensions/AsyncResultExtensionsBothOperands.cs
+++ b/CSharpFunctionalExtensions/AsyncResultExtensionsBothOperands.cs
@@ -158,21 +158,16 @@ namespace CSharpFunctionalExtensions
             return result;
         }
 
-        public static async Task<Result<K, TError>> Map<T, K, TError>(this Task<Result<T, TError>> resultTask,
+        public static Task<Result<K, TError>> Map<T, K, TError>(this Task<Result<T, TError>> resultTask,
             Func<T, Task<K>> func) where TError : class
-        {
-            return await resultTask.OnSuccess(func).ConfigureAwait(false);
-        }
+            => resultTask.OnSuccess(func);
 
-        public static async Task<Result<K>> Map<T, K>(this Task<Result<T>> resultTask, Func<T, Task<K>> func)
-        {
-            return await resultTask.OnSuccess(func).ConfigureAwait(false);
-        }
+        public static Task<Result<K>> Map<T, K>(this Task<Result<T>> resultTask, Func<T, Task<K>> func)
+            => resultTask.OnSuccess(func);
 
-        public static async Task<Result<T>> Map<T>(this Task<Result> resultTask, Func<Task<T>> func)
-        {
-            return await resultTask.OnSuccess(func).ConfigureAwait(false);
-        }
+        public static Task<Result<T>> Map<T>(this Task<Result> resultTask, Func<Task<T>> func)
+            => resultTask.OnSuccess(func);
+
 
         public static async Task<Result<T, TError>> OnSuccess<T, TError>(this Task<Result<T, TError>> resultTask,
             Func<T, Task> action)

--- a/CSharpFunctionalExtensions/AsyncResultExtensionsLeftOperand.cs
+++ b/CSharpFunctionalExtensions/AsyncResultExtensionsLeftOperand.cs
@@ -12,82 +12,82 @@ namespace CSharpFunctionalExtensions
         public static async Task<Result<K, TError>> OnSuccess<T, K, TError>(this Task<Result<T, TError>> resultTask,
             Func<T, K> func) where TError : class
         {
-            Result<T, TError> result = await resultTask.ConfigureAwait(false);
+            Result<T, TError> result = await resultTask.ConfigureAwait(Result.DefaultConfigureAwait);
             return result.OnSuccess(func);
         }
 
         public static async Task<Result<K>> OnSuccess<T, K>(this Task<Result<T>> resultTask, Func<T, K> func)
         {
-            Result<T> result = await resultTask.ConfigureAwait(false);
+            Result<T> result = await resultTask.ConfigureAwait(Result.DefaultConfigureAwait);
             return result.OnSuccess(func);
         }
 
         public static async Task<Result<T>> OnSuccess<T>(this Task<Result> resultTask, Func<T> func)
         {
-            Result result = await resultTask.ConfigureAwait(false);
+            Result result = await resultTask.ConfigureAwait(Result.DefaultConfigureAwait);
             return result.OnSuccess(func);
         }
 
         public static async Task<Result<K, TError>> OnSuccess<T, K, TError>(this Task<Result<T, TError>> resultTask,
             Func<T, Result<K, TError>> func) where TError : class
         {
-            Result<T, TError> result = await resultTask.ConfigureAwait(false);
+            Result<T, TError> result = await resultTask.ConfigureAwait(Result.DefaultConfigureAwait);
             return result.OnSuccess(func);
         }
 
         public static async Task<Result<K>> OnSuccess<T, K>(this Task<Result<T>> resultTask, Func<T, Result<K>> func)
         {
-            Result<T> result = await resultTask.ConfigureAwait(false);
+            Result<T> result = await resultTask.ConfigureAwait(Result.DefaultConfigureAwait);
             return result.OnSuccess(func);
         }
 
         public static async Task<Result<T>> OnSuccess<T>(this Task<Result> resultTask, Func<Result<T>> func)
         {
-            Result result = await resultTask.ConfigureAwait(false);
+            Result result = await resultTask.ConfigureAwait(Result.DefaultConfigureAwait);
             return result.OnSuccess(func);
         }
 
         public static async Task<Result<K>> OnSuccess<T, K>(this Task<Result<T>> resultTask, Func<Result<K>> func)
         {
-            Result<T> result = await resultTask.ConfigureAwait(false);
+            Result<T> result = await resultTask.ConfigureAwait(Result.DefaultConfigureAwait);
             return result.OnSuccess(func);
         }
 
         public static async Task<Result<K, TError>> OnSuccess<T, K, TError>(this Task<Result<T, TError>> resultTask,
             Func<Result<K, TError>> func) where TError : class
         {
-            Result<T, TError> result = await resultTask.ConfigureAwait(false);
+            Result<T, TError> result = await resultTask.ConfigureAwait(Result.DefaultConfigureAwait);
             return result.OnSuccess(func);
         }
 
         public static async Task<Result> OnSuccess<T>(this Task<Result<T>> resultTask, Func<T, Result> func)
         {
-            Result<T> result = await resultTask.ConfigureAwait(false);
+            Result<T> result = await resultTask.ConfigureAwait(Result.DefaultConfigureAwait);
             return result.OnSuccess(func);
         }
 
         public static async Task<Result> OnSuccess(this Task<Result> resultTask, Func<Result> func)
         {
-            Result result = await resultTask.ConfigureAwait(false);
+            Result result = await resultTask.ConfigureAwait(Result.DefaultConfigureAwait);
             return result.OnSuccess(func);
         }
 
         public static async Task<Result<T>> Ensure<T>(this Task<Result<T>> resultTask, Func<T, bool> predicate, string errorMessage)
         {
-            Result<T> result = await resultTask.ConfigureAwait(false);
+            Result<T> result = await resultTask.ConfigureAwait(Result.DefaultConfigureAwait);
             return result.Ensure(predicate, errorMessage);
         }
 
         public static async Task<Result<T, TError>> Ensure<T, TError>(this Task<Result<T, TError>> resultTask,
             Func<T, bool> predicate, TError error) where TError : class
         {
-            Result<T, TError> result = await resultTask.ConfigureAwait(false);
+            Result<T, TError> result = await resultTask.ConfigureAwait(Result.DefaultConfigureAwait);
             return result.Ensure(predicate, error);
         }
 
         public static async Task<Result> Ensure(this Task<Result> resultTask, Func<bool> predicate, string errorMessage)
         {
-            Result result = await resultTask.ConfigureAwait(false);
+            Result result = await resultTask.ConfigureAwait(Result.DefaultConfigureAwait);
             return result.Ensure(predicate, errorMessage);
         }
 
@@ -103,94 +103,94 @@ namespace CSharpFunctionalExtensions
 
         public static async Task<Result<T>> OnSuccess<T>(this Task<Result<T>> resultTask, Action<T> action)
         {
-            Result<T> result = await resultTask.ConfigureAwait(false);
+            Result<T> result = await resultTask.ConfigureAwait(Result.DefaultConfigureAwait);
             return result.OnSuccess(action);
         }
 
         public static async Task<Result> OnSuccess(this Task<Result> resultTask, Action action)
         {
-            Result result = await resultTask.ConfigureAwait(false);
+            Result result = await resultTask.ConfigureAwait(Result.DefaultConfigureAwait);
             return result.OnSuccess(action);
         }
 
         public static async Task<T> OnBoth<T>(this Task<Result> resultTask, Func<Result, T> func)
         {
-            Result result = await resultTask.ConfigureAwait(false);
+            Result result = await resultTask.ConfigureAwait(Result.DefaultConfigureAwait);
             return result.OnBoth(func);
         }
 
         public static async Task<K> OnBoth<T, K>(this Task<Result<T>> resultTask, Func<Result<T>, K> func)
         {
-            Result<T> result = await resultTask.ConfigureAwait(false);
+            Result<T> result = await resultTask.ConfigureAwait(Result.DefaultConfigureAwait);
             return result.OnBoth(func);
         }
 
         public static async Task<K> OnBoth<T, K, TError>(this Task<Result<T, TError>> resultTask,
             Func<Result<T, TError>, K> func)
         {
-            Result<T, TError> result = await resultTask.ConfigureAwait(false);
+            Result<T, TError> result = await resultTask.ConfigureAwait(Result.DefaultConfigureAwait);
             return result.OnBoth(func);
         }
 
         public static async Task<Result<T>> OnFailure<T>(this Task<Result<T>> resultTask, Action action)
         {
-            Result<T> result = await resultTask.ConfigureAwait(false);
+            Result<T> result = await resultTask.ConfigureAwait(Result.DefaultConfigureAwait);
             return result.OnFailure(action);
         }
 
         public static async Task<Result> OnFailure(this Task<Result> resultTask, Action action)
         {
-            Result result = await resultTask.ConfigureAwait(false);
+            Result result = await resultTask.ConfigureAwait(Result.DefaultConfigureAwait);
             return result.OnFailure(action);
         }
 
         public static async Task<Result<T>> OnFailure<T>(this Task<Result<T>> resultTask, Action<string> action)
         {
-            Result<T> result = await resultTask.ConfigureAwait(false);
+            Result<T> result = await resultTask.ConfigureAwait(Result.DefaultConfigureAwait);
             return result.OnFailure(action);
         }
 
         public static async Task<Result<T, TError>> OnFailure<T, TError>(this Task<Result<T, TError>> resultTask,
             Action<TError> action) where TError : class
         {
-            Result<T, TError> result = await resultTask.ConfigureAwait(false);
+            Result<T, TError> result = await resultTask.ConfigureAwait(Result.DefaultConfigureAwait);
             return result.OnFailure(action);
         }
 
         public static async Task<Result> OnFailure(this Task<Result> resultTask, Action<string> action)
         {
-            Result result = await resultTask.ConfigureAwait(false);
+            Result result = await resultTask.ConfigureAwait(Result.DefaultConfigureAwait);
             return result.OnFailure(action);
         }
 
         public static async Task<Result<T>> OnFailureCompensate<T>(this Task<Result<T>> resultTask, Func<Result<T>> func)
         {
-            Result<T> result = await resultTask.ConfigureAwait(false);
+            Result<T> result = await resultTask.ConfigureAwait(Result.DefaultConfigureAwait);
             return result.OnFailureCompensate(func);
         }
 
         public static async Task<Result> OnFailureCompensate(this Task<Result> resultTask, Func<Result> func)
         {
-            Result result = await resultTask.ConfigureAwait(false);
+            Result result = await resultTask.ConfigureAwait(Result.DefaultConfigureAwait);
             return result.OnFailureCompensate(func);
         }
 
         public static async Task<Result<T>> OnFailureCompensate<T>(this Task<Result<T>> resultTask, Func<string, Result<T>> func)
         {
-            Result<T> result = await resultTask.ConfigureAwait(false);
+            Result<T> result = await resultTask.ConfigureAwait(Result.DefaultConfigureAwait);
             return result.OnFailureCompensate(func);
         }
 
         public static async Task<Result<T, TError>> OnFailureCompensate<T, TError>(this Task<Result<T, TError>> resultTask,
             Func<TError, Result<T, TError>> func) where TError : class
         {
-            Result<T, TError> result = await resultTask.ConfigureAwait(false);
+            Result<T, TError> result = await resultTask.ConfigureAwait(Result.DefaultConfigureAwait);
             return result.OnFailureCompensate(func);
         }
 
         public static async Task<Result> OnFailureCompensate(this Task<Result> resultTask, Func<string, Result> func)
         {
-            Result result = await resultTask.ConfigureAwait(false);
+            Result result = await resultTask.ConfigureAwait(Result.DefaultConfigureAwait);
             return result.OnFailureCompensate(func);
         }
     }

--- a/CSharpFunctionalExtensions/AsyncResultExtensionsRightOperand.cs
+++ b/CSharpFunctionalExtensions/AsyncResultExtensionsRightOperand.cs
@@ -14,7 +14,7 @@ namespace CSharpFunctionalExtensions
             if (result.IsFailure)
                 return Result.Fail<K>(result.Error);
 
-            K value = await func(result.Value).ConfigureAwait(false);
+            K value = await func(result.Value).ConfigureAwait(Result.DefaultConfigureAwait);
 
             return Result.Ok(value);
         }
@@ -25,7 +25,7 @@ namespace CSharpFunctionalExtensions
             if (result.IsFailure)
                 return Result.Fail<K, TError>(result.Error);
 
-            K value = await func(result.Value).ConfigureAwait(false);
+            K value = await func(result.Value).ConfigureAwait(Result.DefaultConfigureAwait);
 
             return Result.Ok<K, TError>(value);
         }
@@ -35,7 +35,7 @@ namespace CSharpFunctionalExtensions
             if (result.IsFailure)
                 return Result.Fail<T>(result.Error);
 
-            T value = await func().ConfigureAwait(false);
+            T value = await func().ConfigureAwait(Result.DefaultConfigureAwait);
 
             return Result.Ok(value);
         }
@@ -45,7 +45,7 @@ namespace CSharpFunctionalExtensions
             if (result.IsFailure)
                 return Result.Fail<K>(result.Error);
 
-            return await func(result.Value).ConfigureAwait(false);
+            return await func(result.Value).ConfigureAwait(Result.DefaultConfigureAwait);
         }
 
         public static async Task<Result<K, TError>> OnSuccess<T, K, TError>(this Result<T, TError> result,
@@ -54,7 +54,7 @@ namespace CSharpFunctionalExtensions
             if (result.IsFailure)
                 return Result.Fail<K, TError>(result.Error);
 
-            return await func(result.Value).ConfigureAwait(false);
+            return await func(result.Value).ConfigureAwait(Result.DefaultConfigureAwait);
         }
 
         public static async Task<Result<T>> OnSuccess<T>(this Result result, Func<Task<Result<T>>> func)
@@ -62,7 +62,7 @@ namespace CSharpFunctionalExtensions
             if (result.IsFailure)
                 return Result.Fail<T>(result.Error);
 
-            return await func().ConfigureAwait(false);
+            return await func().ConfigureAwait(Result.DefaultConfigureAwait);
         }
 
         public static async Task<Result<K>> OnSuccess<T, K>(this Result<T> result, Func<Task<Result<K>>> func)
@@ -70,7 +70,7 @@ namespace CSharpFunctionalExtensions
             if (result.IsFailure)
                 return Result.Fail<K>(result.Error);
 
-            return await func().ConfigureAwait(false);
+            return await func().ConfigureAwait(Result.DefaultConfigureAwait);
         }
 
         public static async Task<Result<K, TError>> OnSuccess<T, K, TError>(this Result<T, TError> result,
@@ -79,7 +79,7 @@ namespace CSharpFunctionalExtensions
             if (result.IsFailure)
                 return Result.Fail<K, TError>(result.Error);
 
-            return await func().ConfigureAwait(false);
+            return await func().ConfigureAwait(Result.DefaultConfigureAwait);
         }
 
         public static async Task<Result> OnSuccess<T>(this Result<T> result, Func<T, Task<Result>> func)
@@ -87,7 +87,7 @@ namespace CSharpFunctionalExtensions
             if (result.IsFailure)
                 return Result.Fail(result.Error);
 
-            return await func(result.Value).ConfigureAwait(false);
+            return await func(result.Value).ConfigureAwait(Result.DefaultConfigureAwait);
         }
 
         public static async Task<Result> OnSuccess(this Result result, Func<Task<Result>> func)
@@ -95,7 +95,7 @@ namespace CSharpFunctionalExtensions
             if (result.IsFailure)
                 return result;
 
-            return await func().ConfigureAwait(false);
+            return await func().ConfigureAwait(Result.DefaultConfigureAwait);
         }
 
         public static async Task<Result<T>> Ensure<T>(this Result<T> result, Func<T, Task<bool>> predicate, string errorMessage)
@@ -103,7 +103,7 @@ namespace CSharpFunctionalExtensions
             if (result.IsFailure)
                 return result;
 
-            if (!await predicate(result.Value).ConfigureAwait(false))
+            if (!await predicate(result.Value).ConfigureAwait(Result.DefaultConfigureAwait))
                 return Result.Fail<T>(errorMessage);
 
             return result;
@@ -115,7 +115,7 @@ namespace CSharpFunctionalExtensions
             if (result.IsFailure)
                 return result;
 
-            if (!await predicate(result.Value).ConfigureAwait(false))
+            if (!await predicate(result.Value).ConfigureAwait(Result.DefaultConfigureAwait))
                 return Result.Fail<T, TError>(error);
 
             return result;
@@ -126,7 +126,7 @@ namespace CSharpFunctionalExtensions
             if (result.IsFailure)
                 return result;
 
-            if (!await predicate().ConfigureAwait(false))
+            if (!await predicate().ConfigureAwait(Result.DefaultConfigureAwait))
                 return Result.Fail(errorMessage);
 
             return result;
@@ -146,7 +146,7 @@ namespace CSharpFunctionalExtensions
         {
             if (result.IsSuccess)
             {
-                await action(result.Value).ConfigureAwait(false);
+                await action(result.Value).ConfigureAwait(Result.DefaultConfigureAwait);
             }
 
             return result;
@@ -157,7 +157,7 @@ namespace CSharpFunctionalExtensions
         {
             if (result.IsSuccess)
             {
-                await action(result.Value).ConfigureAwait(false);
+                await action(result.Value).ConfigureAwait(Result.DefaultConfigureAwait);
             }
 
             return result;
@@ -167,7 +167,7 @@ namespace CSharpFunctionalExtensions
         {
             if (result.IsSuccess)
             {
-                await action().ConfigureAwait(false);
+                await action().ConfigureAwait(Result.DefaultConfigureAwait);
             }
 
             return result;
@@ -175,24 +175,24 @@ namespace CSharpFunctionalExtensions
 
         public static async Task<T> OnBoth<T>(this Result result, Func<Result, Task<T>> func)
         {
-            return await func(result).ConfigureAwait(false);
+            return await func(result).ConfigureAwait(Result.DefaultConfigureAwait);
         }
 
         public static async Task<K> OnBoth<T, K>(this Result<T> result, Func<Result<T>, Task<K>> func)
         {
-            return await func(result).ConfigureAwait(false);
+            return await func(result).ConfigureAwait(Result.DefaultConfigureAwait);
         }
 
         public static async Task<K> OnBoth<T, K, TError>(this Result<T, TError> result, Func<Result<T>, Task<K>> func)
         {
-            return await func(result).ConfigureAwait(false);
+            return await func(result).ConfigureAwait(Result.DefaultConfigureAwait);
         }
 
         public static async Task<Result<T>> OnFailure<T>(this Result<T> result, Func<Task> func)
         {
             if (result.IsFailure)
             {
-                await func().ConfigureAwait(false);
+                await func().ConfigureAwait(Result.DefaultConfigureAwait);
             }
 
             return result;
@@ -202,7 +202,7 @@ namespace CSharpFunctionalExtensions
         {
             if (result.IsFailure)
             {
-                await func().ConfigureAwait(false);
+                await func().ConfigureAwait(Result.DefaultConfigureAwait);
             }
 
             return result;
@@ -212,7 +212,7 @@ namespace CSharpFunctionalExtensions
         {
             if (result.IsFailure)
             {
-                await func().ConfigureAwait(false);
+                await func().ConfigureAwait(Result.DefaultConfigureAwait);
             }
 
             return result;
@@ -222,7 +222,7 @@ namespace CSharpFunctionalExtensions
         {
             if (result.IsFailure)
             {
-                await func(result.Error).ConfigureAwait(false);
+                await func(result.Error).ConfigureAwait(Result.DefaultConfigureAwait);
             }
 
             return result;
@@ -233,7 +233,7 @@ namespace CSharpFunctionalExtensions
         {
             if (result.IsFailure)
             {
-                await func(result.Error).ConfigureAwait(false);
+                await func(result.Error).ConfigureAwait(Result.DefaultConfigureAwait);
             }
 
             return result;
@@ -242,7 +242,7 @@ namespace CSharpFunctionalExtensions
         public static async Task<Result<T>> OnFailureCompensate<T>(this Result<T> result, Func<Task<Result<T>>> func)
         {
             if (result.IsFailure)
-                return await func().ConfigureAwait(false);
+                return await func().ConfigureAwait(Result.DefaultConfigureAwait);
 
             return result;
         }
@@ -250,7 +250,7 @@ namespace CSharpFunctionalExtensions
         public static async Task<Result<T, TError>> OnFailureCompensate<T, TError>(this Result<T, TError> result, Func<Task<Result<T, TError>>> func)
         {
             if (result.IsFailure)
-                return await func().ConfigureAwait(false);
+                return await func().ConfigureAwait(Result.DefaultConfigureAwait);
 
             return result;
         }
@@ -258,7 +258,7 @@ namespace CSharpFunctionalExtensions
         public static async Task<Result> OnFailureCompensate(this Result result, Func<Task<Result>> func)
         {
             if (result.IsFailure)
-                return await func().ConfigureAwait(false);
+                return await func().ConfigureAwait(Result.DefaultConfigureAwait);
 
             return result;
         }
@@ -266,7 +266,7 @@ namespace CSharpFunctionalExtensions
         public static async Task<Result<T>> OnFailureCompensate<T>(this Result<T> result, Func<string, Task<Result<T>>> func)
         {
             if (result.IsFailure)
-                return await func(result.Error).ConfigureAwait(false);
+                return await func(result.Error).ConfigureAwait(Result.DefaultConfigureAwait);
 
             return result;
         }
@@ -275,7 +275,7 @@ namespace CSharpFunctionalExtensions
             Func<TError, Task<Result<T, TError>>> func)
         {
             if (result.IsFailure)
-                return await func(result.Error).ConfigureAwait(false);
+                return await func(result.Error).ConfigureAwait(Result.DefaultConfigureAwait);
 
             return result;
         }
@@ -283,9 +283,9 @@ namespace CSharpFunctionalExtensions
         public static async Task<Result> Combine(this IEnumerable<Task<Result>> tasks, string errorMessageSeparator)
         {
 #if NET40
-            Result[] results = await TaskEx.WhenAll(tasks).ConfigureAwait(false);
+            Result[] results = await TaskEx.WhenAll(tasks).ConfigureAwait(Result.DefaultConfigureAwait);
 #else
-            Result[] results = await Task.WhenAll(tasks).ConfigureAwait(false);
+            Result[] results = await Task.WhenAll(tasks).ConfigureAwait(Result.DefaultConfigureAwait);
 #endif
             return results.Combine(errorMessageSeparator);
         }
@@ -294,35 +294,35 @@ namespace CSharpFunctionalExtensions
             string errorMessageSeparator)
         {
 #if NET40
-            Result<T>[] results = await TaskEx.WhenAll(tasks).ConfigureAwait(false);
+            Result<T>[] results = await TaskEx.WhenAll(tasks).ConfigureAwait(Result.DefaultConfigureAwait);
 #else
-            Result<T>[] results = await Task.WhenAll(tasks).ConfigureAwait(false);
+            Result<T>[] results = await Task.WhenAll(tasks).ConfigureAwait(Result.DefaultConfigureAwait);
 #endif
             return results.Combine(errorMessageSeparator);
         }
 
         public static async Task<Result> Combine(this Task<IEnumerable<Result>> task, string errorMessageSeparator)
         {
-            IEnumerable<Result> results = await task.ConfigureAwait(false);
+            IEnumerable<Result> results = await task.ConfigureAwait(Result.DefaultConfigureAwait);
             return results.Combine(errorMessageSeparator);
         }
 
         public static async Task<Result<IEnumerable<T>>> Combine<T>(this Task<IEnumerable<Result<T>>> task,
             string errorMessageSeparator)
         {
-            IEnumerable<Result<T>> results = await task.ConfigureAwait(false);
+            IEnumerable<Result<T>> results = await task.ConfigureAwait(Result.DefaultConfigureAwait);
             return results.Combine(errorMessageSeparator);
         }
 
         public static async Task<Result> Combine(this Task<IEnumerable<Task<Result>>> task,
             string errorMessageSeparator)
         {
-            var tasks = await task.ConfigureAwait(false);
+            var tasks = await task.ConfigureAwait(Result.DefaultConfigureAwait);
 
 #if NET40
-            var results = await TaskEx.WhenAll(tasks).ConfigureAwait(false);
+            var results = await TaskEx.WhenAll(tasks).ConfigureAwait(Result.DefaultConfigureAwait);
 #else
-            var results = await Task.WhenAll(tasks).ConfigureAwait(false);
+            var results = await Task.WhenAll(tasks).ConfigureAwait(Result.DefaultConfigureAwait);
 #endif
 
             return results.Combine(errorMessageSeparator);
@@ -331,11 +331,11 @@ namespace CSharpFunctionalExtensions
         public static async Task<Result<IEnumerable<T>>> Combine<T>(this Task<IEnumerable<Task<Result<T>>>> task,
             string errorMessageSeparator)
         {
-            var tasks = await task.ConfigureAwait(false);
+            var tasks = await task.ConfigureAwait(Result.DefaultConfigureAwait);
 #if NET40
-            var results = await TaskEx.WhenAll(tasks).ConfigureAwait(false);
+            var results = await TaskEx.WhenAll(tasks).ConfigureAwait(Result.DefaultConfigureAwait);
 #else
-            var results = await Task.WhenAll(tasks).ConfigureAwait(false);
+            var results = await Task.WhenAll(tasks).ConfigureAwait(Result.DefaultConfigureAwait);
 #endif
 
             return results.Combine(errorMessageSeparator);
@@ -346,9 +346,9 @@ namespace CSharpFunctionalExtensions
             string errorMessageSeparator)
         {
 #if NET40
-            IEnumerable<Result<T>> results = await TaskEx.WhenAll(tasks).ConfigureAwait(false);
+            IEnumerable<Result<T>> results = await TaskEx.WhenAll(tasks).ConfigureAwait(Result.DefaultConfigureAwait);
 #else
-            IEnumerable<Result<T>> results = await Task.WhenAll(tasks).ConfigureAwait(false);
+            IEnumerable<Result<T>> results = await Task.WhenAll(tasks).ConfigureAwait(Result.DefaultConfigureAwait);
 #endif
 
             return results.Combine(composer, errorMessageSeparator);
@@ -358,35 +358,35 @@ namespace CSharpFunctionalExtensions
             Func<IEnumerable<T>, TNew> composer,
             string errorMessageSeparator)
         {
-            IEnumerable<Task<Result<T>>> tasks = await task.ConfigureAwait(false);
+            IEnumerable<Task<Result<T>>> tasks = await task.ConfigureAwait(Result.DefaultConfigureAwait);
             return await tasks.Combine(composer, errorMessageSeparator);
         }
 
         public static async Task<Result> OnSuccessTry(this Task<Result> task, Action action,
             Func<Exception, string> errorHandler = null)
         {
-            var result = await task.ConfigureAwait(false);
+            var result = await task.ConfigureAwait(Result.DefaultConfigureAwait);
             return result.OnSuccessTry(action, errorHandler);
         }
 
         public static async Task<Result<T>> OnSuccessTry<T>(this Task<Result> task, Func<T> func,
             Func<Exception, string> errorHandler = null)
         {
-            var result = await task.ConfigureAwait(false);
+            var result = await task.ConfigureAwait(Result.DefaultConfigureAwait);
             return result.OnSuccessTry(func, errorHandler);
         }
 
         public static async Task<Result> OnSuccessTry<T>(this Task<Result<T>> task, Action<T> action,
             Func<Exception, string> errorHandler = null)
         {
-            var result = await task.ConfigureAwait(false);
+            var result = await task.ConfigureAwait(Result.DefaultConfigureAwait);
             return result.OnSuccessTry(action, errorHandler);
         }
 
         public static async Task<Result<R>> OnSuccessTry<T, R>(this Task<Result<T>> task, Func<T, R> action,
             Func<Exception, string> errorHandler = null)
         {
-            var result = await task.ConfigureAwait(false);
+            var result = await task.ConfigureAwait(Result.DefaultConfigureAwait);
             return result.OnSuccessTry(action, errorHandler);
         }
     }

--- a/CSharpFunctionalExtensions/Result.cs
+++ b/CSharpFunctionalExtensions/Result.cs
@@ -102,6 +102,7 @@ namespace CSharpFunctionalExtensions
         private static readonly Result OkResult = new Result(false, null);
 
         public static string ErrorMessagesSeparator = ", ";
+        public static bool DefaultConfigureAwait = false;
 
         void ISerializable.GetObjectData(SerializationInfo oInfo, StreamingContext oContext)
         {
@@ -148,7 +149,7 @@ namespace CSharpFunctionalExtensions
 
         public static async Task<Result> Create(Func<Task<bool>> predicate, string error)
         {
-            bool isSuccess = await predicate().ConfigureAwait(false);
+            bool isSuccess = await predicate().ConfigureAwait(Result.DefaultConfigureAwait);
             return Create(isSuccess, error);
         }
 
@@ -178,7 +179,7 @@ namespace CSharpFunctionalExtensions
         
         public static async Task<Result<T>> Create<T>(Func<Task<bool>> predicate, T value, string error)
         {
-            bool isSuccess = await predicate().ConfigureAwait(false);
+            bool isSuccess = await predicate().ConfigureAwait(Result.DefaultConfigureAwait);
             return Create(isSuccess, value, error);
         }
 
@@ -211,7 +212,7 @@ namespace CSharpFunctionalExtensions
         
         public static async Task<Result<TValue, TError>> Create<TValue, TError>(Func<Task<bool>> predicate, TValue value, TError error) where TError : class
         {
-            bool isSuccess = await predicate().ConfigureAwait(false);
+            bool isSuccess = await predicate().ConfigureAwait(Result.DefaultConfigureAwait);
             return isSuccess
                 ? Ok<TValue, TError>(value)
                 : Fail<TValue, TError>(error);
@@ -312,7 +313,7 @@ namespace CSharpFunctionalExtensions
             
             try
             {
-                var result = await func().ConfigureAwait(false);
+                var result = await func().ConfigureAwait(Result.DefaultConfigureAwait);
                 
                 return Ok(result);
             }
@@ -344,7 +345,7 @@ namespace CSharpFunctionalExtensions
         {
             try
             {
-                var result = await func().ConfigureAwait(false);
+                var result = await func().ConfigureAwait(Result.DefaultConfigureAwait);
                 
                 return Ok<TValue, TError>(result);
             }


### PR DESCRIPTION
**_Please see my [comment](https://github.com/vkhorikov/CSharpFunctionalExtensions/pull/103#issuecomment-465034796) on PR #103_** 

This PR implements DefaultConfigureAwait configurable property per #104 and also a minor tidying up of Map() pass through to OnSuccess() #105