### PR TITLE
Remove generic constraints requiring errors to be reference types.

### DIFF
--- a/CSharpFunctionalExtensions.Tests/MaybeTests/ExtensionsTests.cs
+++ b/CSharpFunctionalExtensions.Tests/MaybeTests/ExtensionsTests.cs
@@ -1,4 +1,5 @@
-﻿using FluentAssertions;
+﻿using System;
+using FluentAssertions;
 using Xunit;
 
 
@@ -89,6 +90,18 @@ namespace CSharpFunctionalExtensions.Tests.MaybeTests
 
             var errorInstance = new MyErrorClass();
             Result<MyClass, MyErrorClass> result = maybe.ToResult(errorInstance);
+
+            result.IsSuccess.Should().BeFalse();
+            result.Error.Should().Be(errorInstance);
+        }
+
+        [Fact]
+        public void ToResult_with_struct_error_type_returns_custom_failure_if_no_value_with_default_error()
+        {
+            Maybe<MyClass> maybe = null;
+
+            int errorInstance = 0;
+            Result<MyClass, int> result = maybe.ToResult(errorInstance);
 
             result.IsSuccess.Should().BeFalse();
             result.Error.Should().Be(errorInstance);

--- a/CSharpFunctionalExtensions.Tests/ResultTests/ResultTests.cs
+++ b/CSharpFunctionalExtensions.Tests/ResultTests/ResultTests.cs
@@ -8,6 +8,64 @@ namespace CSharpFunctionalExtensions.Tests.ResultTests
     public class ResultTests
     {
         [Fact]
+        public void Ok_argument_is_null_Success_result_expected()
+        {
+            Result result = Result.Ok<string>(null);
+
+            result.IsSuccess.Should().BeTrue();
+        }
+
+        [Fact]
+        public void Fail_argument_is_default_Fail_result_expected()
+        {
+            Result result = Result.Fail<string, int>(0);
+
+            result.IsFailure.Should().BeTrue();
+        }
+
+        [Fact]
+        public void Fail_argument_is_not_default_Fail_result_expected()
+        {
+            Result result = Result.Fail<string, int>(1);
+
+            result.IsFailure.Should().BeTrue();
+        }
+
+        [Fact]
+        public void Fail_argument_is_null_Exception_expected()
+        {
+            var exception = Record.Exception(() =>
+                Result.Fail<string, string>(null));
+            Assert.IsType<ArgumentNullException>(exception);
+        }
+
+        [Fact]
+        public void Create_value_is_null_Success_result_expected()
+        {
+            Result result = Result.Create<string>(true, null, null);
+
+            result.IsSuccess.Should().BeTrue();
+        }
+
+        [Fact]
+        public void Create_error_is_null_Exception_expected()
+        {
+            var exception = Record.Exception(() =>
+                Result.Create<string, string>(false, null, null));
+
+            Assert.IsType<ArgumentNullException>(exception);
+        }
+
+        [Fact]
+        public void Create_error_is_default_Failure_result_expected()
+        {
+            Result<bool, int> result = Result.Create<bool, int>(false, false, 0);
+
+            result.IsFailure.Should().BeTrue();
+            result.Error.Should().Be(0);
+        }
+
+        [Fact]
         public void Create_argument_is_true_Success_result_expected()
         {
             Result result = Result.Create(true, string.Empty);

--- a/CSharpFunctionalExtensions/AsyncMaybeExtensions.cs
+++ b/CSharpFunctionalExtensions/AsyncMaybeExtensions.cs
@@ -11,7 +11,7 @@ namespace CSharpFunctionalExtensions
             return maybe.ToResult(errorMessage);
         }
 
-        public static async Task<Result<T, E>> ToResult<T, E>(this Task<Maybe<T>> maybeTask, E error) where T : class where E : class
+        public static async Task<Result<T, E>> ToResult<T, E>(this Task<Maybe<T>> maybeTask, E error) where T : class
         {
             Maybe<T> maybe = await maybeTask.ConfigureAwait(Result.DefaultConfigureAwait);
             return maybe.ToResult(error);

--- a/CSharpFunctionalExtensions/AsyncResultExtensionsBothOperands.cs
+++ b/CSharpFunctionalExtensions/AsyncResultExtensionsBothOperands.cs
@@ -9,7 +9,7 @@ namespace CSharpFunctionalExtensions
     public static class AsyncResultExtensionsBothOperands
     {
         public static async Task<Result<K, E>> OnSuccess<T, K, E>(this Task<Result<T, E>> resultTask,
-            Func<T, Task<K>> func) where E : class
+            Func<T, Task<K>> func)
         {
             Result<T, E> result = await resultTask.ConfigureAwait(Result.DefaultConfigureAwait);
 
@@ -46,7 +46,7 @@ namespace CSharpFunctionalExtensions
         }
 
         public static async Task<Result<K, E>> OnSuccess<T, K, E>(this Task<Result<T, E>> resultTask,
-            Func<T, Task<Result<K, E>>> func) where E : class
+            Func<T, Task<Result<K, E>>> func)
         {
             Result<T, E> result = await resultTask.ConfigureAwait(Result.DefaultConfigureAwait);
 
@@ -77,7 +77,7 @@ namespace CSharpFunctionalExtensions
         }
 
         public static async Task<Result<K, E>> OnSuccess<T, K, E>(this Task<Result<T, E>> resultTask,
-            Func<Task<Result<K, E>>> func) where E : class
+            Func<Task<Result<K, E>>> func)
         {
             Result<T, E> result = await resultTask.ConfigureAwait(Result.DefaultConfigureAwait);
 
@@ -131,7 +131,7 @@ namespace CSharpFunctionalExtensions
         }
 
         public static async Task<Result<T, E>> Ensure<T, E>(this Task<Result<T, E>> resultTask,
-            Func<T, Task<bool>> predicate, E error) where E : class
+            Func<T, Task<bool>> predicate, E error)
         {
             Result<T, E> result = await resultTask.ConfigureAwait(Result.DefaultConfigureAwait);
 
@@ -158,7 +158,7 @@ namespace CSharpFunctionalExtensions
         }
 
         public static Task<Result<K, E>> Map<T, K, E>(this Task<Result<T, E>> resultTask,
-            Func<T, Task<K>> func) where E : class
+            Func<T, Task<K>> func)
             => resultTask.OnSuccess(func);
 
         public static Task<Result<K>> Map<T, K>(this Task<Result<T>> resultTask, Func<T, Task<K>> func)

