### PR TITLE
Added F# analogue TryFind for Map (Dictionary)

### DIFF
--- a/CSharpFunctionalExtensions.Tests/MaybeTests/ExtensionsTests.cs
+++ b/CSharpFunctionalExtensions.Tests/MaybeTests/ExtensionsTests.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using FluentAssertions;
 using Xunit;
 
@@ -386,6 +387,30 @@ namespace CSharpFunctionalExtensions.Tests.MaybeTests
             };
 
             var maybe = source.TryLast(x => x.Value == 5);
+
+            maybe.HasValue.Should().BeFalse();
+        }
+
+        [Fact]
+        public void TryFind_dict_contains_key() 
+        {
+            var dict = new Dictionary<string, string> 
+            { 
+                { "key", "value" } 
+            };
+
+            var maybe = dict.TryFind("key");
+
+            maybe.HasValue.Should().BeTrue();
+            maybe.Value.Should().Be("value");
+        }
+
+        [Fact]
+        public void TryFind_dict_does_not_contains_key() 
+        {
+            var dict = new Dictionary<string, string>();
+
+            var maybe = dict.TryFind("key");
 
             maybe.HasValue.Should().BeFalse();
         }

--- a/CSharpFunctionalExtensions/Maybe/MaybeExtensions.cs
+++ b/CSharpFunctionalExtensions/Maybe/MaybeExtensions.cs
@@ -166,5 +166,14 @@ namespace CSharpFunctionalExtensions
             }
             return Maybe<T>.None;
         }
+
+        public static Maybe<V> TryFind<K, V>(this IReadOnlyDictionary<K, V> dict, K key) 
+        {
+            if (dict.ContainsKey(key)) 
+            {
+                return dict[key];
+            }
+            return Maybe<V>.None;   
+        }
     }
 }

--- a/CSharpFunctionalExtensions/Maybe/MaybeExtensions.cs
+++ b/CSharpFunctionalExtensions/Maybe/MaybeExtensions.cs
@@ -167,7 +167,7 @@ namespace CSharpFunctionalExtensions
             return Maybe<T>.None;
         }
 
-        public static Maybe<V> TryFind<K, V>(this IReadOnlyDictionary<K, V> dict, K key) 
+        public static Maybe<V> TryFind<K, V>(this IDictionary<K, V> dict, K key) 
         {
             if (dict.ContainsKey(key)) 
             {

--- a/CSharpFunctionalExtensions/Maybe/MaybeExtensions.cs
+++ b/CSharpFunctionalExtensions/Maybe/MaybeExtensions.cs
@@ -167,6 +167,7 @@ namespace CSharpFunctionalExtensions
             return Maybe<T>.None;
         }
 
+#if NET40
         public static Maybe<V> TryFind<K, V>(this IDictionary<K, V> dict, K key) 
         {
             if (dict.ContainsKey(key)) 
@@ -175,5 +176,15 @@ namespace CSharpFunctionalExtensions
             }
             return Maybe<V>.None;   
         }
+#else
+        public static Maybe<V> TryFind<K, V>(this IReadOnlyDictionary<K, V> dict, K key) 
+        {
+            if (dict.ContainsKey(key)) 
+            {
+                return dict[key];
+            }
+            return Maybe<V>.None;   
+        }
+#endif
     }
 }


### PR DESCRIPTION
Added `Maybe.TryFind` extension for working with dictionary (`IReadOnlyDictionary`)

```csharp
var dict = new Dictionary<string, string> { { "key", "value" } };
var maybeWithValue = dict.TryFind("key");
var maybeWithNone = dict.TryFind("anotherKey");
```

note:
Net framework 4.0 does not support `IReadOnlyDictionary`