### PR TITLE
Add missing Result.Try for async action

### DIFF
--- a/CSharpFunctionalExtensions.Tests/ResultTests/ResultTests.cs
+++ b/CSharpFunctionalExtensions.Tests/ResultTests/ResultTests.cs
@@ -556,6 +556,39 @@ namespace CSharpFunctionalExtensions.Tests.ResultTests
             result.IsFailure.Should().BeTrue();
             result.Error.Should().Be("execute error");
         }
+        
+        [Fact]
+        public async Task Try_execute_async_action_success_without_error_handler_function_result_expected()
+        {
+            Func<Task> action = () => Task.CompletedTask;
+            
+            var result = await Result.Try(action);
+
+            result.IsSuccess.Should().BeTrue();
+        }
+        
+        [Fact]
+        public async Task Try_execute_async_action_failed_without_error_handler_failed_result_expected()
+        {
+            Func<Task> action = () => Task.FromException(new Exception("func error"));
+            
+            var result = await Result.Try(action);
+
+            result.IsFailure.Should().BeTrue();
+            result.Error.Should().Be("func error");
+        }
+        
+        [Fact]
+        public async Task Try_execute_async_action_failed_with_error_handler_failed_result_expected()
+        {
+            Func<Task> action = () => Task.FromException(new Exception("func error"));
+            Func<Exception, string> handler = exc => "execute error";
+            
+            var result = await Result.Try(action, handler);
+
+            result.IsFailure.Should().BeTrue();
+            result.Error.Should().Be("execute error");
+        }
 
         [Fact]
         public void Try_with_error_execute_function_success_without_error_success_result_expected()

--- a/CSharpFunctionalExtensions/Result/Methods/Try.cs
+++ b/CSharpFunctionalExtensions/Result/Methods/Try.cs
@@ -23,6 +23,22 @@ namespace CSharpFunctionalExtensions
             }
         }
 
+        public static async Task<Result> Try(Func<Task> action, Func<Exception, string> errorHandler = null)
+        {
+            errorHandler = errorHandler ?? DefaultTryErrorHandler;
+
+            try
+            {
+                await action().ConfigureAwait(DefaultConfigureAwait);
+                return Success();
+            }
+            catch (Exception exc)
+            {
+                string message = errorHandler(exc);
+                return Failure(message);
+            }
+        }
+
         public static Result<T> Try<T>(Func<T> func, Func<Exception, string> errorHandler = null)
         {
             errorHandler = errorHandler ?? DefaultTryErrorHandler;


### PR DESCRIPTION
We are missing this `Result.Try` overload in our use of Result

The reason is that if we don't have this overload, the overload resolution fallbacks to the  `... Result<T> Try<T>(Func<T> func, ...` overload and this results in a `Result<Task>` return type.