### PR TITLE
Quality improvements

### DIFF
--- a/CSharpFunctionalExtensions.Examples/ResultExtensions/ExampleWithOnFailureMethod.cs
+++ b/CSharpFunctionalExtensions.Examples/ResultExtensions/ExampleWithOnFailureMethod.cs
@@ -28,7 +28,7 @@ namespace CSharpFunctionalExtensions.Examples.ResultExtensions
         {
             public void AddBalance(decimal moneyAmount)
             {
-                
+
             }
         }
 
@@ -41,7 +41,7 @@ namespace CSharpFunctionalExtensions.Examples.ResultExtensions
 
             public void RollbackLastTransaction()
             {
-                
+
             }
 
             public Task RollbackLastTransactionAsync()

--- a/CSharpFunctionalExtensions.Tests/CSharpFunctionalExtensions.Tests.csproj
+++ b/CSharpFunctionalExtensions.Tests/CSharpFunctionalExtensions.Tests.csproj
@@ -6,10 +6,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="4.19.4" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
-    <PackageReference Include="xunit" Version="2.3.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
+    <PackageReference Include="FluentAssertions" Version="5.10.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/CSharpFunctionalExtensions.Tests/MaybeTests/BasicTests.cs
+++ b/CSharpFunctionalExtensions.Tests/MaybeTests/BasicTests.cs
@@ -1,5 +1,5 @@
-﻿using System;
-using FluentAssertions;
+﻿using FluentAssertions;
+using System;
 using Xunit;
 
 namespace CSharpFunctionalExtensions.Tests.MaybeTests

--- a/CSharpFunctionalExtensions.Tests/MaybeTests/BasicTests.cs
+++ b/CSharpFunctionalExtensions.Tests/MaybeTests/BasicTests.cs
@@ -43,7 +43,7 @@ namespace CSharpFunctionalExtensions.Tests.MaybeTests
                 MyClass myClass = maybe.Value;
             };
 
-            action.ShouldThrow<InvalidOperationException>();
+            action.Should().Throw<InvalidOperationException>();
         }
 
         [Fact]

--- a/CSharpFunctionalExtensions.Tests/MaybeTests/BugTests.cs
+++ b/CSharpFunctionalExtensions.Tests/MaybeTests/BugTests.cs
@@ -1,8 +1,6 @@
-﻿using System;
+﻿using FluentAssertions;
+using System;
 using System.Collections.Generic;
-
-using FluentAssertions;
-
 using Xunit;
 
 

--- a/CSharpFunctionalExtensions.Tests/MaybeTests/DeserializationTests.cs
+++ b/CSharpFunctionalExtensions.Tests/MaybeTests/DeserializationTests.cs
@@ -1,8 +1,8 @@
-﻿using System;
+﻿using FluentAssertions;
+using System;
 using System.IO;
 using System.Runtime.Serialization;
 using System.Runtime.Serialization.Formatters.Binary;
-using FluentAssertions;
 using Xunit;
 
 namespace CSharpFunctionalExtensions.Tests.MaybeTests

--- a/CSharpFunctionalExtensions.Tests/MaybeTests/DeserializationTests.cs
+++ b/CSharpFunctionalExtensions.Tests/MaybeTests/DeserializationTests.cs
@@ -33,7 +33,7 @@ namespace CSharpFunctionalExtensions.Tests.MaybeTests
 
             deserialized.HasValue.Should().BeTrue();
             deserialized.HasNoValue.Should().BeFalse();
-            deserialized.Value.ShouldBeEquivalentTo(instance);
+            deserialized.Value.Should().BeEquivalentTo(instance);
         }
 
         private static Stream Serialize(object source)

--- a/CSharpFunctionalExtensions.Tests/MaybeTests/ExtensionsTests.cs
+++ b/CSharpFunctionalExtensions.Tests/MaybeTests/ExtensionsTests.cs
@@ -1,6 +1,6 @@
-﻿using System;
+﻿using FluentAssertions;
+using System;
 using System.Collections.Generic;
-using FluentAssertions;
 using Xunit;
 
 

--- a/CSharpFunctionalExtensions.Tests/MaybeTests/ExtensionsTests.cs
+++ b/CSharpFunctionalExtensions.Tests/MaybeTests/ExtensionsTests.cs
@@ -165,27 +165,27 @@ namespace CSharpFunctionalExtensions.Tests.MaybeTests
         [Fact]
         public void SelectMany_returns_no_value_if_maybe_has_no_value()
         {
-	        Maybe<int> maybe1 = 1;
-	        var maybe2 = Maybe<int>.None;
+            Maybe<int> maybe1 = 1;
+            var maybe2 = Maybe<int>.None;
 
-	        var maybe3 = from a in maybe1 from b in maybe2 select a + b;
+            var maybe3 = from a in maybe1 from b in maybe2 select a + b;
 
-	        maybe3.HasValue.Should().BeFalse();
+            maybe3.HasValue.Should().BeFalse();
         }
 
         [Fact]
         public void SelectMany_returns_projection_if_maybes_has_values()
         {
-	        Maybe<int> maybe1 = 1;
-	        Maybe<int> maybe2 = 2;
+            Maybe<int> maybe1 = 1;
+            Maybe<int> maybe2 = 2;
 
-	        var maybe3 = from a in maybe1 from b in maybe2 select a + b;
+            var maybe3 = from a in maybe1 from b in maybe2 select a + b;
 
-	        maybe3.HasValue.Should().BeTrue();
-	        maybe3.Value.Should().Be(3);
+            maybe3.HasValue.Should().BeTrue();
+            maybe3.Value.Should().Be(3);
         }
 
-		[Fact]
+        [Fact]
         public void Bind_returns_new_maybe()
         {
             Maybe<MyClass> maybe = new MyClass { Property = "Some value" };
@@ -262,18 +262,18 @@ namespace CSharpFunctionalExtensions.Tests.MaybeTests
         [Fact]
         public void Choose_double_values()
         {
-            var source = new [] 
-            { 
-                Maybe<int>.None, 
+            var source = new[]
+            {
+                Maybe<int>.None,
                 1,
-                Maybe<int>.None, 
-                2, 
-                3 
+                Maybe<int>.None,
+                2,
+                3
             };
 
             var doubled = source.Choose(x => x * 2);
 
-            var expected = new [] { 2, 4, 6 };
+            var expected = new[] { 2, 4, 6 };
             doubled.Should().BeEquivalentTo(expected);
         }
 
@@ -392,11 +392,11 @@ namespace CSharpFunctionalExtensions.Tests.MaybeTests
         }
 
         [Fact]
-        public void TryFind_dict_contains_key() 
+        public void TryFind_dict_contains_key()
         {
-            var dict = new Dictionary<string, string> 
-            { 
-                { "key", "value" } 
+            var dict = new Dictionary<string, string>
+            {
+                { "key", "value" }
             };
 
             var maybe = dict.TryFind("key");
@@ -406,7 +406,7 @@ namespace CSharpFunctionalExtensions.Tests.MaybeTests
         }
 
         [Fact]
-        public void TryFind_dict_does_not_contains_key() 
+        public void TryFind_dict_does_not_contains_key()
         {
             var dict = new Dictionary<string, string>();
 

--- a/CSharpFunctionalExtensions.Tests/ResultTests/CombineMethodTests.cs
+++ b/CSharpFunctionalExtensions.Tests/ResultTests/CombineMethodTests.cs
@@ -4,36 +4,10 @@ using System.Linq;
 using System.Threading.Tasks;
 using Xunit;
 
-
 namespace CSharpFunctionalExtensions.Tests.ResultTests
 {
     public class CombineMethodTests
     {
-        [Fact]
-        public void FirstFailureOrSuccess_returns_the_first_failed_result()
-        {
-            Result result1 = Result.Success();
-            Result result2 = Result.Failure("Failure 1");
-            Result result3 = Result.Failure("Failure 2");
-
-            Result result = Result.FirstFailureOrSuccess(result1, result2, result3);
-
-            result.IsFailure.Should().BeTrue();
-            result.Error.Should().Be("Failure 1");
-        }
-
-        [Fact]
-        public void FirstFailureOrSuccess_returns_Ok_if_no_failures()
-        {
-            Result result1 = Result.Success();
-            Result result2 = Result.Success();
-            Result result3 = Result.Success();
-
-            Result result = Result.FirstFailureOrSuccess(result1, result2, result3);
-
-            result.IsSuccess.Should().BeTrue();
-        }
-
         [Fact]
         public void Combine_combines_all_errors_together()
         {

--- a/CSharpFunctionalExtensions.Tests/ResultTests/ConvertFailureTests.cs
+++ b/CSharpFunctionalExtensions.Tests/ResultTests/ConvertFailureTests.cs
@@ -15,7 +15,7 @@ namespace CSharpFunctionalExtensions.Tests.ResultTests
 
             Action action = () => okResultWithoutValue.ConvertFailure<MyValueClass>();
 
-            action.ShouldThrow<InvalidOperationException>();
+            action.Should().Throw<InvalidOperationException>();
         }
 
         [Fact]
@@ -36,7 +36,7 @@ namespace CSharpFunctionalExtensions.Tests.ResultTests
 
             Action action = () => okResultWithValue.ConvertFailure();
 
-            action.ShouldThrow<InvalidOperationException>();
+            action.Should().Throw<InvalidOperationException>();
         }
 
         [Fact]
@@ -57,7 +57,7 @@ namespace CSharpFunctionalExtensions.Tests.ResultTests
 
             Action action = () => okResultWithValue.ConvertFailure<MyValueClass2>();
 
-            action.ShouldThrow<InvalidOperationException>();
+            action.Should().Throw<InvalidOperationException>();
         }
 
         [Fact]
@@ -82,7 +82,7 @@ namespace CSharpFunctionalExtensions.Tests.ResultTests
 
             Action action = () => okResultWithValue.ConvertFailure<MyValueClass2>();
 
-            action.ShouldThrow<InvalidOperationException>();
+            action.Should().Throw<InvalidOperationException>();
         }
 
         [Fact]
@@ -93,7 +93,7 @@ namespace CSharpFunctionalExtensions.Tests.ResultTests
             Result<MyValueClass2, MyErrorClass> failedResultWithoutValue = failedResultWithValue.ConvertFailure<MyValueClass2>();
 
             failedResultWithoutValue.IsFailure.Should().BeTrue();
-            failedResultWithoutValue.Error.ShouldBeEquivalentTo(new MyErrorClass
+            failedResultWithoutValue.Error.Should().BeEquivalentTo(new MyErrorClass
             {
                 Prop = "Failed"
             });

--- a/CSharpFunctionalExtensions.Tests/ResultTests/ConvertFailureTests.cs
+++ b/CSharpFunctionalExtensions.Tests/ResultTests/ConvertFailureTests.cs
@@ -1,5 +1,5 @@
-﻿using System;
-using FluentAssertions;
+﻿using FluentAssertions;
+using System;
 using Xunit;
 
 namespace CSharpFunctionalExtensions.Tests.ResultTests

--- a/CSharpFunctionalExtensions.Tests/ResultTests/DeconstructionTests.cs
+++ b/CSharpFunctionalExtensions.Tests/ResultTests/DeconstructionTests.cs
@@ -1,5 +1,5 @@
-﻿using System;
-using FluentAssertions;
+﻿using FluentAssertions;
+using System;
 using Xunit;
 
 namespace CSharpFunctionalExtensions.Tests.ResultTests

--- a/CSharpFunctionalExtensions.Tests/ResultTests/DeserializationTests.cs
+++ b/CSharpFunctionalExtensions.Tests/ResultTests/DeserializationTests.cs
@@ -55,7 +55,7 @@ namespace CSharpFunctionalExtensions.Tests.ResultTests
 
             Result<DeserializationTestObject> result = Deserialize<Result<DeserializationTestObject>>(serialized);
 
-            result.Value.ShouldBeEquivalentTo(language);
+            result.Value.Should().BeEquivalentTo(language);
         }
 
         [Fact]
@@ -67,7 +67,7 @@ namespace CSharpFunctionalExtensions.Tests.ResultTests
 
             Result<object, DeserializationTestObject> result = Deserialize<Result<object, DeserializationTestObject>>(serialized);
 
-            result.Error.ShouldBeEquivalentTo(errorObject);
+            result.Error.Should().BeEquivalentTo(errorObject);
         }
 
         private static Stream Serialize(object source)

--- a/CSharpFunctionalExtensions.Tests/ResultTests/DeserializationTests.cs
+++ b/CSharpFunctionalExtensions.Tests/ResultTests/DeserializationTests.cs
@@ -1,8 +1,8 @@
-﻿using System;
+﻿using FluentAssertions;
+using System;
 using System.IO;
 using System.Runtime.Serialization;
 using System.Runtime.Serialization.Formatters.Binary;
-using FluentAssertions;
 using Xunit;
 
 namespace CSharpFunctionalExtensions.Tests.ResultTests

--- a/CSharpFunctionalExtensions.Tests/ResultTests/EnsureMethodTests.cs
+++ b/CSharpFunctionalExtensions.Tests/ResultTests/EnsureMethodTests.cs
@@ -16,7 +16,7 @@ namespace CSharpFunctionalExtensions.Tests.ResultTests
 
             result.Should().Be(sut);
         }
