### PR TITLE
Match extension method

### DIFF
--- a/CSharpFunctionalExtensions.Tests/MaybeTests/ExtensionsTests.cs
+++ b/CSharpFunctionalExtensions.Tests/MaybeTests/ExtensionsTests.cs
@@ -236,6 +236,27 @@ namespace CSharpFunctionalExtensions.Tests.MaybeTests
             integer.Should().Be(0);
         }
 
+        [Fact]
+        public void Match_follows_some_branch_where_there_is_a_value()
+        {
+            Maybe<MyClass> maybe = new MyClass { IntProperty = 42 };
+
+            maybe.Match(
+                Some: (value) => value.IntProperty.Should().Be(42),
+                None: () => throw new FieldAccessException("Accessed None path while maybe has value")
+            );
+        }
+
+        [Fact]
+        public void Match_follows_none_branch_where_is_no_value()
+        {
+            Maybe<MyClass> maybe = null;
+
+            maybe.Match(
+                Some: (value) => throw new FieldAccessException("Accessed Some path while maybe has no value"),
+                None: () => Assert.True(true)
+            );
+        }
 
         private static Maybe<string> GetPropertyIfExists(MyClass myClass)
         {

--- a/CSharpFunctionalExtensions.Tests/ResultTests/ExtensionTests.cs
+++ b/CSharpFunctionalExtensions.Tests/ResultTests/ExtensionTests.cs
@@ -239,6 +239,49 @@ namespace CSharpFunctionalExtensions.Tests.ResultTests
             result.Error.Should().Be("execute action exception");
         }
         
+
+        [Fact]
+        public void Match_for_Result_of_int_follows_Ok_branch_where_there_is_a_value()
+        {
+            var result = Result.Ok(20);
+
+            result.Match(
+                Ok: (value) => value.Should().Be(20),
+                Failure: (_) => throw new FieldAccessException("Accessed Failure path while result is Ok")
+            );
+        }
+
+        [Fact]
+        public void Match_for_Result_of_int_follows_Failure_branch_where_is_no_value()
+        {
+            var result = Result.Fail<int>("error");
+
+            result.Match(
+                Ok: (_) => throw new FieldAccessException("Accessed Ok path while result is Failure"),
+                Failure: (message) => message.Should().Be("error")
+            );
+        }
+        public void Match_for_empty_Result_follows_Ok_branch_where_there_is_a_value()
+        {
+            var result = Result.Ok();
+
+            result.Match(
+                Ok: () => Assert.True(true),
+                Failure: (_) => throw new FieldAccessException("Accessed Failure path while result is Ok")
+            );
+        }
+
+        [Fact]
+        public void Match_for_empty_Result_follows_Failure_branch_where_is_no_value()
+        {
+            var result = Result.Fail("error");
+
+            result.Match(
+                Ok: () => throw new FieldAccessException("Accessed Ok path while result is Failure"),
+                Failure: (message) => message.Should().Be("error")
+            );
+        }
+
         private class MyClass
         {
             public string Property { get; set; }

--- a/CSharpFunctionalExtensions/MaybeExtensions.cs
+++ b/CSharpFunctionalExtensions/MaybeExtensions.cs
@@ -76,5 +76,24 @@ namespace CSharpFunctionalExtensions
 
             action(maybe.Value);
         }
+
+        public static TE Match<TE, T>(this Maybe<T> maybe, Func<T, TE> Some, Func<TE> None)
+        {
+            return maybe.HasValue
+                ? Some(maybe.Value)
+                : None();
+        }
+
+        public static void Match<T>(this Maybe<T> maybe, Action<T> Some, Action None)
+        {
+            if (maybe.HasValue)
+            {
+                Some(maybe.Value);
+            }
+            else
+            {
+                None();
+            }
+        }
     }
 }

--- a/CSharpFunctionalExtensions/ResultExtensions.cs
+++ b/CSharpFunctionalExtensions/ResultExtensions.cs
@@ -374,5 +374,43 @@ namespace CSharpFunctionalExtensions
                 ? Result.Ok(composer(result.Value))
                 : Result.Fail<K>(result.Error);
         }
+
+        public static TE Match<TE, T>(this Result<T> result, Func<T, TE> Ok, Func<string, TE> Failure)
+        {
+            return result.IsSuccess
+                ? Ok(result.Value)
+                : Failure(result.Error);
+        }
+
+        public static void Match<T>(this Result<T> result, Action<T> Ok, Action<string> Failure)
+        {
+            if (result.IsSuccess)
+            {
+                Ok(result.Value);
+            }
+            else
+            {
+                Failure(result.Error);
+            }
+        }
+
+        public static TE Match<TE>(this Result result, Func<TE> Ok, Func<string, TE> Failure)
+        {
+            return result.IsSuccess
+                ? Ok()
+                : Failure(result.Error);
+        }
+        
+        public static void Match(this Result result, Action Ok, Action<string> Failure)
+        {
+            if (result.IsSuccess)
+            {
+                Ok();
+            }
+            else
+            {
+                Failure(result.Error);
+            }
+        }
     }
 }


### PR DESCRIPTION
This PR introduces possibility to use values kept in either `Maybe` or `Result` in a safe and functional way. It forces handling all possible paths by bringing `match`-like behavior from F#.

References: [1](https://blog.ploeh.dk/2018/06/04/church-encoded-maybe/), [2](https://blog.ploeh.dk/2018/06/11/church-encoded-either/)

Btw. @vkhorikov I love your videos, blog and this package, so thank you for all great work!