--- a/CSharpFunctionalExtensions/AsyncResultExtensionsLeftOperand.cs
+++ b/CSharpFunctionalExtensions/AsyncResultExtensionsLeftOperand.cs
@@ -9,7 +9,7 @@ namespace CSharpFunctionalExtensions
     public static class AsyncResultExtensionsLeftOperand
     {
         public static async Task<Result<K, E>> OnSuccess<T, K, E>(this Task<Result<T, E>> resultTask,
-            Func<T, K> func) where E : class
+            Func<T, K> func)
         {
             Result<T, E> result = await resultTask.ConfigureAwait(Result.DefaultConfigureAwait);
             return result.OnSuccess(func);
@@ -28,7 +28,7 @@ namespace CSharpFunctionalExtensions
         }
 
         public static async Task<Result<K, E>> OnSuccess<T, K, E>(this Task<Result<T, E>> resultTask,
-            Func<T, Result<K, E>> func) where E : class
+            Func<T, Result<K, E>> func)
         {
             Result<T, E> result = await resultTask.ConfigureAwait(Result.DefaultConfigureAwait);
             return result.OnSuccess(func);
@@ -53,7 +53,7 @@ namespace CSharpFunctionalExtensions
         }
 
         public static async Task<Result<K, E>> OnSuccess<T, K, E>(this Task<Result<T, E>> resultTask,
-            Func<Result<K, E>> func) where E : class
+            Func<Result<K, E>> func)
         {
             Result<T, E> result = await resultTask.ConfigureAwait(Result.DefaultConfigureAwait);
             return result.OnSuccess(func);
@@ -78,7 +78,7 @@ namespace CSharpFunctionalExtensions
         }
 
         public static async Task<Result<T, E>> Ensure<T, E>(this Task<Result<T, E>> resultTask,
-            Func<T, bool> predicate, E error) where E : class
+            Func<T, bool> predicate, E error)
         {
             Result<T, E> result = await resultTask.ConfigureAwait(Result.DefaultConfigureAwait);
             return result.Ensure(predicate, error);
@@ -94,7 +94,7 @@ namespace CSharpFunctionalExtensions
             => resultTask.OnSuccess(func);
 
         public static Task<Result<K, E>> Map<T, K, E>(this Task<Result<T, E>> resultTask,
-            Func<T, K> func) where E : class
+            Func<T, K> func)
             => resultTask.OnSuccess(func);
 
         public static Task<Result<T>> Map<T>(this Task<Result> resultTask, Func<T> func)