-        
+
         [Fact]
         public void Ensure_source_result_is_success_predicate_is_failed_expected_result_failure()
         {
@@ -28,12 +28,12 @@ namespace CSharpFunctionalExtensions.Tests.ResultTests
             result.IsFailure.Should().BeTrue();
             result.Error.Should().Be("predicate failed");
         }
-        
+
         [Fact]
         public void Ensure_source_result_is_success_predicate_is_passed_expected_result_success()
         {
             Result sut = Result.Success();
-            
+
             Result result = sut.Ensure(() => true, string.Empty);
 
             result.Should().Be(sut);
@@ -48,7 +48,7 @@ namespace CSharpFunctionalExtensions.Tests.ResultTests
 
             result.Should().Be(sut);
         }
-        
+
         [Fact]
         public async Task Ensure_source_result_is_success_async_predicate_is_failed_expected_result_failure()
         {
@@ -60,7 +60,7 @@ namespace CSharpFunctionalExtensions.Tests.ResultTests
             result.IsFailure.Should().BeTrue();
             result.Error.Should().Be("predicate problems");
         }
-        
+
         [Fact]
         public async Task Ensure_source_result_is_success_async_predicate_is_passed_expected_result_success()
         {
@@ -70,17 +70,17 @@ namespace CSharpFunctionalExtensions.Tests.ResultTests
 
             result.Should().Be(sut);
         }
-        
+
         [Fact]
         public async Task Ensure_task_source_result_is_failure_predicate_do_not_invoked_expect_is_result_failure()
         {
-            Task<Result> sut = Task.FromResult(Result.Failure("some error"));            
+            Task<Result> sut = Task.FromResult(Result.Failure("some error"));
 
             Result result = await sut.Ensure(() => true, string.Empty);
 
             result.Should().Be(sut.Result);
         }
-        
+
         [Fact]
         public async Task Ensure_task_source_result_is_success_predicate_is_failed_expected_result_failure()
         {
@@ -92,7 +92,7 @@ namespace CSharpFunctionalExtensions.Tests.ResultTests
             result.IsFailure.Should().BeTrue();
             result.Error.Should().Be("predicate problems");
         }
-        
+
         [Fact]
         public async Task Ensure_task_source_result_is_success_predicate_is_passed_expected_result_success()
         {
@@ -102,17 +102,17 @@ namespace CSharpFunctionalExtensions.Tests.ResultTests
 
             result.Should().Be(sut.Result);
         }
-        
+
         [Fact]
         public async Task Ensure_task_source_result_is_failure_async_predicate_do_not_invoked_expect_is_result_failure()
         {
             Task<Result> sut = Task.FromResult(Result.Failure("some error"));
-            
+
             Result result = await sut.Ensure(() => Task.FromResult(false), string.Empty);
 
             result.Should().Be(sut.Result);
         }
-        
+
         [Fact]
         public async Task Ensure_task_source_result_is_success_async_predicate_is_failed_expected_result_failure()
         {
@@ -124,7 +124,7 @@ namespace CSharpFunctionalExtensions.Tests.ResultTests
             result.IsFailure.Should().BeTrue();
             result.Error.Should().Be("predicate problems");
         }
-        
+
         [Fact]
         public async Task Ensure_task_source_result_is_success_async_predicate_is_passed_expected_result_success()
         {
@@ -134,7 +134,7 @@ namespace CSharpFunctionalExtensions.Tests.ResultTests
 
             result.Should().Be(sut.Result);
         }
-        
+
         [Fact]
         public void Ensure_generic_source_result_is_failure_predicate_do_not_invoked_expect_is_error_result_failure()
         {
@@ -144,7 +144,7 @@ namespace CSharpFunctionalExtensions.Tests.ResultTests
 
             result.Should().Be(sut);
         }
-        
+
         [Fact]
         public void Ensure_generic_source_result_is_success_predicate_is_failed_expected_error_result_failure()
         {
@@ -156,7 +156,7 @@ namespace CSharpFunctionalExtensions.Tests.ResultTests
             result.IsFailure.Should().BeTrue();
             result.Error.Should().Be("test error");
         }
-        
+
         [Fact]
         public void Ensure_generic_source_result_is_success_predicate_is_passed_expected_error_result_success()
         {
@@ -166,7 +166,7 @@ namespace CSharpFunctionalExtensions.Tests.ResultTests
 
             result.Should().Be(sut);
         }
-        
+
         [Fact]
         public async Task Ensure_generic_source_result_is_failure_async_predicate_do_not_invoked_expect_is_error_result_failure()
         {
@@ -176,7 +176,7 @@ namespace CSharpFunctionalExtensions.Tests.ResultTests
 
             result.Should().Be(sut);
         }
-        
+
         [Fact]
         public async Task Ensure_generic_source_result_is_success_async_predicate_is_failed_expected_error_result_failure()
         {
@@ -188,7 +188,7 @@ namespace CSharpFunctionalExtensions.Tests.ResultTests
             result.IsFailure.Should().BeTrue();
             result.Error.Should().Be("test ensure error");
         }
-        
+
         [Fact]
         public async Task Ensure_generic_source_result_is_success_async_predicate_is_passed_expected_error_result_success()
         {
@@ -198,7 +198,7 @@ namespace CSharpFunctionalExtensions.Tests.ResultTests
 
             result.Should().Be(sut);
         }
-        
+
         [Fact]
         public async Task Ensure_generic_task_source_result_is_failure_async_predicate_do_not_invoked_expect_is_error_result_failure()
         {
@@ -208,7 +208,7 @@ namespace CSharpFunctionalExtensions.Tests.ResultTests
 
             result.Should().Be(sut.Result);
         }
-        
+
         [Fact]
         public async Task Ensure_generic_task_source_result_is_success_async_predicate_is_failed_expected_error_result_failure()
         {
@@ -220,7 +220,7 @@ namespace CSharpFunctionalExtensions.Tests.ResultTests
             result.IsFailure.Should().BeTrue();
             result.Error.Should().Be("test ensure error");
         }
-        
+
         [Fact]
         public async Task Ensure_generic_task_source_result_is_success_async_predicate_is_passed_expected_error_result_success()
         {
@@ -230,7 +230,7 @@ namespace CSharpFunctionalExtensions.Tests.ResultTests
 
             result.Should().Be(sut.Result);
         }
-        
+
         [Fact]
         public async Task Ensure_generic_task_source_result_is_failure_predicate_do_not_invoked_expect_is_error_result_failure()
         {
@@ -240,7 +240,7 @@ namespace CSharpFunctionalExtensions.Tests.ResultTests
 
             result.Should().Be(sut.Result);
         }
-        
+
         [Fact]
         public async Task Ensure_generic_task_source_result_is_success_predicate_is_failed_expected_error_result_failure()
         {
@@ -252,7 +252,7 @@ namespace CSharpFunctionalExtensions.Tests.ResultTests
             result.IsFailure.Should().BeTrue();
             result.Error.Should().Be("test ensure error");
         }
-        
+
         [Fact]
         public async Task Ensure_generic_task_source_result_is_success_predicate_is_passed_expected_error_result_success()
         {
@@ -262,7 +262,7 @@ namespace CSharpFunctionalExtensions.Tests.ResultTests
 
             result.Should().Be(sut.Result);
         }
-        
+
         [Fact]
         public async Task Ensure_generic_source_result_with_error_is_failure_async_predicate_do_not_invoked_expect_is_error_result_failure()
         {
@@ -272,7 +272,7 @@ namespace CSharpFunctionalExtensions.Tests.ResultTests
 
             result.Should().Be(sut);
         }
-        
+
         [Fact]
         public async Task Ensure_generic_source_result_with_error_is_success_async_predicate_is_failed_expected_error_result_failure()
         {
@@ -285,7 +285,7 @@ namespace CSharpFunctionalExtensions.Tests.ResultTests
             result.IsFailure.Should().BeTrue();
             result.Error.Should().Be(error);
         }
-        
+
         [Fact]
         public async Task Ensure_generic_source_result_with_error_is_success_async_predicate_is_passed_expected_error_result_success()
         {
@@ -295,7 +295,7 @@ namespace CSharpFunctionalExtensions.Tests.ResultTests
 
             result.Should().Be(sut);
         }
