### PR TITLE
Implicit Maybe bool conversion

### DIFF
--- a/CSharpFunctionalExtensions.Tests/MaybeTests/BasicTests.cs
+++ b/CSharpFunctionalExtensions.Tests/MaybeTests/BasicTests.cs
@@ -13,6 +13,7 @@ namespace CSharpFunctionalExtensions.Tests.MaybeTests
 
             maybe.HasValue.Should().BeFalse();
             maybe.HasNoValue.Should().BeTrue();
+            ((bool) maybe).Should().BeFalse();
         }
 
         [Fact]
@@ -22,6 +23,7 @@ namespace CSharpFunctionalExtensions.Tests.MaybeTests
 
             maybe.HasValue.Should().BeFalse();
             maybe.HasNoValue.Should().BeTrue();
+            ((bool) maybe).Should().BeFalse();
         }
 
         [Fact]
@@ -55,6 +57,7 @@ namespace CSharpFunctionalExtensions.Tests.MaybeTests
 
             maybe.HasValue.Should().BeTrue();
             maybe.HasNoValue.Should().BeFalse();
+            ((bool) maybe).Should().BeTrue();
             maybe.Value.Should().Be(instance);
         }
 

--- a/CSharpFunctionalExtensions/Maybe/Maybe.cs
+++ b/CSharpFunctionalExtensions/Maybe/Maybe.cs
@@ -37,6 +37,8 @@ namespace CSharpFunctionalExtensions
             return new Maybe<T>(value);
         }
 
+        public static implicit operator bool(Maybe<T> value) => value.HasValue;
+
         public static Maybe<T> From(T obj)
         {
             return new Maybe<T>(obj);


### PR DESCRIPTION
Allows for `Maybe`s to be converted to `bool`s implicitly.
_Should_ include all tests required.