@@ -150,7 +150,7 @@ namespace CSharpFunctionalExtensions
         }
 
         public static async Task<Result<T, E>> OnFailure<T, E>(this Task<Result<T, E>> resultTask,
-            Action<E> action) where E : class
+            Action<E> action)
         {
             Result<T, E> result = await resultTask.ConfigureAwait(Result.DefaultConfigureAwait);
             return result.OnFailure(action);
@@ -181,7 +181,7 @@ namespace CSharpFunctionalExtensions
         }
 
         public static async Task<Result<T, E>> OnFailureCompensate<T, E>(this Task<Result<T, E>> resultTask,
-            Func<E, Result<T, E>> func) where E : class
+            Func<E, Result<T, E>> func)
         {
             Result<T, E> result = await resultTask.ConfigureAwait(Result.DefaultConfigureAwait);
             return result.OnFailureCompensate(func);

--- a/CSharpFunctionalExtensions/AsyncResultExtensionsRightOperand.cs
+++ b/CSharpFunctionalExtensions/AsyncResultExtensionsRightOperand.cs
@@ -20,7 +20,7 @@ namespace CSharpFunctionalExtensions
         }
 
         public static async Task<Result<K, E>> OnSuccess<T, K, E>(this Result<T, E> result,
-            Func<T, Task<K>> func) where E : class
+            Func<T, Task<K>> func)
         {
             if (result.IsFailure)
                 return Result.Fail<K, E>(result.Error);
@@ -49,7 +49,7 @@ namespace CSharpFunctionalExtensions
         }
 
         public static async Task<Result<K, E>> OnSuccess<T, K, E>(this Result<T, E> result,
-            Func<T, Task<Result<K, E>>> func) where E : class
+            Func<T, Task<Result<K, E>>> func)
         {
             if (result.IsFailure)
                 return Result.Fail<K, E>(result.Error);
@@ -74,7 +74,7 @@ namespace CSharpFunctionalExtensions
         }
 
         public static async Task<Result<K, E>> OnSuccess<T, K, E>(this Result<T, E> result,
-            Func<Task<Result<K, E>>> func) where E : class
+            Func<Task<Result<K, E>>> func)
         {
             if (result.IsFailure)
                 return Result.Fail<K, E>(result.Error);
@@ -110,7 +110,7 @@ namespace CSharpFunctionalExtensions
         }
 
         public static async Task<Result<T, E>> Ensure<T, E>(this Result<T, E> result,
-            Func<T, Task<bool>> predicate, E error) where E : class
+            Func<T, Task<bool>> predicate, E error)
         {
             if (result.IsFailure)
                 return result;
@@ -136,7 +136,7 @@ namespace CSharpFunctionalExtensions
             => result.OnSuccess(func);
 
         public static Task<Result<K, E>> Map<T, K, E>(this Result<T, E> result,
-            Func<T, Task<K>> func) where E : class
+            Func<T, Task<K>> func)
             => result.OnSuccess(func);
 
         public static Task<Result<T>> Map<T>(this Result result, Func<Task<T>> func)