-        
+
         [Fact]
         public async Task Ensure_task_source_result_is_failure_async_predicate_with_arg_do_not_invoked_expect_is_error_result_failure()
         {
@@ -305,7 +305,7 @@ namespace CSharpFunctionalExtensions.Tests.ResultTests
 
             result.Should().Be(sut.Result);
         }
-        
+
         [Fact]
         public async Task Ensure_task_source_result_is_success_async_predicate_with_arg_is_failed_expected_error_result_failure()
         {
@@ -318,7 +318,7 @@ namespace CSharpFunctionalExtensions.Tests.ResultTests
             result.IsFailure.Should().BeTrue();
             result.Error.Should().Be(error);
         }
-        
+
         [Fact]
         public async Task Ensure_task_source_result_is_success_async_predicate_with_arg_is_passed_expected_error_result_success()
         {
@@ -338,7 +338,7 @@ namespace CSharpFunctionalExtensions.Tests.ResultTests
 
             result.Should().Be(sut.Result);
         }
-        
+
         [Fact]
         public async Task Ensure_task_source_result_is_success_predicate_with_arg_is_failed_expected_error_result_failure()
         {
@@ -351,7 +351,7 @@ namespace CSharpFunctionalExtensions.Tests.ResultTests
             result.IsFailure.Should().BeTrue();
             result.Error.Should().Be(error);
         }
-        
+
         [Fact]
         public async Task Ensure_task_source_result_is_success_predicate_with_arg_is_passed_expected_error_result_success()
         {
@@ -371,7 +371,7 @@ namespace CSharpFunctionalExtensions.Tests.ResultTests
 
             result.Should().Be(sut);
         }
-        
+
         [Fact]
         public void Ensure_source_result_is_success_predicate_with_arg_is_failed_expected_error_result_failure()
         {
@@ -384,7 +384,7 @@ namespace CSharpFunctionalExtensions.Tests.ResultTests
             result.IsFailure.Should().BeTrue();
             result.Error.Should().Be(error);
         }
-        
+
         [Fact]
         public void Ensure_source_result_is_success_predicate_with_arg_is_passed_expected_error_result_success()
         {

--- a/CSharpFunctionalExtensions.Tests/ResultTests/EnsureMethodTests.cs
+++ b/CSharpFunctionalExtensions.Tests/ResultTests/EnsureMethodTests.cs
@@ -1,6 +1,6 @@
+using FluentAssertions;
 using System;
 using System.Threading.Tasks;
-using FluentAssertions;
 using Xunit;
 
 namespace CSharpFunctionalExtensions.Tests.ResultTests

--- a/CSharpFunctionalExtensions.Tests/ResultTests/FailedResultTests.cs
+++ b/CSharpFunctionalExtensions.Tests/ResultTests/FailedResultTests.cs
@@ -1,5 +1,5 @@
-﻿using System;
-using FluentAssertions;
+﻿using FluentAssertions;
+using System;
 using Xunit;
 
 

--- a/CSharpFunctionalExtensions.Tests/ResultTests/FailedResultTests.cs
+++ b/CSharpFunctionalExtensions.Tests/ResultTests/FailedResultTests.cs
@@ -34,7 +34,7 @@ namespace CSharpFunctionalExtensions.Tests.ResultTests
 
             Action action = () => { MyClass myClass = result.Value; };
 
-            action.ShouldThrow<ResultFailureException>();
+            action.Should().Throw<ResultFailureException>();
         }
 
         [Fact]
@@ -44,7 +44,7 @@ namespace CSharpFunctionalExtensions.Tests.ResultTests
 
             Action action = () => { MyClass myClass = result.Value; };
 
-            action.ShouldThrow<ResultFailureException<MyErrorClass>>();
+            action.Should().Throw<ResultFailureException<MyErrorClass>>();
         }
 
         [Fact]
@@ -55,10 +55,10 @@ namespace CSharpFunctionalExtensions.Tests.ResultTests
             Action action3 = () => { Result.Failure<MyClass>(null); };
             Action action4 = () => { Result.Failure<MyClass>(string.Empty); };
 
-            action1.ShouldThrow<ArgumentNullException>();
-            action2.ShouldThrow<ArgumentNullException>();
-            action3.ShouldThrow<ArgumentNullException>();
-            action4.ShouldThrow<ArgumentNullException>();
+            action1.Should().Throw<ArgumentNullException>();
+            action2.Should().Throw<ArgumentNullException>();
+            action3.Should().Throw<ArgumentNullException>();
+            action4.Should().Throw<ArgumentNullException>();
         }
 
 

--- a/CSharpFunctionalExtensions.Tests/ResultTests/Methods/FirstFailureOrSuccessTests.cs
+++ b/CSharpFunctionalExtensions.Tests/ResultTests/Methods/FirstFailureOrSuccessTests.cs
@@ -1,0 +1,35 @@
+﻿using FluentAssertions;
+using Xunit;
+
+namespace CSharpFunctionalExtensions.Tests.ResultTests.Methods
+{
+    public class FirstFailureOrSuccessTests
+    {
+        [Fact]
+        public void FirstFailureOrSuccess_returns_the_first_failed_result()
+        {
+            Result result1 = Result.Success();
+            Result result2 = Result.Failure("Failure 1");
+            Result result3 = Result.Failure("Failure 2");
+
+            Result result = Result.FirstFailureOrSuccess(result1, result2, result3);
+
+            result.IsFailure.Should().BeTrue();
+            result.Error.Should().Be("Failure 1");
+            result.Should().Be(result2);
+        }
+
+        [Fact]
+        public void FirstFailureOrSuccess_returns_success_if_no_failures()
+        {
+            Result result1 = Result.Success();
+            Result result2 = Result.Success();
+            Result result3 = Result.Success();
+
+            Result result = Result.FirstFailureOrSuccess(result1, result2, result3);
+
+            result.IsSuccess.Should().BeTrue();
+            result.Should().Be(Result.Success());
+        }
+    }
+}

--- a/CSharpFunctionalExtensions.Tests/ResultTests/ResultTests.cs
+++ b/CSharpFunctionalExtensions.Tests/ResultTests/ResultTests.cs
@@ -18,7 +18,7 @@ namespace CSharpFunctionalExtensions.Tests.ResultTests
         [Fact]
         public void Fail_argument_is_default_Fail_result_expected()
         {
-            Result result = Result.Failure<string, int>(0);
+            Result<string, int> result = Result.Failure<string, int>(0);
 
             result.IsFailure.Should().BeTrue();
         }
@@ -26,7 +26,7 @@ namespace CSharpFunctionalExtensions.Tests.ResultTests
         [Fact]
         public void Fail_argument_is_not_default_Fail_result_expected()
         {
-            Result result = Result.Failure<string, int>(1);
+            Result<string, int> result = Result.Failure<string, int>(1);
 
             result.IsFailure.Should().BeTrue();
         }

--- a/CSharpFunctionalExtensions.Tests/ResultTests/ResultTests.cs
+++ b/CSharpFunctionalExtensions.Tests/ResultTests/ResultTests.cs
@@ -72,7 +72,7 @@ namespace CSharpFunctionalExtensions.Tests.ResultTests
 
             result.IsSuccess.Should().BeTrue();
         }
-        
+
         [Fact]
         public void Create_argument_is_false_Failure_result_expected()
         {
@@ -81,15 +81,15 @@ namespace CSharpFunctionalExtensions.Tests.ResultTests
             result.IsFailure.Should().BeTrue();
             result.Error.Should().Be("simple result error");
         }
-        
+
         [Fact]
         public void Create_predicate_is_true_Success_result_expected()
