### PR TITLE
Add more overloads for Result Match extension methods

### DIFF
--- a/CSharpFunctionalExtensions.Tests/ResultTests/ExtensionTests.cs
+++ b/CSharpFunctionalExtensions.Tests/ResultTests/ExtensionTests.cs
@@ -282,6 +282,60 @@ namespace CSharpFunctionalExtensions.Tests.ResultTests
             );
         }
 
+        [Fact]
+        public void Match_for_Result_with_non_string_error_follows_Failure_branch_where_is_no_value()
+        {
+            var error = new CustomError {
+                Message = "Error"
+            };
+            var result = Result.Fail<int, CustomError>(error);
+
+            result.Match(
+                Ok: (_) => throw new FieldAccessException("Accessed Ok path while result is Failure"),
+                Failure: (err) => error.Message.Should().Be("Error")
+            );
+        }
+
+        [Fact]
+        public void Match_for_Result_with_non_string_error_returns_value_from_Failure_path()
+        {
+            var error = new CustomError
+            {
+                Message = "Error",
+                Value = 100
+            };
+            var result = Result.Fail<int, CustomError>(error);
+
+            var val = result.Match(
+                Ok: (value) => value,
+                Failure: (err) => err.Value
+            );
+
+            val.Should().Be(100);
+        }
+
+        public void Match_for_Result_with_non_string_error_returns_value_from_Ok_path()
+        {
+            var error = new CustomError
+            {
+                Message = "Error",
+                Value = 100
+            };
+            var result = Result.Ok<int, CustomError>(20);
+
+            var val = result.Match(
+                Ok: (value) => value,
+                Failure: (err) => err.Value
+            );
+
+            val.Should().Be(20);
+        }
+
+        private class CustomError {
+            public string Message { get; set; }
+            public int Value { get; set; }
+        }
+        
         private class MyClass
         {
             public string Property { get; set; }

--- a/CSharpFunctionalExtensions/ResultExtensions.cs
+++ b/CSharpFunctionalExtensions/ResultExtensions.cs
@@ -396,7 +396,14 @@ namespace CSharpFunctionalExtensions
                 : Result.Fail<K>(result.Error);
         }
 
-        public static TE Match<TE, T>(this Result<T> result, Func<T, TE> Ok, Func<string, TE> Failure)
+        public static TOutput Match<TOutput, TError, TValue>(this Result<TValue, TError> result, Func<TValue, TOutput> Ok, Func<TError, TOutput> Failure)
+        {
+            return result.IsSuccess
+                ? Ok(result.Value)
+                : Failure(result.Error);
+        }
+
+        public static TOutput Match<TOutput, TValue>(this Result<TValue> result, Func<TValue, TOutput> Ok, Func<string, TOutput> Failure)
         {
             return result.IsSuccess
                 ? Ok(result.Value)
@@ -415,7 +422,19 @@ namespace CSharpFunctionalExtensions
             }
         }
 
-        public static TE Match<TE>(this Result result, Func<TE> Ok, Func<string, TE> Failure)
+        public static void Match<TError, TValue>(this Result<TValue, TError> result, Action<TValue> Ok, Action<TError> Failure)
+        {
+            if (result.IsSuccess)
+            {
+                Ok(result.Value);
+            }
+            else
+            {
+                Failure(result.Error);
+            }
+        }
+
+        public static T Match<T>(this Result result, Func<T> Ok, Func<string, T> Failure)
         {
             return result.IsSuccess
                 ? Ok()


### PR DESCRIPTION
I noticed that some overloads are missing - when `Failure` path's type is non-string (custom) so I added those with meaningful names for generic type parameters.