--- a/CSharpFunctionalExtensions/MaybeExtensions.cs
+++ b/CSharpFunctionalExtensions/MaybeExtensions.cs
@@ -12,7 +12,7 @@ namespace CSharpFunctionalExtensions
             return Result.Ok(maybe.Value);
         }
 
-        public static Result<T, E> ToResult<T, E>(this Maybe<T> maybe, E error) where E : class
+        public static Result<T, E> ToResult<T, E>(this Maybe<T> maybe, E error)
         {
             if (maybe.HasNoValue)
                 return Result.Fail<T, E>(error);

--- a/CSharpFunctionalExtensions/Result.cs
+++ b/CSharpFunctionalExtensions/Result.cs
@@ -193,33 +193,33 @@ namespace CSharpFunctionalExtensions
         }
 
         [DebuggerStepThrough]
-        public static Result<T, E> Ok<T, E>(T value) where E : class
+        public static Result<T, E> Ok<T, E>(T value)
         {
             return new Result<T, E>(false, value, default(E));
         }
 
         [DebuggerStepThrough]
-        public static Result<T, E> Fail<T, E>(E error) where E : class
+        public static Result<T, E> Fail<T, E>(E error)
         {
             return new Result<T, E>(true, default(T), error);
         }
 
         [DebuggerStepThrough]
-        public static Result<T, E> Create<T, E>(bool isSuccess, T value, E error) where E : class
+        public static Result<T, E> Create<T, E>(bool isSuccess, T value, E error)
         {
             return isSuccess
                 ? Ok<T, E>(value)
                 : Fail<T, E>(error);
         }
 
-        public static Result<T, E> Create<T, E>(Func<bool> predicate, T value, E error) where E : class
+        public static Result<T, E> Create<T, E>(Func<bool> predicate, T value, E error)
         {
             return predicate()
                 ? Ok<T, E>(value)
                 : Fail<T, E>(error);
         }
 
-        public static async Task<Result<T, E>> Create<T, E>(Func<Task<bool>> predicate, T value, E error) where E : class
+        public static async Task<Result<T, E>> Create<T, E>(Func<Task<bool>> predicate, T value, E error)
         {
             bool isSuccess = await predicate().ConfigureAwait(Result.DefaultConfigureAwait);
             return isSuccess
@@ -330,7 +330,6 @@ namespace CSharpFunctionalExtensions
         }
 
         public static Result<T, E> Try<T, E>(Func<T> func, Func<Exception, E> errorHandler)