-        {   
+        {
             Result result = Result.SuccessIf(() => true, string.Empty);
 
             result.IsSuccess.Should().BeTrue();
         }
-        
+
         [Fact]
         public void Create_predicate_is_false_Failure_result_expected()
         {
@@ -98,7 +98,7 @@ namespace CSharpFunctionalExtensions.Tests.ResultTests
             result.IsFailure.Should().BeTrue();
             result.Error.Should().Be("predicate result error");
         }
-        
+
         [Fact]
         public async Task Create_async_predicate_is_true_Success_result_expected()
         {
@@ -106,7 +106,7 @@ namespace CSharpFunctionalExtensions.Tests.ResultTests
 
             result.IsSuccess.Should().BeTrue();
         }
-        
+
         [Fact]
         public async Task Create_async_predicate_is_false_Failure_result_expected()
         {
@@ -192,7 +192,7 @@ namespace CSharpFunctionalExtensions.Tests.ResultTests
             result.IsFailure.Should().BeTrue();
             result.Error.Should().Be("predicate result error");
         }
-        
+
         [Fact]
         public void Create_generic_argument_is_true_Success_result_expected()
         {
@@ -202,7 +202,7 @@ namespace CSharpFunctionalExtensions.Tests.ResultTests
             result.IsSuccess.Should().BeTrue();
             result.Value.Should().Be(val);
         }
-        
+
         [Fact]
         public void Create_generic_argument_is_false_Failure_result_expected()
         {
@@ -212,52 +212,52 @@ namespace CSharpFunctionalExtensions.Tests.ResultTests
             result.IsFailure.Should().BeTrue();
             result.Error.Should().Be("simple result error");
         }
-        
+
         [Fact]
         public void Create_generic_predicate_is_true_Success_result_expected()
         {
             DateTime val = new DateTime(2000, 1, 1);
-            
+
             Result<DateTime> result = Result.SuccessIf(() => true, val, string.Empty);
 
             result.IsSuccess.Should().BeTrue();
             result.Value.Should().Be(val);
         }
-        
+
         [Fact]
         public void Create_generic_predicate_is_false_Failure_result_expected()
         {
             string val = "string value";
-            
+
             Result<string> result = Result.SuccessIf(() => false, val, "predicate result error");
 
             result.IsFailure.Should().BeTrue();
             result.Error.Should().Be("predicate result error");
         }
-        
+
         [Fact]
         public async Task Create_generic_async_predicate_is_true_Success_result_expected()
         {
             int val = 42;
-            
+
             Result<int> result = await Result.SuccessIf(() => Task.FromResult(true), val, string.Empty);
 
             result.IsSuccess.Should().BeTrue();
             result.Value.Should().Be(val);
         }
-        
+
         [Fact]
         public async Task Create_generic_async_predicate_is_false_Failure_result_expected()
         {
             bool val = true;
-            
+
             Result<bool> result = await Result.SuccessIf(() => Task.FromResult(false), val, "predicate result error");
 
             result.IsFailure.Should().BeTrue();
             result.Error.Should().Be("predicate result error");
         }
-        
-        
+
+
         [Fact]
         public void Create_error_generic_argument_is_true_Success_result_expected()
         {
@@ -267,59 +267,59 @@ namespace CSharpFunctionalExtensions.Tests.ResultTests
             result.IsSuccess.Should().BeTrue();
             result.Value.Should().Be(val);
         }
-        
+
         [Fact]
         public void Create_error_generic_argument_is_false_Failure_result_expected()
         {
             double val = .56;
             var error = new Error();
-            
+
             Result<double, Error> result = Result.SuccessIf(false, val, error);
 
             result.IsFailure.Should().BeTrue();
             result.Error.Should().Be(error);
         }
-        
+
         [Fact]
         public void Create_error_generic_predicate_is_true_Success_result_expected()
         {
             DateTime val = new DateTime(2000, 1, 1);
-            
+
             Result<DateTime, Error> result = Result.SuccessIf(() => true, val, new Error());
 
             result.IsSuccess.Should().BeTrue();
             result.Value.Should().Be(val);
         }
-        
+
         [Fact]
         public void Create_error_generic_predicate_is_false_Failure_result_expected()
         {
             string val = "string value";
             var error = new Error();
-            
+
             Result<string, Error> result = Result.SuccessIf(() => false, val, error);
 
             result.IsFailure.Should().BeTrue();
             result.Error.Should().Be(error);
         }
-        
+
         [Fact]
         public async Task Create_error_generic_async_predicate_is_true_Success_result_expected()
         {
             int val = 42;
-            
+
             Result<int, Error> result = await Result.SuccessIf(() => Task.FromResult(true), val, new Error());
 
             result.IsSuccess.Should().BeTrue();
             result.Value.Should().Be(val);
         }
-        
+
         [Fact]
         public async Task Create_error_generic_async_predicate_is_false_Failure_result_expected()
         {
             bool val = true;
             var error = new Error();
-            
+
             Result<bool, Error> result = await Result.SuccessIf(() => Task.FromResult(false), val, error);
 
             result.IsFailure.Should().BeTrue();
@@ -467,7 +467,7 @@ namespace CSharpFunctionalExtensions.Tests.ResultTests
             result.IsSuccess.Should().BeTrue();
             result.Value.Should().Be(null);
         }
-        
+
         [Fact]
         public void Can_work_with_maybe_of_struct()
         {
@@ -478,7 +478,7 @@ namespace CSharpFunctionalExtensions.Tests.ResultTests
             result.IsSuccess.Should().BeTrue();
             result.Value.Should().Be(Maybe<DateTime>.None);
         }
-        
+
         [Fact]
         public void Can_work_with_maybe_of_ref_type()
         {
@@ -494,96 +494,96 @@ namespace CSharpFunctionalExtensions.Tests.ResultTests
         public void Try_execute_function_success_without_error_handler_function_result_expected()
         {
             Func<int> func = () => 5;
-            
+
             var result = Result.Try(func);
 
             result.IsSuccess.Should().BeTrue();
             result.Value.Should().Be(5);
         }
-        
+
         [Fact]
         public void Try_execute_function_failed_without_error_handler_failed_result_expected()
         {
             Func<int> func = () => throw new Exception("func error");
-            
+
             var result = Result.Try(func);
 
             result.IsFailure.Should().BeTrue();
             result.Error.Should().Be("func error");
         }
-        
+
         [Fact]
         public void Try_execute_function_failed_with_error_handler_failed_result_expected()
         {
             Func<int> func = () => throw new Exception("func error");
             Func<Exception, string> handler = exc => "execute error";
-            
+
             var result = Result.Try(func, handler);
 
             result.IsFailure.Should().BeTrue();
             result.Error.Should().Be("execute error");
         }
-        
+
         [Fact]
         public void Try_execute_action_success_without_error_handler_function_result_expected()
         {
             Action action = () => { };
-            
+
             var result = Result.Try(action);
 
             result.IsSuccess.Should().BeTrue();
         }
-        
+
         [Fact]
         public void Try_execute_action_failed_without_error_handler_failed_result_expected()
         {
             Action action = () => throw new Exception("func error");
-            
+
             var result = Result.Try(action);
 
             result.IsFailure.Should().BeTrue();
             result.Error.Should().Be("func error");
         }
-        
+
         [Fact]
         public void Try_execute_action_failed_with_error_handler_failed_result_expected()
         {
             Action action = () => throw new Exception("func error");
             Func<Exception, string> handler = exc => "execute error";
-            
+
             var result = Result.Try(action, handler);
 
             result.IsFailure.Should().BeTrue();
             result.Error.Should().Be("execute error");
         }
-        
+
         [Fact]
         public async Task Try_execute_async_action_success_without_error_handler_function_result_expected()
         {
             Func<Task> action = () => Task.CompletedTask;
-            
+
             var result = await Result.Try(action);
 
             result.IsSuccess.Should().BeTrue();
         }
-        
+
         [Fact]
         public async Task Try_execute_async_action_failed_without_error_handler_failed_result_expected()
         {
             Func<Task> action = () => Task.FromException(new Exception("func error"));
-            
+
             var result = await Result.Try(action);
 
             result.IsFailure.Should().BeTrue();
             result.Error.Should().Be("func error");
         }
-        
+
         [Fact]
         public async Task Try_execute_async_action_failed_with_error_handler_failed_result_expected()
         {
             Func<Task> action = () => Task.FromException(new Exception("func error"));
             Func<Exception, string> handler = exc => "execute error";
-            
+
             var result = await Result.Try(action, handler);
 
             result.IsFailure.Should().BeTrue();
@@ -595,76 +595,76 @@ namespace CSharpFunctionalExtensions.Tests.ResultTests
         {
             Func<string> func = () => "execution result";
             var error = new Error();
-            
+
             var result = Result.Try(func, exc => error);
 
             result.IsSuccess.Should().BeTrue();
             result.Value.Should().Be("execution result");
         }
-        
+
         [Fact]
         public void Try_with_error_execute_function_failed_with_error_handler_failed_result_expected()
         {
             Func<int> func = () => throw new Exception("func error");
             var error = new Error();
-            
+
             var result = Result.Try(func, exc => error);
 
             result.IsFailure.Should().BeTrue();
             result.Error.Should().Be(error);
         }
-        
+
         [Fact]
         public async Task Try_async_execute_function_success_without_error_handler_function_result_expected()
         {
             Func<Task<int>> func = () => Task.FromResult(5);
-            
+
             var result = await Result.Try(func);
 
             result.IsSuccess.Should().BeTrue();
             result.Value.Should().Be(5);
         }
-        
+
         [Fact]
         public async Task Try_async_execute_function_failed_without_error_handler_failed_result_expected()
         {
             Func<Task<int>> func = () => Task.FromException<int>(new Exception("func error"));
-            
+
             var result = await Result.Try(func);
 
             result.IsFailure.Should().BeTrue();
             result.Error.Should().Be("func error");
         }
-        
+
         [Fact]
         public async Task Try_async_execute_function_failed_with_error_handler_failed_result_expected()
         {
             Func<Task<int>> func = () => Task.FromException<int>(new Exception("func error"));
             Func<Exception, string> handler = exc => "execute error";
-            
+
             var result = await Result.Try(func, handler);
 
             result.IsFailure.Should().BeTrue();
             result.Error.Should().Be("execute error");
         }
-        
+
         [Fact]
         public async Task Try_async_with_error_execute_function_success_without_error_success_result_expected()
         {
             Func<Task<string>> func = () => Task.FromResult("execution result");
-            
+
             var result = await Result.Try(func, exc => new Error());
 
             result.IsSuccess.Should().BeTrue();
             result.Value.Should().Be("execution result");
         }
-        
+
         [Fact]
         public async Task Try_async_with_error_execute_function_failed_with_error_handler_failed_result_expected()
         {
             Func<Task<DateTime>> func = () => Task.FromException<DateTime>(new Exception("func error"));
             var error = new Error();
-            
+
             var result = await Result.Try(func, exc => error);
 
             result.IsFailure.Should().BeTrue();

--- a/CSharpFunctionalExtensions.Tests/ResultTests/ResultTests.cs
+++ b/CSharpFunctionalExtensions.Tests/ResultTests/ResultTests.cs
@@ -1,6 +1,6 @@
+using FluentAssertions;
 using System;
 using System.Threading.Tasks;
-using FluentAssertions;
 using Xunit;
 
 namespace CSharpFunctionalExtensions.Tests.ResultTests

--- a/CSharpFunctionalExtensions.Tests/ResultTests/SerializationTests.cs
+++ b/CSharpFunctionalExtensions.Tests/ResultTests/SerializationTests.cs
@@ -1,5 +1,5 @@
-﻿using System.Runtime.Serialization;
-using FluentAssertions;
+﻿using FluentAssertions;
+using System.Runtime.Serialization;
 using Xunit;
 
 namespace CSharpFunctionalExtensions.Tests.ResultTests

--- a/CSharpFunctionalExtensions.Tests/ResultTests/SucceededResultTests.cs
+++ b/CSharpFunctionalExtensions.Tests/ResultTests/SucceededResultTests.cs
@@ -1,5 +1,5 @@
-﻿using System;
-using FluentAssertions;
+﻿using FluentAssertions;
+using System;
 using Xunit;
 
 

--- a/CSharpFunctionalExtensions.Tests/ResultTests/SucceededResultTests.cs
+++ b/CSharpFunctionalExtensions.Tests/ResultTests/SucceededResultTests.cs
@@ -54,7 +54,7 @@ namespace CSharpFunctionalExtensions.Tests.ResultTests
                 string error = result.Error;
             };
 
-            action.ShouldThrow<ResultSuccessException>();
+            action.Should().Throw<ResultSuccessException>();
         }
 
         [Fact]
@@ -67,7 +67,7 @@ namespace CSharpFunctionalExtensions.Tests.ResultTests
                 string error = result.Error;
             };
 
-            action.ShouldThrow<ResultSuccessException>();
+            action.Should().Throw<ResultSuccessException>();
         }
 
         [Fact]
@@ -80,7 +80,7 @@ namespace CSharpFunctionalExtensions.Tests.ResultTests
                 MyErrorClass error = result.Error;
             };
 
-            action.ShouldThrow<ResultSuccessException>();
+            action.Should().Throw<ResultSuccessException>();
         }
 
         private void Can_create_a_generic_version_with_a_generic_error_typed<E>()

--- a/CSharpFunctionalExtensions.Tests/ValueObjectTests/BasicTests.cs
+++ b/CSharpFunctionalExtensions.Tests/ValueObjectTests/BasicTests.cs
@@ -1,6 +1,6 @@
-﻿using System;
+﻿using FluentAssertions;
+using System;
 using System.Collections.Generic;