-            where E : class
         {
             try
             {
@@ -344,7 +343,6 @@ namespace CSharpFunctionalExtensions
         }
 
         public static async Task<Result<T, E>> Try<T, E>(Func<Task<T>> func, Func<Exception, E> errorHandler)
-            where E : class
         {
             try
             {

--- a/CSharpFunctionalExtensions/ResultExtensions.cs
+++ b/CSharpFunctionalExtensions/ResultExtensions.cs
@@ -7,7 +7,7 @@ namespace CSharpFunctionalExtensions
     public static partial class ResultExtensions
     {
         public static Result<K, E> OnSuccess<T, K, E>(this Result<T, E> result,
-            Func<T, K> func) where E : class
+            Func<T, K> func)
         {
             if (result.IsFailure)
                 return Result.Fail<K, E>(result.Error);
@@ -32,7 +32,7 @@ namespace CSharpFunctionalExtensions
         }
 
         public static Result<K, E> OnSuccess<T, K, E>(this Result<T, E> result,
-            Func<T, Result<K, E>> func) where E : class
+            Func<T, Result<K, E>> func)
         {
             if (result.IsFailure)
                 return Result.Fail<K, E>(result.Error);
@@ -57,7 +57,7 @@ namespace CSharpFunctionalExtensions
         }
 
         public static Result<K, E> OnSuccess<T, K, E>(this Result<T, E> result,
-            Func<Result<K, E>> func) where E : class
+            Func<Result<K, E>> func)
         {
             if (result.IsFailure)
                 return Result.Fail<K, E>(result.Error);
@@ -74,7 +74,7 @@ namespace CSharpFunctionalExtensions
         }
 
         public static Result<K> OnSuccess<T, K, E>(this Result<T, E> result,
-            Func<T, Result<K>> func) where E : class
+            Func<T, Result<K>> func)
         {
             if (result.IsFailure)
                 return Result.Fail<K, E>(result.Error);
@@ -83,7 +83,7 @@ namespace CSharpFunctionalExtensions
         }
 
         public static Result OnSuccess<T, K, E>(this Result<T, E> result,
-            Func<T, Result> func) where E : class
+            Func<T, Result> func)
         {
             if (result.IsFailure)
                 return Result.Fail<K, E>(result.Error);
@@ -108,7 +108,7 @@ namespace CSharpFunctionalExtensions
         }
 
         public static Result<T, E> Ensure<T, E>(this Result<T, E> result,
-            Func<T, bool> predicate, E error) where E : class
+            Func<T, bool> predicate, E error)
         {
             if (result.IsFailure)
                 return result;
@@ -142,7 +142,7 @@ namespace CSharpFunctionalExtensions
         }
 
         public static Result<K, E> Map<T, K, E>(this Result<T, E> result,
-            Func<T, K> func) where E : class
+            Func<T, K> func)
             => result.OnSuccess(func);
 
         public static Result<K> Map<T, K>(this Result<T> result, Func<T, K> func)
@@ -152,7 +152,7 @@ namespace CSharpFunctionalExtensions
             => result.OnSuccess(func);
 
         public static Result<T, E> OnSuccess<T, E>(this Result<T, E> result,
-            Action<T> action) where E : class
+            Action<T> action)
         {
             if (result.IsSuccess)
             {
@@ -226,13 +226,13 @@ namespace CSharpFunctionalExtensions
         }
 
         public static T OnBoth<T, E>(this Result<T, E> result,
-            Func<Result<T, E>, T> func) where E : class
+            Func<Result<T, E>, T> func)
         {
             return func(result);
         }
 
         public static Result<T, E> OnFailure<T, E>(this Result<T, E> result,
-            Action action) where E : class
+            Action action)
         {
             if (result.IsFailure)
             {
@@ -263,7 +263,7 @@ namespace CSharpFunctionalExtensions
         }
 
         public static Result<T, E> OnFailure<T, E>(this Result<T, E> result,
-            Action<E> action) where E : class
+            Action<E> action)
         {
             if (result.IsFailure)
             {
@@ -294,7 +294,7 @@ namespace CSharpFunctionalExtensions
         }
 
         public static Result<T, E> OnFailureCompensate<T, E>(this Result<T, E> result,
-            Func<Result<T, E>> func) where E : class
+            Func<Result<T, E>> func)
         {
             if (result.IsFailure)
                 return func();
@@ -319,7 +319,7 @@ namespace CSharpFunctionalExtensions
         }
 
         public static Result<T, E> OnFailureCompensate<T, E>(this Result<T, E> result,
-            Func<E, Result<T, E>> func) where E : class
+            Func<E, Result<T, E>> func)
         {
             if (result.IsFailure)
                 return func(result.Error);


### PR DESCRIPTION
Null errors for results representing failures will still throw an
exception, but errors that are structs can use the default value
without causing an exception to be thrown.