-using FluentAssertions;
 using Xunit;
 
 namespace CSharpFunctionalExtensions.Tests.ValueObjectTests

--- a/CSharpFunctionalExtensions/CSharpFunctionalExtensions.csproj
+++ b/CSharpFunctionalExtensions/CSharpFunctionalExtensions.csproj
@@ -40,7 +40,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta2-19367-01">
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/CSharpFunctionalExtensions/ICombine.cs
+++ b/CSharpFunctionalExtensions/ICombine.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-
-namespace CSharpFunctionalExtensions
+﻿namespace CSharpFunctionalExtensions
 {
     public interface ICombine
     {

--- a/CSharpFunctionalExtensions/Maybe/MaybeExtensions.cs
+++ b/CSharpFunctionalExtensions/Maybe/MaybeExtensions.cs
@@ -63,12 +63,12 @@ namespace CSharpFunctionalExtensions
         }
 
         public static Maybe<V> SelectMany<T, U, V>(this Maybe<T> maybe,
-	        Func<T, Maybe<U>> selector,
-	        Func<T, U, V> project)
+            Func<T, Maybe<U>> selector,
+            Func<T, U, V> project)
         {
-	        return maybe.Unwrap(
-		        x => selector(x).Unwrap(u => project(x, u), Maybe<V>.None),
-		        Maybe<V>.None);
+            return maybe.Unwrap(
+                x => selector(x).Unwrap(u => project(x, u), Maybe<V>.None),
+                Maybe<V>.None);
         }
 
         public static Maybe<K> Map<T, K>(this Maybe<T> maybe, Func<T, K> selector)
@@ -168,22 +168,22 @@ namespace CSharpFunctionalExtensions
         }
 
 #if NET40
-        public static Maybe<V> TryFind<K, V>(this IDictionary<K, V> dict, K key) 
+        public static Maybe<V> TryFind<K, V>(this IDictionary<K, V> dict, K key)
         {
-            if (dict.ContainsKey(key)) 
+            if (dict.ContainsKey(key))
             {
                 return dict[key];
             }
-            return Maybe<V>.None;   
+            return Maybe<V>.None;
         }
 #else
-        public static Maybe<V> TryFind<K, V>(this IReadOnlyDictionary<K, V> dict, K key) 
+        public static Maybe<V> TryFind<K, V>(this IReadOnlyDictionary<K, V> dict, K key)
         {
-            if (dict.ContainsKey(key)) 
+            if (dict.ContainsKey(key))
             {
                 return dict[key];
             }
-            return Maybe<V>.None;   
+            return Maybe<V>.None;
         }
 #endif
     }

--- a/CSharpFunctionalExtensions/Result/Exceptions/ResultFailureException.cs
+++ b/CSharpFunctionalExtensions/Result/Exceptions/ResultFailureException.cs
@@ -1,5 +1,4 @@
-﻿using CSharpFunctionalExtensions.Internal;
-using System;
+﻿using System;
 
 namespace CSharpFunctionalExtensions
 {

--- a/CSharpFunctionalExtensions/Result/Exceptions/ResultSuccessException.cs
+++ b/CSharpFunctionalExtensions/Result/Exceptions/ResultSuccessException.cs
@@ -1,5 +1,4 @@
-﻿using CSharpFunctionalExtensions.Internal;
-using System;
+﻿using System;
 
 namespace CSharpFunctionalExtensions
 {

--- a/CSharpFunctionalExtensions/Result/Extensions/Bind.cs
+++ b/CSharpFunctionalExtensions/Result/Extensions/Bind.cs
@@ -37,15 +37,6 @@ namespace CSharpFunctionalExtensions
             return func();
         }
 
-        // Potential loss of E fidelity. Not present in Async overloads
-        public static Result<K> Bind<T, K, E>(this Result<T, E> result, Func<T, Result<K>> func)
-        {
-            if (result.IsFailure)
-                return Result.Failure<K, E>(result.Error);
-
-            return func(result.Value);
-        }
-
         /// <summary>
         ///     Selects result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.
         /// </summary>

--- a/CSharpFunctionalExtensions/Result/Extensions/FinallyAsyncRight.cs
+++ b/CSharpFunctionalExtensions/Result/Extensions/FinallyAsyncRight.cs
@@ -24,7 +24,7 @@ namespace CSharpFunctionalExtensions
         /// <summary>
         ///     Passes the result to the given function (regardless of success/failure state) to yield a final output value.
         /// </summary>
-        public static async Task<K> Finally<T, K, E>(this Result<T, E> result, Func<Result<T>, Task<K>> func)
+        public static async Task<K> Finally<T, K, E>(this Result<T, E> result, Func<Result<T, E>, Task<K>> func)
         {
             return await func(result).ConfigureAwait(Result.DefaultConfigureAwait);
         }

--- a/CSharpFunctionalExtensions/Result/Methods/Combine.cs
+++ b/CSharpFunctionalExtensions/Result/Methods/Combine.cs
@@ -6,12 +6,29 @@ namespace CSharpFunctionalExtensions
 {
     public partial struct Result
     {
+        /// <summary>
+        ///     Combines several results (and any errors) into a single result.
+        ///     The returned result will be a failure if any of the input <paramref name="results"/> are failures.
+        ///     The E error class must implement ICombine to provide an accumulator function for combining any errors.</summary>
+        /// <param name="results">
+        ///     The Results to be combined.</param>
+        /// <returns>
+        ///     A Result that is a success when all the input <paramref name="results"/> are also successes.</returns>
         public static Result<bool, E> Combine<T, E>(IEnumerable<Result<T, E>> results)
             where E : ICombine
         {
             return Combine(results, (errors) => errors.Aggregate((x, y) => (E)x.Combine(y)));
         }
 
+        /// <summary>
+        ///     Combines several results (and any errors) into a single result.
+        ///     The returned result will be a failure if any of the input <paramref name="results"/> are failures.</summary>
+        /// <param name="results">
+        ///     The Results to be combined.</param>
+        /// <param name="composerError">
+        ///     A function that combines any errors.</param>
+        /// <returns>
+        ///     A Result that is a success when all the input <paramref name="results"/> are also successes.</returns>
         public static Result<bool, E> Combine<T, E>(IEnumerable<Result<T, E>> results, Func<IEnumerable<E>, E> composerError)
         {
             List<Result<T, E>> failedResults = results.Where(x => x.IsFailure).ToList();
@@ -23,6 +40,15 @@ namespace CSharpFunctionalExtensions
             return Failure<bool, E>(errorMessage);
         }
 
+        /// <summary>
+        ///     Combines several results (and any error messages) into a single result.
+        ///     The returned result will be a failure if any of the input <paramref name="results"/> are failures.</summary>
+        /// <param name="results">
+        ///     The Results to be combined.</param>
+        /// <param name="errorMessagesSeparator">
+        ///     A string that is used to separate any concatenated error messages. If omitted, the default <see cref="Result.ErrorMessagesSeparator" /> is used.</param>
+        /// <returns>
+        ///     A Result that is a success when all the input <paramref name="results"/> are also successes.</returns>
         public static Result Combine(IEnumerable<Result> results, string errorMessagesSeparator = null)
         {
             List<Result> failedResults = results.Where(x => x.IsFailure).ToList();
@@ -34,6 +60,15 @@ namespace CSharpFunctionalExtensions
             return Failure(errorMessage);
         }
 
+        /// <summary>
+        ///     Combines several results (and any error messages) into a single result.
+        ///     The returned result will be a failure if any of the input <paramref name="results"/> are failures.</summary>
+        /// <param name="results">
+        ///     The Results to be combined.</param>
+        /// <param name="errorMessagesSeparator">
+        ///     A string that is used to separate any concatenated error messages. If omitted, the default <see cref="Result.ErrorMessagesSeparator" /> is used.</param>
+        /// <returns>
+        ///     A Result that is a success when all the input <paramref name="results"/> are also successes.</returns>
         public static Result Combine<T>(IEnumerable<Result<T>> results, string errorMessagesSeparator = null)
         {
             var untyped = results.Select(result => (Result)result);
@@ -41,36 +76,72 @@ namespace CSharpFunctionalExtensions
         }
 
         /// <summary>
-        /// Combines several results (and any error messages) into a single result.
-        /// The returned result will be a failure if any of the input <paramref name="results"/> are failures.
-        /// Error messages are concatenated with the default <see cref="Result.ErrorMessagesSeparator" /> between each message.
-        /// </summary>
-        /// <param name="results">The Results to be combined.</param>
-        /// <returns>A Result that is a success when all the input <paramref name="results"/> are also successes.</returns>
+        ///     Combines several results (and any error messages) into a single result.
+        ///     The returned result will be a failure if any of the input <paramref name="results"/> are failures.
+        ///     Error messages are concatenated with the default <see cref="Result.ErrorMessagesSeparator" /> between each message.</summary>
+        /// <param name="results">
+        ///     The Results to be combined.</param>
+        /// <returns>
+        ///     A Result that is a success when all the input <paramref name="results"/> are also successes.</returns>
         public static Result Combine(params Result[] results)
             => Combine(results, ErrorMessagesSeparator);
 
+        /// <summary>
+        ///     Combines several results (and any errors) into a single result.
+        ///     The returned result will be a failure if any of the input <paramref name="results"/> are failures.
+        ///     The E error class must implement ICombine to provide an accumulator function for combining any errors.</summary>
+        /// <param name="results">
+        ///     The Results to be combined.</param>
+        /// <returns>
+        ///     A Result that is a success when all the input <paramref name="results"/> are also successes.</returns>
         public static Result<bool, E> Combine<T, E>(params Result<T, E>[] results)
             where E : ICombine
             => Combine<T, E>(results, (errors) => errors.Aggregate((x, y) => (E)x.Combine(y)));
 
+        /// <summary>
+        ///     Combines several results (and any errors) into a single result.
+        ///     The returned result will be a failure if any of the input <paramref name="results"/> are failures.</summary>
+        /// <param name="composerError">
+        ///     A function that combines any errors.</param>
+        /// <param name="results">
+        ///     The Results to be combined.</param>
+        /// <returns>
+        ///     A Result that is a success when all the input <paramref name="results"/> are also successes.</returns>
         public static Result<bool, E> Combine<T, E>(Func<IEnumerable<E>, E> composerError, params Result<T, E>[] results)
             => Combine<T, E>(results, composerError);
 
         /// <summary>
-        /// Combines several results (and any error messages) into a single result.
-        /// The returned result will be a failure if any of the input <paramref name="results"/> are failures.
-        /// Error messages are concatenated with the specified <paramref name="errorMessagesSeparator"/> between each message.
-        /// </summary>
-        /// <param name="errorMessagesSeparator">The string to use as a separator. If omitted, the default <see cref="Result.ErrorMessagesSeparator" /> is used instead.</param>
-        /// <param name="results">The Results to be combined.</param>
-        /// <returns>A Result that is a success when all the input <paramref name="results"/> are also successes.</returns>
+        ///     Combines several results (and any error messages) into a single result.
+        ///     The returned result will be a failure if any of the input <paramref name="results"/> are failures.</summary>
+        /// <param name="errorMessagesSeparator">
+        ///     A string that is used to separate any concatenated error messages. If omitted, the default <see cref="Result.ErrorMessagesSeparator" /> is used.</param>
+        /// <param name="results">
+        ///     The Results to be combined.</param>
+        /// <returns>
+        ///     A Result that is a success when all the input <paramref name="results"/> are also successes.</returns>
         public static Result Combine(string errorMessagesSeparator, params Result[] results)
             => Combine(results, errorMessagesSeparator);
 
+        /// <summary>
+        ///     Combines several results (and any error messages) into a single result.
+        ///     The returned result will be a failure if any of the input <paramref name="results"/> are failures.
+        ///     Error messages are concatenated with the default <see cref="Result.ErrorMessagesSeparator" /> between each message.</summary>
+        /// <param name="results">
+        ///     The Results to be combined.</param>
+        /// <returns>
+        ///     A Result that is a success when all the input <paramref name="results"/> are also successes.</returns>
         public static Result Combine<T>(params Result<T>[] results)
             => Combine(results, ErrorMessagesSeparator);
 
+        /// <summary>
+        ///     Combines several results (and any error messages) into a single result.
+        ///     The returned result will be a failure if any of the input <paramref name="results"/> are failures.</summary>
+        /// <param name="errorMessagesSeparator">
+        ///     A string that is used to separate any concatenated error messages. If omitted, the default <see cref="Result.ErrorMessagesSeparator" /> is used.</param>
+        /// <param name="results">
+        ///     The Results to be combined.</param>
+        /// <returns>
+        ///     A Result that is a success when all the input <paramref name="results"/> are also successes.</returns>
         public static Result Combine<T>(string errorMessagesSeparator, params Result<T>[] results)
             => Combine(results, errorMessagesSeparator);
     }

--- a/CSharpFunctionalExtensions/Result/Methods/Combine.cs
+++ b/CSharpFunctionalExtensions/Result/Methods/Combine.cs
@@ -37,13 +37,15 @@ namespace CSharpFunctionalExtensions
         ///     A Result that is a success when all the input <paramref name="results"/> are also successes.</returns>
         public static Result Combine<T>(IEnumerable<Result<T>> results, string errorMessagesSeparator = null)
         {
-            var untyped = results.Select(result => (Result)result);
+            IEnumerable<Result> untyped = results.Select(result => (Result)result);
             return Combine(untyped, errorMessagesSeparator);
         }
 
+        // TODO: Ideally, we would be using BaseResult<E> or equivalent instead of Result<bool, E>.
         /// <summary>
         ///     Combines several results (and any errors) into a single result.
-        ///     The returned result will be a failure if any of the input <paramref name="results"/> are failures.</summary>
+        ///     The returned result will be a failure if any of the input <paramref name="results"/> are failures.
+        ///     NB: The bool value type is arbitrary - the value is not intended to be used.</summary>
         /// <param name="results">
         ///     The Results to be combined.</param>
         /// <param name="composerError">
@@ -57,23 +59,23 @@ namespace CSharpFunctionalExtensions
             if (failedResults.Count == 0)
                 return Success<bool, E>(true);
 
-            var errorMessage = composerError(failedResults.Select(x => x.Error));
-            return Failure<bool, E>(errorMessage);
+            E error = composerError(failedResults.Select(x => x.Error));
+            return Failure<bool, E>(error);
         }
 
+        // TODO: Ideally, we would be using BaseResult<E> or equivalent instead of Result<bool, E>.
         /// <summary>
         ///     Combines several results (and any errors) into a single result.
         ///     The returned result will be a failure if any of the input <paramref name="results"/> are failures.
-        ///     The E error class must implement ICombine to provide an accumulator function for combining any errors.</summary>
+        ///     The E error class must implement ICombine to provide an accumulator function for combining any errors.
+        ///     NB: The bool value type is arbitrary - the value is not intended to be used.</summary>
         /// <param name="results">
         ///     The Results to be combined.</param>
         /// <returns>
         ///     A Result that is a success when all the input <paramref name="results"/> are also successes.</returns>
         public static Result<bool, E> Combine<T, E>(IEnumerable<Result<T, E>> results)
             where E : ICombine
-        {
-            return Combine(results, (errors) => errors.Aggregate((x, y) => (E)x.Combine(y)));
-        }
+            => Combine(results, (errors) => errors.Aggregate((x, y) => (E)x.Combine(y)));
 
         /// <summary>
         ///     Combines several results (and any error messages) into a single result.
@@ -97,17 +99,19 @@ namespace CSharpFunctionalExtensions
         public static Result Combine<T>(params Result<T>[] results)
             => Combine(results, ErrorMessagesSeparator);
 
+        // TODO: Ideally, we would be using BaseResult<E> or equivalent instead of Result<bool, E>.
         /// <summary>
         ///     Combines several results (and any errors) into a single result.
         ///     The returned result will be a failure if any of the input <paramref name="results"/> are failures.
-        ///     The E error class must implement ICombine to provide an accumulator function for combining any errors.</summary>
+        ///     The E error class must implement ICombine to provide an accumulator function for combining any errors.
+        ///     NB: The bool value type is arbitrary - the result Value is not intended to be used.</summary>
         /// <param name="results">
         ///     The Results to be combined.</param>
         /// <returns>
         ///     A Result that is a success when all the input <paramref name="results"/> are also successes.</returns>
         public static Result<bool, E> Combine<T, E>(params Result<T, E>[] results)
             where E : ICombine
-            => Combine<T, E>(results, (errors) => errors.Aggregate((x, y) => (E)x.Combine(y)));
+            => Combine(results, (errors) => errors.Aggregate((x, y) => (E)x.Combine(y)));
 
         /// <summary>
         ///     Combines several results (and any error messages) into a single result.
@@ -133,9 +137,11 @@ namespace CSharpFunctionalExtensions
         public static Result Combine<T>(string errorMessagesSeparator, params Result<T>[] results)
             => Combine(results, errorMessagesSeparator);
 
+        // TODO: Ideally, we would be using BaseResult<E> or equivalent instead of Result<bool, E>.
         /// <summary>
         ///     Combines several results (and any errors) into a single result.
-        ///     The returned result will be a failure if any of the input <paramref name="results"/> are failures.</summary>
+        ///     The returned result will be a failure if any of the input <paramref name="results"/> are failures.
+        ///     NB: The bool value type is arbitrary - the result Value is not intended to be used.</summary>
         /// <param name="composerError">
         ///     A function that combines any errors.</param>
         /// <param name="results">
@@ -143,6 +149,6 @@ namespace CSharpFunctionalExtensions
         /// <returns>
         ///     A Result that is a success when all the input <paramref name="results"/> are also successes.</returns>
         public static Result<bool, E> Combine<T, E>(Func<IEnumerable<E>, E> composerError, params Result<T, E>[] results)
-            => Combine<T, E>(results, composerError);
+            => Combine(results, composerError);
     }
 }

--- a/CSharpFunctionalExtensions/Result/Methods/Combine.cs
+++ b/CSharpFunctionalExtensions/Result/Methods/Combine.cs
@@ -7,40 +7,6 @@ namespace CSharpFunctionalExtensions
     public partial struct Result
     {
         /// <summary>
-        ///     Combines several results (and any errors) into a single result.
-        ///     The returned result will be a failure if any of the input <paramref name="results"/> are failures.
-        ///     The E error class must implement ICombine to provide an accumulator function for combining any errors.</summary>
-        /// <param name="results">
-        ///     The Results to be combined.</param>
-        /// <returns>
-        ///     A Result that is a success when all the input <paramref name="results"/> are also successes.</returns>
-        public static Result<bool, E> Combine<T, E>(IEnumerable<Result<T, E>> results)
-            where E : ICombine
-        {
-            return Combine(results, (errors) => errors.Aggregate((x, y) => (E)x.Combine(y)));
-        }
-
-        /// <summary>
-        ///     Combines several results (and any errors) into a single result.
-        ///     The returned result will be a failure if any of the input <paramref name="results"/> are failures.</summary>
-        /// <param name="results">
-        ///     The Results to be combined.</param>
-        /// <param name="composerError">
-        ///     A function that combines any errors.</param>
-        /// <returns>
-        ///     A Result that is a success when all the input <paramref name="results"/> are also successes.</returns>
-        public static Result<bool, E> Combine<T, E>(IEnumerable<Result<T, E>> results, Func<IEnumerable<E>, E> composerError)
-        {
-            List<Result<T, E>> failedResults = results.Where(x => x.IsFailure).ToList();
-
-            if (failedResults.Count == 0)
-                return Success<bool, E>(true);
-
-            var errorMessage = composerError(failedResults.Select(x => x.Error));
-            return Failure<bool, E>(errorMessage);
-        }
-
-        /// <summary>
         ///     Combines several results (and any error messages) into a single result.
         ///     The returned result will be a failure if any of the input <paramref name="results"/> are failures.</summary>
         /// <param name="results">
@@ -76,6 +42,40 @@ namespace CSharpFunctionalExtensions
         }
 
         /// <summary>
+        ///     Combines several results (and any errors) into a single result.
+        ///     The returned result will be a failure if any of the input <paramref name="results"/> are failures.</summary>
+        /// <param name="results">
+        ///     The Results to be combined.</param>
+        /// <param name="composerError">
+        ///     A function that combines any errors.</param>
+        /// <returns>
+        ///     A Result that is a success when all the input <paramref name="results"/> are also successes.</returns>
+        public static Result<bool, E> Combine<T, E>(IEnumerable<Result<T, E>> results, Func<IEnumerable<E>, E> composerError)
+        {
+            List<Result<T, E>> failedResults = results.Where(x => x.IsFailure).ToList();
+
+            if (failedResults.Count == 0)
+                return Success<bool, E>(true);
+
+            var errorMessage = composerError(failedResults.Select(x => x.Error));
+            return Failure<bool, E>(errorMessage);
+        }
+
+        /// <summary>
+        ///     Combines several results (and any errors) into a single result.
+        ///     The returned result will be a failure if any of the input <paramref name="results"/> are failures.
+        ///     The E error class must implement ICombine to provide an accumulator function for combining any errors.</summary>
+        /// <param name="results">
+        ///     The Results to be combined.</param>
+        /// <returns>
+        ///     A Result that is a success when all the input <paramref name="results"/> are also successes.</returns>
+        public static Result<bool, E> Combine<T, E>(IEnumerable<Result<T, E>> results)
+            where E : ICombine
+        {
+            return Combine(results, (errors) => errors.Aggregate((x, y) => (E)x.Combine(y)));
+        }
+
+        /// <summary>
         ///     Combines several results (and any error messages) into a single result.
         ///     The returned result will be a failure if any of the input <paramref name="results"/> are failures.
         ///     Error messages are concatenated with the default <see cref="Result.ErrorMessagesSeparator" /> between each message.</summary>
@@ -84,6 +84,17 @@ namespace CSharpFunctionalExtensions
         /// <returns>
         ///     A Result that is a success when all the input <paramref name="results"/> are also successes.</returns>
         public static Result Combine(params Result[] results)
+            => Combine(results, ErrorMessagesSeparator);
+
+        /// <summary>
+        ///     Combines several results (and any error messages) into a single result.
+        ///     The returned result will be a failure if any of the input <paramref name="results"/> are failures.
+        ///     Error messages are concatenated with the default <see cref="Result.ErrorMessagesSeparator" /> between each message.</summary>
+        /// <param name="results">
+        ///     The Results to be combined.</param>
+        /// <returns>
+        ///     A Result that is a success when all the input <paramref name="results"/> are also successes.</returns>
+        public static Result Combine<T>(params Result<T>[] results)
             => Combine(results, ErrorMessagesSeparator);
 
         /// <summary>
@@ -99,18 +110,6 @@ namespace CSharpFunctionalExtensions
             => Combine<T, E>(results, (errors) => errors.Aggregate((x, y) => (E)x.Combine(y)));
 
         /// <summary>
-        ///     Combines several results (and any errors) into a single result.
-        ///     The returned result will be a failure if any of the input <paramref name="results"/> are failures.</summary>
-        /// <param name="composerError">
-        ///     A function that combines any errors.</param>
-        /// <param name="results">
-        ///     The Results to be combined.</param>
-        /// <returns>
-        ///     A Result that is a success when all the input <paramref name="results"/> are also successes.</returns>
-        public static Result<bool, E> Combine<T, E>(Func<IEnumerable<E>, E> composerError, params Result<T, E>[] results)
-            => Combine<T, E>(results, composerError);
-
-        /// <summary>
         ///     Combines several results (and any error messages) into a single result.
         ///     The returned result will be a failure if any of the input <paramref name="results"/> are failures.</summary>
         /// <param name="errorMessagesSeparator">
@@ -124,17 +123,6 @@ namespace CSharpFunctionalExtensions
 
         /// <summary>
         ///     Combines several results (and any error messages) into a single result.
-        ///     The returned result will be a failure if any of the input <paramref name="results"/> are failures.
-        ///     Error messages are concatenated with the default <see cref="Result.ErrorMessagesSeparator" /> between each message.</summary>
-        /// <param name="results">
-        ///     The Results to be combined.</param>
-        /// <returns>
-        ///     A Result that is a success when all the input <paramref name="results"/> are also successes.</returns>
-        public static Result Combine<T>(params Result<T>[] results)
-            => Combine(results, ErrorMessagesSeparator);
-
-        /// <summary>
-        ///     Combines several results (and any error messages) into a single result.
         ///     The returned result will be a failure if any of the input <paramref name="results"/> are failures.</summary>
         /// <param name="errorMessagesSeparator">
         ///     A string that is used to separate any concatenated error messages. If omitted, the default <see cref="Result.ErrorMessagesSeparator" /> is used.</param>
@@ -144,5 +132,17 @@ namespace CSharpFunctionalExtensions
         ///     A Result that is a success when all the input <paramref name="results"/> are also successes.</returns>
         public static Result Combine<T>(string errorMessagesSeparator, params Result<T>[] results)
             => Combine(results, errorMessagesSeparator);
+
+        /// <summary>
+        ///     Combines several results (and any errors) into a single result.
+        ///     The returned result will be a failure if any of the input <paramref name="results"/> are failures.</summary>
+        /// <param name="composerError">
+        ///     A function that combines any errors.</param>
+        /// <param name="results">
+        ///     The Results to be combined.</param>
+        /// <returns>
+        ///     A Result that is a success when all the input <paramref name="results"/> are also successes.</returns>
+        public static Result<bool, E> Combine<T, E>(Func<IEnumerable<E>, E> composerError, params Result<T, E>[] results)
+            => Combine<T, E>(results, composerError);
     }
 }

--- a/CSharpFunctionalExtensions/Result/Methods/ConvertFailure.cs
+++ b/CSharpFunctionalExtensions/Result/Methods/ConvertFailure.cs
@@ -4,6 +4,9 @@ namespace CSharpFunctionalExtensions
 {
     public partial struct Result
     {
+        /// <summary>
+        ///     Throws if the result is a success. Else returns a new failure result of the given type.
+        /// </summary>
         public Result<K> ConvertFailure<K>()
         {
             if (IsSuccess)
@@ -15,6 +18,9 @@ namespace CSharpFunctionalExtensions
 
     public partial struct Result<T>
     {
+        /// <summary>
+        ///     Throws if the result is a success. Else returns a new failure result.
+        /// </summary>
         public Result ConvertFailure()
         {
             if (IsSuccess)
@@ -23,6 +29,9 @@ namespace CSharpFunctionalExtensions
             return Result.Failure(Error);
         }
 
+        /// <summary>
+        ///     Throws if the result is a success. Else returns a new failure result of the given type.
+        /// </summary>
         public Result<K> ConvertFailure<K>()
         {
             if (IsSuccess)
@@ -34,6 +43,9 @@ namespace CSharpFunctionalExtensions
 
     public partial struct Result<T, E>
     {
+        /// <summary>
+        ///     Throws if the result is a success. Else returns a new failure result of the given type.
+        /// </summary>
         public Result<K, E> ConvertFailure<K>()
         {
             if (IsSuccess)

--- a/CSharpFunctionalExtensions/Result/Methods/Failure.cs
+++ b/CSharpFunctionalExtensions/Result/Methods/Failure.cs
@@ -2,16 +2,25 @@
 {
     public partial struct Result
     {
+        /// <summary>
+        ///     Creates a failure result with the given error message.
+        /// </summary>
         public static Result Failure(string error)
         {
             return new Result(true, error);
         }
 
+        /// <summary>
+        ///     Creates a failure result with the given error message.
+        /// </summary>
         public static Result<T> Failure<T>(string error)
         {
             return new Result<T>(true, error, default);
         }
 
+        /// <summary>
+        ///     Creates a failure result with the given error.
+        /// </summary>
         public static Result<T, E> Failure<T, E>(E error)
         {
             return new Result<T, E>(true, error, default);

--- a/CSharpFunctionalExtensions/Result/Methods/FailureIf.cs
+++ b/CSharpFunctionalExtensions/Result/Methods/FailureIf.cs
@@ -5,36 +5,63 @@ namespace CSharpFunctionalExtensions
 {
     public partial struct Result
     {
+        /// <summary>
+        ///     Creates a result whose success/failure reflects the supplied condition. Opposite of SuccessIf().
+        /// </summary>
         public static Result FailureIf(bool isFailure, string error)
             => SuccessIf(!isFailure, error);
 
+        /// <summary>
+        ///     Creates a result whose success/failure depends on the supplied predicate. Opposite of SuccessIf().
+        /// </summary>
         public static Result FailureIf(Func<bool> failurePredicate, string error)
             => SuccessIf(!failurePredicate(), error);
 
+        /// <summary>
+        ///     Creates a result whose success/failure depends on the supplied predicate. Opposite of SuccessIf().
+        /// </summary>
         public static async Task<Result> FailureIf(Func<Task<bool>> failurePredicate, string error)
         {
             bool isFailure = await failurePredicate().ConfigureAwait(DefaultConfigureAwait);
             return SuccessIf(!isFailure, error);
         }
 
+        /// <summary>
+        ///     Creates a result whose success/failure reflects the supplied condition. Opposite of SuccessIf().
+        /// </summary>
         public static Result<T> FailureIf<T>(bool isFailure, T value, string error)
             => SuccessIf(!isFailure, value, error);
 
+        /// <summary>
+        ///     Creates a result whose success/failure depends on the supplied predicate. Opposite of SuccessIf().
+        /// </summary>
         public static Result<T> FailureIf<T>(Func<bool> failurePredicate, T value, string error)
             => SuccessIf(!failurePredicate(), value, error);
 
+        /// <summary>
+        ///     Creates a result whose success/failure depends on the supplied predicate. Opposite of SuccessIf().
+        /// </summary>
         public static async Task<Result<T>> FailureIf<T>(Func<Task<bool>> failurePredicate, T value, string error)
         {
             bool isFailure = await failurePredicate().ConfigureAwait(DefaultConfigureAwait);
             return SuccessIf(!isFailure, value, error);
         }
 
+        /// <summary>
+        ///     Creates a result whose success/failure reflects the supplied condition. Opposite of SuccessIf().
+        /// </summary>
         public static Result<T, E> FailureIf<T, E>(bool isFailure, T value, E error)
             => SuccessIf(!isFailure, value, error);
 
+        /// <summary>
+        ///     Creates a result whose success/failure depends on the supplied predicate. Opposite of SuccessIf().
+        /// </summary>
         public static Result<T, E> FailureIf<T, E>(Func<bool> failurePredicate, T value, E error)
             => SuccessIf(!failurePredicate(), value, error);
 
+        /// <summary>
+        ///     Creates a result whose success/failure depends on the supplied predicate. Opposite of SuccessIf().
+        /// </summary>
         public static async Task<Result<T, E>> FailureIf<T, E>(Func<Task<bool>> failurePredicate, T value, E error)
         {
             bool isFailure = await failurePredicate().ConfigureAwait(DefaultConfigureAwait);

--- a/CSharpFunctionalExtensions/Result/Methods/FirstFailureOrSuccess.cs
+++ b/CSharpFunctionalExtensions/Result/Methods/FirstFailureOrSuccess.cs
@@ -11,7 +11,7 @@
             foreach (Result result in results)
             {
                 if (result.IsFailure)
-                    return Failure(result.Error);
+                    return result;
             }
 
             return Success();

--- a/CSharpFunctionalExtensions/Result/Methods/FirstFailureOrSuccess.cs
+++ b/CSharpFunctionalExtensions/Result/Methods/FirstFailureOrSuccess.cs
@@ -3,9 +3,9 @@
     public partial struct Result
     {
         /// <summary>
-        /// Returns first failure in the list of <paramref name="results"/>. If there is no failure returns success.
+        ///     Returns the first failure from the supplied <paramref name="results"/>.
+        ///     If there is no failure, a success result is returned.
         /// </summary>
-        /// <param name="results">List of results.</param>
         public static Result FirstFailureOrSuccess(params Result[] results)
         {
             foreach (Result result in results)

--- a/CSharpFunctionalExtensions/Result/Methods/Success.cs
+++ b/CSharpFunctionalExtensions/Result/Methods/Success.cs
@@ -2,16 +2,25 @@
 {
     public partial struct Result
     {
+        /// <summary>
+        ///     Creates a success result.
+        /// </summary>
         public static Result Success()
         {
             return new Result(false, default);
         }
 
+        /// <summary>
+        ///     Creates a success result containing the given value.
+        /// </summary>
         public static Result<T> Success<T>(T value)
         {
             return new Result<T>(false, default, value);
         }
 
+        /// <summary>
+        ///     Creates a success result containing the given value.
+        /// </summary>
         public static Result<T, E> Success<T, E>(T value)
         {
             return new Result<T, E>(false, default, value);

--- a/CSharpFunctionalExtensions/Result/Methods/SuccessIf.cs
+++ b/CSharpFunctionalExtensions/Result/Methods/SuccessIf.cs
@@ -5,6 +5,9 @@ namespace CSharpFunctionalExtensions
 {
     public partial struct Result
     {
+        /// <summary>
+        ///     Creates a result whose success/failure reflects the supplied condition. Opposite of FailureIf().
+        /// </summary>
         public static Result SuccessIf(bool isSuccess, string error)
         {
             return isSuccess
@@ -12,17 +15,26 @@ namespace CSharpFunctionalExtensions
                 : Failure(error);
         }
 
+        /// <summary>
+        ///     Creates a result whose success/failure depends on the supplied predicate. Opposite of FailureIf().
+        /// </summary>
         public static Result SuccessIf(Func<bool> predicate, string error)
         {
             return SuccessIf(predicate(), error);
         }
 
+        /// <summary>
+        ///     Creates a result whose success/failure depends on the supplied predicate. Opposite of FailureIf().
+        /// </summary>
         public static async Task<Result> SuccessIf(Func<Task<bool>> predicate, string error)
         {
             bool isSuccess = await predicate().ConfigureAwait(DefaultConfigureAwait);
             return SuccessIf(isSuccess, error);
         }
 
+        /// <summary>
+        ///     Creates a result whose success/failure reflects the supplied condition. Opposite of FailureIf().
+        /// </summary>
         public static Result<T> SuccessIf<T>(bool isSuccess, T value, string error)
         {
             return isSuccess
@@ -30,17 +42,26 @@ namespace CSharpFunctionalExtensions
                 : Failure<T>(error);
         }
 
+        /// <summary>
+        ///     Creates a result whose success/failure depends on the supplied predicate. Opposite of FailureIf().
+        /// </summary>
         public static Result<T> SuccessIf<T>(Func<bool> predicate, T value, string error)
         {
             return SuccessIf(predicate(), value, error);
         }
 
+        /// <summary>
+        ///     Creates a result whose success/failure depends on the supplied predicate. Opposite of FailureIf().
+        /// </summary>
         public static async Task<Result<T>> SuccessIf<T>(Func<Task<bool>> predicate, T value, string error)
         {
             bool isSuccess = await predicate().ConfigureAwait(DefaultConfigureAwait);
             return SuccessIf(isSuccess, value, error);
         }
 
+        /// <summary>
+        ///     Creates a result whose success/failure reflects the supplied condition. Opposite of FailureIf().
+        /// </summary>
         public static Result<T, E> SuccessIf<T, E>(bool isSuccess, T value, E error)
         {
             return isSuccess
@@ -48,11 +69,17 @@ namespace CSharpFunctionalExtensions
                 : Failure<T, E>(error);
         }
 
+        /// <summary>
+        ///     Creates a result whose success/failure depends on the supplied predicate. Opposite of FailureIf().
+        /// </summary>
         public static Result<T, E> SuccessIf<T, E>(Func<bool> predicate, T value, E error)
         {
             return SuccessIf(predicate(), value, error);
         }
 
+        /// <summary>
+        ///     Creates a result whose success/failure depends on the supplied predicate. Opposite of FailureIf().
+        /// </summary>
         public static async Task<Result<T, E>> SuccessIf<T, E>(Func<Task<bool>> predicate, T value, E error)
         {
             bool isSuccess = await predicate().ConfigureAwait(DefaultConfigureAwait);

--- a/CSharpFunctionalExtensions/Result/Methods/Try.cs
+++ b/CSharpFunctionalExtensions/Result/Methods/Try.cs
@@ -7,6 +7,9 @@ namespace CSharpFunctionalExtensions
     {
         private static readonly Func<Exception, string> DefaultTryErrorHandler = exc => exc.Message;
 
+        /// <summary>
+        ///     Attempts to execute the supplied action. Returns a Result indicating whether the action executed successfully.
+        /// </summary>
         public static Result Try(Action action, Func<Exception, string> errorHandler = null)
         {
             errorHandler = errorHandler ?? DefaultTryErrorHandler;
@@ -23,6 +26,9 @@ namespace CSharpFunctionalExtensions
             }
         }
 
+        /// <summary>
+        ///     Attempts to execute the supplied action. Returns a Result indicating whether the action executed successfully.
+        /// </summary>
         public static async Task<Result> Try(Func<Task> action, Func<Exception, string> errorHandler = null)
         {
             errorHandler = errorHandler ?? DefaultTryErrorHandler;
@@ -39,6 +45,10 @@ namespace CSharpFunctionalExtensions
             }
         }
 
+        /// <summary>
+        ///     Attempts to execute the supplied function. Returns a Result indicating whether the function executed successfully.
+        ///     If the function executed successfully, the result contains its return value.
+        /// </summary>
         public static Result<T> Try<T>(Func<T> func, Func<Exception, string> errorHandler = null)
         {
             errorHandler = errorHandler ?? DefaultTryErrorHandler;
@@ -54,6 +64,10 @@ namespace CSharpFunctionalExtensions
             }
         }
 
+        /// <summary>
+        ///     Attempts to execute the supplied function. Returns a Result indicating whether the function executed successfully.
+        ///     If the function executed successfully, the result contains its return value.
+        /// </summary>
         public static async Task<Result<T>> Try<T>(Func<Task<T>> func, Func<Exception, string> errorHandler = null)
         {
             errorHandler = errorHandler ?? DefaultTryErrorHandler;
@@ -70,6 +84,10 @@ namespace CSharpFunctionalExtensions
             }
         }
 
+        /// <summary>
+        ///     Attempts to execute the supplied function. Returns a Result indicating whether the function executed successfully.
+        ///     If the function executed successfully, the result contains its return value.
+        /// </summary>
         public static Result<T, E> Try<T, E>(Func<T> func, Func<Exception, E> errorHandler)
         {
             try
@@ -83,6 +101,10 @@ namespace CSharpFunctionalExtensions
             }
         }
 
+        /// <summary>
+        ///     Attempts to execute the supplied function. Returns a Result indicating whether the function executed successfully.
+        ///     If the function executed successfully, the result contains its return value.
+        /// </summary>
         public static async Task<Result<T, E>> Try<T, E>(Func<Task<T>> func, Func<Exception, E> errorHandler)
         {
             try

--- a/CSharpFunctionalExtensions/Result/Obsolete/OnBothAsyncRight.cs
+++ b/CSharpFunctionalExtensions/Result/Obsolete/OnBothAsyncRight.cs
@@ -14,7 +14,7 @@ namespace CSharpFunctionalExtensions
             => Finally(result, func);
 
         [Obsolete("Use Finally() instead.")]
-        public static Task<K> OnBoth<T, K, E>(this Result<T, E> result, Func<Result<T>, Task<K>> func)
+        public static Task<K> OnBoth<T, K, E>(this Result<T, E> result, Func<Result<T, E>, Task<K>> func)
             => Finally(result, func);
     }
 }

--- a/CSharpFunctionalExtensions/Result/Obsolete/OnSuccess.cs
+++ b/CSharpFunctionalExtensions/Result/Obsolete/OnSuccess.cs
@@ -29,10 +29,6 @@ namespace CSharpFunctionalExtensions
             => Bind(result, func);
 
         [Obsolete("Use Bind() instead.")]
-        public static Result<K> OnSuccess<T, K, E>(this Result<T, E> result, Func<T, Result<K>> func)
-            => Bind(result, func);
-
-        [Obsolete("Use Bind() instead.")]
         public static Result OnSuccess<T>(this Result<T> result, Func<T, Result> func)
             => Bind(result, func);
 

--- a/CSharpFunctionalExtensions/Result/ResultTE.cs
+++ b/CSharpFunctionalExtensions/Result/ResultTE.cs
@@ -29,21 +29,5 @@ namespace CSharpFunctionalExtensions
 
         void ISerializable.GetObjectData(SerializationInfo info, StreamingContext context)
             => _logic.GetObjectData(info, this);
-
-        public static implicit operator Result(Result<T, E> result)
-        {
-            if (result.IsSuccess)
-                return Result.Success();
-            else
-                return Result.Failure(result.Error.ToString());
-        }
-
-        public static implicit operator Result<T>(Result<T, E> result)
-        {
-            if (result.IsSuccess)
-                return Result.Success(result.Value);
-            else
-                return Result.Failure<T>(result.Error.ToString());
-        }
     }
 }

--- a/CSharpFunctionalExtensions/ValueObject/ValueObject.cs
+++ b/CSharpFunctionalExtensions/ValueObject/ValueObject.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 
 

--- a/LinkTest.4.5/Properties/AssemblyInfo.cs
+++ b/LinkTest.4.5/Properties/AssemblyInfo.cs
@@ -1,5 +1,4 @@
 ﻿using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following

--- a/LinkTest.4.6.1/Properties/AssemblyInfo.cs
+++ b/LinkTest.4.6.1/Properties/AssemblyInfo.cs
@@ -1,5 +1,4 @@
 ﻿using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following


### PR DESCRIPTION
Along with some package updates, this PR addresses the first point of #151, namely the risky implicit conversion operators from `Result<T, E>` to the other types.

Whether or not we make a switch to classes for `Result` or find a way to use interfaces to simplify things (I'm still investigating these questions), these implicit conversions seem like a mistake. Implicitly converting `E` to `string` via `ToString()` definitely feels wrong.

Removing these operators even shook out a few minor bugs/mistakes in the library itself, perhaps hinting at how easily they can be misused inadvertently.

Technically this is a breaking change, although I would think that any breakages are likely to be the good kind... but keen to hear your thoughts.