### PR TITLE
Async code improvements, C#8, Bind() unit tests

### DIFF
--- a/CSharpFunctionalExtensions.Examples/CSharpFunctionalExtensions.Examples.csproj
+++ b/CSharpFunctionalExtensions.Examples/CSharpFunctionalExtensions.Examples.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/CSharpFunctionalExtensions.Tests/CSharpFunctionalExtensions.Tests.csproj
+++ b/CSharpFunctionalExtensions.Tests/CSharpFunctionalExtensions.Tests.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp2.0</TargetFramework>
-    <LangVersion>7.1</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/BindAsyncBothTests.cs
+++ b/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/BindAsyncBothTests.cs
@@ -1,0 +1,112 @@
+﻿using FluentAssertions;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace CSharpFunctionalExtensions.Tests.ResultTests.Extensions
+{
+    public class BindAsyncBothTests : BindTestsBase
+    {
+        [Fact]
+        public void Bind_AsyncBoth_returns_failure_and_does_not_execute_func()
+        {
+            Task<Result> input = Result.Failure(ErrorMessage).AsCompletedTask();
+
+            Result output = input.Bind(GetResultTask).Result;
+
+            AssertFailure(output);
+        }
+
+        [Fact]
+        public void Bind_AsyncBoth_selects_new_result()
+        {
+            Task<Result> input = Result.Success().AsCompletedTask();
+
+            Result output = input.Bind(GetResultTask).Result;
+
+            AssertSuccess(output);
+        }
+
+        [Fact]
+        public void Bind_T_AsyncBoth_returns_failure_and_does_not_execute_func()
+        {
+            Task<Result<T>> input = Result.Failure<T>(ErrorMessage).AsCompletedTask();
+
+            Result output = input.Bind(GetResult_WithParam_Task).Result;
+
+            AssertFailure(output);
+        }
+
+        [Fact]
+        public void Bind_T_AsyncBoth_selects_new_result()
+        {
+            Task<Result<T>> input = Result.Success(T.Value).AsCompletedTask();
+
+            Result output = input.Bind(GetResult_WithParam_Task).Result;
+
+            funcParam.Should().Be(T.Value);
+            AssertSuccess(output);
+        }
+
+        [Fact]
+        public void Bind_K_AsyncBoth_returns_failure_and_does_not_execute_func()
+        {
+            Task<Result> input = Result.Failure(ErrorMessage).AsCompletedTask();
+
+            Result<K> output = input.Bind(GetResult_K_Task).Result;
+
+            AssertFailure(output);
+        }
+
+        [Fact]
+        public void Bind_K_AsyncBoth_selects_new_result()
+        {
+            Task<Result> input = Result.Success().AsCompletedTask();
+
+            Result<K> output = input.Bind(GetResult_K_Task).Result;
+
+            AssertSuccess(output);
+        }
+
+        [Fact]
+        public void Bind_T_K_AsyncBoth_returns_failure_and_does_not_execute_func()
+        {
+            Task<Result<T>> input = Result.Failure<T>(ErrorMessage).AsCompletedTask();
+
+            Result<K> output = input.Bind(GetResult_K_WithParam_Task).Result;
+
+            AssertFailure(output);
+        }
+
+        [Fact]
+        public void Bind_T_K_AsyncBoth_selects_new_result()
+        {
+            Task<Result<T>> input = Result.Success(T.Value).AsCompletedTask();
+
+            Result<K> output = input.Bind(GetResult_K_WithParam_Task).Result;
+
+            funcParam.Should().Be(T.Value);
+            AssertSuccess(output);
+        }
+
+        [Fact]
+        public void Bind_T_K_E_AsyncBoth_returns_failure_and_does_not_execute_func()
+        {
+            Task<Result<T, E>> input = Result.Failure<T, E>(E.Value).AsCompletedTask();
+
+            Result<K, E> output = input.Bind(GetResult_K_E_WithParam_Task).Result;
+
+            AssertFailure(output);
+        }
+
+        [Fact]
+        public void Bind_T_K_E_AsyncBoth_selects_new_result()
+        {
+            Task<Result<T, E>> input = Result.Success<T, E>(T.Value).AsCompletedTask();
+
+            Result<K, E> output = input.Bind(GetResult_K_E_WithParam_Task).Result;
+
+            funcParam.Should().Be(T.Value);
+            AssertSuccess(output);
+        }
+    }
+}

--- a/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/BindAsyncLeftTests.cs
+++ b/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/BindAsyncLeftTests.cs
@@ -1,0 +1,112 @@
+﻿using FluentAssertions;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace CSharpFunctionalExtensions.Tests.ResultTests.Extensions
+{
+    public class BindAsyncLeftTests : BindTestsBase
+    {
+        [Fact]
+        public void Bind_AsyncLeft_returns_failure_and_does_not_execute_func()
+        {
+            Task<Result> input = Result.Failure(ErrorMessage).AsCompletedTask();
+
+            Result output = input.Bind(GetResult).Result;
+
+            AssertFailure(output);
+        }
+
+        [Fact]
+        public void Bind_AsyncLeft_selects_new_result()
+        {
+            Task<Result> input = Result.Success().AsCompletedTask();
+
+            Result output = input.Bind(GetResult).Result;
+
+            AssertSuccess(output);
+        }
+
+        [Fact]
+        public void Bind_T_AsyncLeft_returns_failure_and_does_not_execute_func()
+        {
+            Task<Result<T>> input = Result.Failure<T>(ErrorMessage).AsCompletedTask();
+
+            Result output = input.Bind(GetResult_WithParam).Result;
+
+            AssertFailure(output);
+        }
+
+        [Fact]
+        public void Bind_T_AsyncLeft_selects_new_result()
+        {
+            Task<Result<T>> input = Result.Success(T.Value).AsCompletedTask();
+
+            Result output = input.Bind(GetResult_WithParam).Result;
+
+            funcParam.Should().Be(T.Value);
+            AssertSuccess(output);
+        }
+
+        [Fact]
+        public void Bind_K_AsyncLeft_returns_failure_and_does_not_execute_func()
+        {
+            Task<Result> input = Result.Failure(ErrorMessage).AsCompletedTask();
+
+            Result<K> output = input.Bind(GetResult_K).Result;
+
+            AssertFailure(output);
+        }
+
+        [Fact]
+        public void Bind_K_AsyncLeft_selects_new_result()
+        {
+            Task<Result> input = Result.Success().AsCompletedTask();
+
+            Result<K> output = input.Bind(GetResult_K).Result;
+
+            AssertSuccess(output);
+        }
+
+        [Fact]
+        public void Bind_T_K_AsyncLeft_returns_failure_and_does_not_execute_func()
+        {
+            Task<Result<T>> input = Result.Failure<T>(ErrorMessage).AsCompletedTask();
+
+            Result<K> output = input.Bind(GetResult_K_WithParam).Result;
+
+            AssertFailure(output);
+        }
+
+        [Fact]
+        public void Bind_T_K_AsyncLeft_selects_new_result()
+        {
+            Task<Result<T>> input = Result.Success(T.Value).AsCompletedTask();
+
+            Result<K> output = input.Bind(GetResult_K_WithParam).Result;
+
+            funcParam.Should().Be(T.Value);
+            AssertSuccess(output);
+        }
+
+        [Fact]
+        public void Bind_T_K_E_AsyncLeft_returns_failure_and_does_not_execute_func()
+        {
+            Task<Result<T, E>> input = Result.Failure<T, E>(E.Value).AsCompletedTask();
+
+            Result<K, E> output = input.Bind(GetResult_K_E_WithParam).Result;
+
+            AssertFailure(output);
+        }
+
+        [Fact]
+        public void Bind_T_K_E_AsyncLeft_selects_new_result()
+        {
+            Task<Result<T, E>> input = Result.Success<T, E>(T.Value).AsCompletedTask();
+
+            Result<K, E> output = input.Bind(GetResult_K_E_WithParam).Result;
+
+            funcParam.Should().Be(T.Value);
+            AssertSuccess(output);
+        }
+    }
+}

--- a/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/BindAsyncRightTests.cs
+++ b/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/BindAsyncRightTests.cs
@@ -1,0 +1,111 @@
+﻿using FluentAssertions;
+using Xunit;
+
+namespace CSharpFunctionalExtensions.Tests.ResultTests.Extensions
+{
+    public class BindAsyncRightTests : BindTestsBase
+    {
+        [Fact]
+        public void Bind_AsyncRight_returns_failure_and_does_not_execute_func()
+        {
+            Result input = Result.Failure(ErrorMessage);
+
+            Result output = input.Bind(GetResultTask).Result;
+
+            AssertFailure(output);
+        }
+
+        [Fact]
+        public void Bind_AsyncRight_selects_new_result()
+        {
+            Result input = Result.Success();
+
+            Result output = input.Bind(GetResultTask).Result;
+
+            AssertSuccess(output);
+        }
+
+        [Fact]
+        public void Bind_T_AsyncRight_returns_failure_and_does_not_execute_func()
+        {
+            Result<T> input = Result.Failure<T>(ErrorMessage);
+
+            Result output = input.Bind(GetResult_WithParam_Task).Result;
+
+            AssertFailure(output);
+        }
+
+        [Fact]
+        public void Bind_T_AsyncRight_selects_new_result()
+        {
+            Result<T> input = Result.Success(T.Value);
+
+            Result output = input.Bind(GetResult_WithParam_Task).Result;
+
+            funcParam.Should().Be(T.Value);
+            AssertSuccess(output);
+        }
+
+        [Fact]
+        public void Bind_K_AsyncRight_returns_failure_and_does_not_execute_func()
+        {
+            Result input = Result.Failure(ErrorMessage);
+
+            Result<K> output = input.Bind(GetResult_K_Task).Result;
+
+            AssertFailure(output);
+        }
+
+        [Fact]
+        public void Bind_K_AsyncRight_selects_new_result()
+        {
+            Result input = Result.Success();
+
+            Result<K> output = input.Bind(GetResult_K_Task).Result;
+
+            AssertSuccess(output);
+        }
+
+        [Fact]
+        public void Bind_T_K_AsyncRight_returns_failure_and_does_not_execute_func()
+        {
+            Result<T> input = Result.Failure<T>(ErrorMessage);
+
+            Result<K> output = input.Bind(GetResult_K_WithParam_Task).Result;
+
+            AssertFailure(output);
+        }
+
+        [Fact]
+        public void Bind_T_K_AsyncRight_selects_new_result()
+        {
+            Result<T> input = Result.Success(T.Value);
+
+            Result<K> output = input.Bind(GetResult_K_WithParam_Task).Result;
+
+            funcParam.Should().Be(T.Value);
+            AssertSuccess(output);
+        }
+
+        [Fact]
+        public void Bind_T_K_E_AsyncRight_returns_failure_and_does_not_execute_func()
+        {
+            Result<T, E> input = Result.Failure<T, E>(E.Value);
+
+            Result<K, E> output = input.Bind(GetResult_K_E_WithParam_Task).Result;
+
+            AssertFailure(output);
+        }
+
+        [Fact]
+        public void Bind_T_K_E_AsyncRight_selects_new_result()
+        {
+            Result<T, E> input = Result.Success<T, E>(T.Value);
+
+            Result<K, E> output = input.Bind(GetResult_K_E_WithParam_Task).Result;
+
+            funcParam.Should().Be(T.Value);
+            AssertSuccess(output);
+        }
+    }
+}

--- a/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/BindTests.cs
+++ b/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/BindTests.cs
@@ -1,0 +1,111 @@
+﻿using FluentAssertions;
+using Xunit;
+
+namespace CSharpFunctionalExtensions.Tests.ResultTests.Extensions
+{
+    public class BindTests : BindTestsBase
+    {
+        [Fact]
+        public void Bind_returns_failure_and_does_not_execute_func()
+        {
+            Result input = Result.Failure(ErrorMessage);
+
+            Result output = input.Bind(GetResult);
+
+            AssertFailure(output);
+        }
+
+        [Fact]
+        public void Bind_selects_new_result()
+        {
+            Result input = Result.Success();
+
+            Result output = input.Bind(GetResult);
+
+            AssertSuccess(output);
+        }
+
+        [Fact]
+        public void Bind_T_returns_failure_and_does_not_execute_func()
+        {
+            Result<T> input = Result.Failure<T>(ErrorMessage);
+
+            Result output = input.Bind(GetResult_WithParam);
+
+            AssertFailure(output);
+        }
+
+        [Fact]
+        public void Bind_T_selects_new_result()
+        {
+            Result<T> input = Result.Success(T.Value);
+
+            Result output = input.Bind(GetResult_WithParam);
+
+            funcParam.Should().Be(T.Value);
+            AssertSuccess(output);
+        }
+
+        [Fact]
+        public void Bind_K_returns_failure_and_does_not_execute_func()
+        {
+            Result input = Result.Failure(ErrorMessage);
+
+            Result<K> output = input.Bind(GetResult_K);
+
+            AssertFailure(output);
+        }
+
+        [Fact]
+        public void Bind_K_selects_new_result()
+        {
+            Result input = Result.Success();
+
+            Result<K> output = input.Bind(GetResult_K);
+
+            AssertSuccess(output);
+        }
+
+        [Fact]
+        public void Bind_T_K_returns_failure_and_does_not_execute_func()
+        {
+            Result<T> input = Result.Failure<T>(ErrorMessage);
+
+            Result<K> output = input.Bind(GetResult_K_WithParam);
+
+            AssertFailure(output);
+        }
+
+        [Fact]
+        public void Bind_T_K_selects_new_result()
+        {
+            Result<T> input = Result.Success(T.Value);
+
+            Result<K> output = input.Bind(GetResult_K_WithParam);
+
+            funcParam.Should().Be(T.Value);
+            AssertSuccess(output);
+        }
+
+        [Fact]
+        public void Bind_T_K_E_returns_failure_and_does_not_execute_func()
+        {
+            Result<T, E> input = Result.Failure<T, E>(E.Value);
+
+            Result<K, E> output = input.Bind(GetResult_K_E_WithParam);
+
+            AssertFailure(output);
+        }
+
+        [Fact]
+        public void Bind_T_K_E_selects_new_result()
+        {
+            Result<T, E> input = Result.Success<T, E>(T.Value);
+
+            Result<K, E> output = input.Bind(GetResult_K_E_WithParam);
+
+            funcParam.Should().Be(T.Value);
+            AssertSuccess(output);
+        }
+    }
+}

--- a/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/BindTestsBase.cs
+++ b/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/BindTestsBase.cs
@@ -1,0 +1,108 @@
+﻿using FluentAssertions;
+using System.Threading.Tasks;
+
+namespace CSharpFunctionalExtensions.Tests.ResultTests.Extensions
+{
+    public class BindTestsBase : TestBase
+    {
+        protected const string ErrorMessage = "Error Message";
+
+        protected bool funcExecuted;
+        protected T funcParam;
+
+        protected BindTestsBase()
+        {
+            funcExecuted = false;
+            funcParam = null;
+        }
+
+        protected Result GetResult()
+        {
+            funcExecuted = true;
+            return Result.Success();
+        }
+
+        protected Task<Result> GetResultTask()
+            => GetResult().AsCompletedTask();
+
+        protected Result GetResult_WithParam(T value)
+        {
+            funcExecuted = true;
+            funcParam = value;
+            return Result.Success(value);
+        }
+
+        protected Task<Result> GetResult_WithParam_Task(T value)
+            => GetResult_WithParam(value).AsCompletedTask();
+
+        protected Result<K> GetResult_K()
+        {
+            funcExecuted = true;
+            return Result.Success(K.Value);
+        }
+
+        protected Task<Result<K>> GetResult_K_Task()
+            => GetResult_K().AsCompletedTask();
+
+        protected Result<K> GetResult_K_WithParam(T value)
+        {
+            funcExecuted = true;
+            funcParam = value;
+            return Result.Success(K.Value);
+        }
+
+        protected Task<Result<K>> GetResult_K_WithParam_Task(T value)
+            => GetResult_K_WithParam(value).AsCompletedTask();
+
+        protected Result<K, E> GetResult_K_E_WithParam(T value)
+        {
+            funcExecuted = true;
+            funcParam = value;
+            return Result.Success<K, E>(K.Value);
+        }
+
+        protected Task<Result<K, E>> GetResult_K_E_WithParam_Task(T value)
+            => GetResult_K_E_WithParam(value).AsCompletedTask();
+
+        protected void AssertFailure(Result output)
+        {
+            funcExecuted.Should().BeFalse();
+            output.IsFailure.Should().BeTrue();
+            output.Error.Should().Be(ErrorMessage);
+        }
+
+        protected void AssertFailure(Result<K> output)
+        {
+            funcExecuted.Should().BeFalse();
+            output.IsFailure.Should().BeTrue();
+            output.Error.Should().Be(ErrorMessage);
+        }
+
+        protected void AssertFailure(Result<K, E> output)
+        {
+            funcExecuted.Should().BeFalse();
+            output.IsFailure.Should().BeTrue();
+            output.Error.Should().Be(E.Value);
+        }
+
+        protected void AssertSuccess(Result output)
+        {
+            funcExecuted.Should().BeTrue();
+            output.IsSuccess.Should().BeTrue();
+        }
+
+        protected void AssertSuccess(Result<K> output)
+        {
+            funcExecuted.Should().BeTrue();
+            output.IsSuccess.Should().BeTrue();
+            output.Value.Should().Be(K.Value);
+        }
+
+        protected void AssertSuccess(Result<K, E> output)
+        {
+            funcExecuted.Should().BeTrue();
+            output.IsSuccess.Should().BeTrue();
+            output.Value.Should().Be(K.Value);
+        }
+    }
+}

--- a/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/TestBase.cs
+++ b/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/TestBase.cs
@@ -7,6 +7,11 @@
             public static readonly T Value = new T();
         }
 
+        protected class K
+        {
+            public static readonly K Value = new K();
+        }
+
         protected class E
         {
             public static readonly E Value = new E();

--- a/CSharpFunctionalExtensions.Tests/TaskExtensions.cs
+++ b/CSharpFunctionalExtensions.Tests/TaskExtensions.cs
@@ -1,0 +1,15 @@
+﻿using System.Threading.Tasks;
+
+#if NET40
+using Task = System.Threading.Tasks.TaskEx;
+#else
+using Task = System.Threading.Tasks.Task;
+#endif
+
+namespace CSharpFunctionalExtensions.Tests
+{
+    internal static class TaskExtensions
+    {
+        public static Task<T> AsCompletedTask<T>(this T obj) => Task.FromResult(obj);
+    }
+}

--- a/CSharpFunctionalExtensions/CSharpFunctionalExtensions.csproj
+++ b/CSharpFunctionalExtensions/CSharpFunctionalExtensions.csproj
@@ -12,7 +12,7 @@
     <PackageProjectUrl>https://enterprisecraftsmanship.com/ps-func</PackageProjectUrl>
     <NeutralLanguage>en-US</NeutralLanguage>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
-    <LangVersion>7.1</LangVersion>
+    <LangVersion>8.0</LangVersion>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>

--- a/CSharpFunctionalExtensions/Maybe/AsyncMaybeExtensions.cs
+++ b/CSharpFunctionalExtensions/Maybe/AsyncMaybeExtensions.cs
@@ -7,13 +7,13 @@ namespace CSharpFunctionalExtensions
         public static async Task<Result<T>> ToResult<T>(this Task<Maybe<T>> maybeTask, string errorMessage)
             where T : class
         {
-            Maybe<T> maybe = await maybeTask.ConfigureAwait(Result.DefaultConfigureAwait);
+            Maybe<T> maybe = await maybeTask.DefaultAwait();
             return maybe.ToResult(errorMessage);
         }
 
         public static async Task<Result<T, E>> ToResult<T, E>(this Task<Maybe<T>> maybeTask, E error) where T : class
         {
-            Maybe<T> maybe = await maybeTask.ConfigureAwait(Result.DefaultConfigureAwait);
+            Maybe<T> maybe = await maybeTask.DefaultAwait();
             return maybe.ToResult(error);
         }
     }

--- a/CSharpFunctionalExtensions/Result/Extensions/Bind.cs
+++ b/CSharpFunctionalExtensions/Result/Extensions/Bind.cs
@@ -43,7 +43,7 @@ namespace CSharpFunctionalExtensions
         public static Result Bind<T>(this Result<T> result, Func<T, Result> func)
         {
             if (result.IsFailure)
-                return Result.Failure(result.Error);
+                return result;
 
             return func(result.Value);
         }

--- a/CSharpFunctionalExtensions/Result/Extensions/BindAsyncBoth.cs
+++ b/CSharpFunctionalExtensions/Result/Extensions/BindAsyncBoth.cs
@@ -10,8 +10,8 @@ namespace CSharpFunctionalExtensions
         /// </summary>
         public static async Task<Result<K, E>> Bind<T, K, E>(this Task<Result<T, E>> resultTask, Func<T, Task<Result<K, E>>> func)
         {
-            Result<T, E> result = await resultTask.ConfigureAwait(Result.DefaultConfigureAwait);
-            return await result.Bind(func).ConfigureAwait(Result.DefaultConfigureAwait);
+            Result<T, E> result = await resultTask.DefaultAwait();
+            return await result.Bind(func).DefaultAwait();
         }
 
         /// <summary>
@@ -19,8 +19,8 @@ namespace CSharpFunctionalExtensions
         /// </summary>
         public static async Task<Result<K>> Bind<T, K>(this Task<Result<T>> resultTask, Func<T, Task<Result<K>>> func)
         {
-            Result<T> result = await resultTask.ConfigureAwait(Result.DefaultConfigureAwait);
-            return await result.Bind(func).ConfigureAwait(Result.DefaultConfigureAwait);
+            Result<T> result = await resultTask.DefaultAwait();
+            return await result.Bind(func).DefaultAwait();
         }
 
         /// <summary>
@@ -28,8 +28,8 @@ namespace CSharpFunctionalExtensions
         /// </summary>
         public static async Task<Result<K>> Bind<K>(this Task<Result> resultTask, Func<Task<Result<K>>> func)
         {
-            Result result = await resultTask.ConfigureAwait(Result.DefaultConfigureAwait);
-            return await result.Bind(func).ConfigureAwait(Result.DefaultConfigureAwait);
+            Result result = await resultTask.DefaultAwait();
+            return await result.Bind(func).DefaultAwait();
         }
 
         /// <summary>
@@ -37,8 +37,8 @@ namespace CSharpFunctionalExtensions
         /// </summary>
         public static async Task<Result> Bind<T>(this Task<Result<T>> resultTask, Func<T, Task<Result>> func)
         {
-            Result<T> result = await resultTask.ConfigureAwait(Result.DefaultConfigureAwait);
-            return await result.Bind(func).ConfigureAwait(Result.DefaultConfigureAwait);
+            Result<T> result = await resultTask.DefaultAwait();
+            return await result.Bind(func).DefaultAwait();
         }
 
         /// <summary>
@@ -46,8 +46,8 @@ namespace CSharpFunctionalExtensions
         /// </summary>
         public static async Task<Result> Bind(this Task<Result> resultTask, Func<Task<Result>> func)
         {
-            Result result = await resultTask.ConfigureAwait(Result.DefaultConfigureAwait);
-            return await result.Bind(func).ConfigureAwait(Result.DefaultConfigureAwait);
+            Result result = await resultTask.DefaultAwait();
+            return await result.Bind(func).DefaultAwait();
         }
     }
 }

--- a/CSharpFunctionalExtensions/Result/Extensions/BindAsyncBoth.cs
+++ b/CSharpFunctionalExtensions/Result/Extensions/BindAsyncBoth.cs
@@ -11,11 +11,7 @@ namespace CSharpFunctionalExtensions
         public static async Task<Result<K, E>> Bind<T, K, E>(this Task<Result<T, E>> resultTask, Func<T, Task<Result<K, E>>> func)
         {
             Result<T, E> result = await resultTask.ConfigureAwait(Result.DefaultConfigureAwait);
-
-            if (result.IsFailure)
-                return Result.Failure<K, E>(result.Error);
-
-            return await func(result.Value).ConfigureAwait(Result.DefaultConfigureAwait);
+            return await result.Bind(func).ConfigureAwait(Result.DefaultConfigureAwait);
         }
 
         /// <summary>
@@ -24,11 +20,7 @@ namespace CSharpFunctionalExtensions
         public static async Task<Result<K>> Bind<T, K>(this Task<Result<T>> resultTask, Func<T, Task<Result<K>>> func)
         {
             Result<T> result = await resultTask.ConfigureAwait(Result.DefaultConfigureAwait);
-
-            if (result.IsFailure)
-                return Result.Failure<K>(result.Error);
-
-            return await func(result.Value).ConfigureAwait(Result.DefaultConfigureAwait);
+            return await result.Bind(func).ConfigureAwait(Result.DefaultConfigureAwait);
         }
 
         /// <summary>
@@ -37,11 +29,7 @@ namespace CSharpFunctionalExtensions
         public static async Task<Result<K>> Bind<K>(this Task<Result> resultTask, Func<Task<Result<K>>> func)
         {
             Result result = await resultTask.ConfigureAwait(Result.DefaultConfigureAwait);
-
-            if (result.IsFailure)
-                return Result.Failure<K>(result.Error);
-
-            return await func().ConfigureAwait(Result.DefaultConfigureAwait);
+            return await result.Bind(func).ConfigureAwait(Result.DefaultConfigureAwait);
         }
 
         /// <summary>
@@ -50,11 +38,7 @@ namespace CSharpFunctionalExtensions
         public static async Task<Result> Bind<T>(this Task<Result<T>> resultTask, Func<T, Task<Result>> func)
         {
             Result<T> result = await resultTask.ConfigureAwait(Result.DefaultConfigureAwait);
-
-            if (result.IsFailure)
-                return Result.Failure(result.Error);
-
-            return await func(result.Value).ConfigureAwait(Result.DefaultConfigureAwait);
+            return await result.Bind(func).ConfigureAwait(Result.DefaultConfigureAwait);
         }
 
         /// <summary>
@@ -63,11 +47,7 @@ namespace CSharpFunctionalExtensions
         public static async Task<Result> Bind(this Task<Result> resultTask, Func<Task<Result>> func)
         {
             Result result = await resultTask.ConfigureAwait(Result.DefaultConfigureAwait);
-
-            if (result.IsFailure)
-                return result;
-
-            return await func().ConfigureAwait(Result.DefaultConfigureAwait);
+            return await result.Bind(func).ConfigureAwait(Result.DefaultConfigureAwait);
         }
     }
 }

--- a/CSharpFunctionalExtensions/Result/Extensions/BindAsyncLeft.cs
+++ b/CSharpFunctionalExtensions/Result/Extensions/BindAsyncLeft.cs
@@ -10,7 +10,7 @@ namespace CSharpFunctionalExtensions
         /// </summary>
         public static async Task<Result<K, E>> Bind<T, K, E>(this Task<Result<T, E>> resultTask, Func<T, Result<K, E>> func)
         {
-            Result<T, E> result = await resultTask.ConfigureAwait(Result.DefaultConfigureAwait);
+            Result<T, E> result = await resultTask.DefaultAwait();
             return result.Bind(func);
         }
 
@@ -19,7 +19,7 @@ namespace CSharpFunctionalExtensions
         /// </summary>
         public static async Task<Result<K>> Bind<T, K>(this Task<Result<T>> resultTask, Func<T, Result<K>> func)
         {
-            Result<T> result = await resultTask.ConfigureAwait(Result.DefaultConfigureAwait);
+            Result<T> result = await resultTask.DefaultAwait();
             return result.Bind(func);
         }
 
@@ -28,7 +28,7 @@ namespace CSharpFunctionalExtensions
         /// </summary>
         public static async Task<Result<K>> Bind<K>(this Task<Result> resultTask, Func<Result<K>> func)
         {
-            Result result = await resultTask.ConfigureAwait(Result.DefaultConfigureAwait);
+            Result result = await resultTask.DefaultAwait();
             return result.Bind(func);
         }
 
@@ -37,7 +37,7 @@ namespace CSharpFunctionalExtensions
         /// </summary>
         public static async Task<Result> Bind<T>(this Task<Result<T>> resultTask, Func<T, Result> func)
         {
-            Result<T> result = await resultTask.ConfigureAwait(Result.DefaultConfigureAwait);
+            Result<T> result = await resultTask.DefaultAwait();
             return result.Bind(func);
         }
 
@@ -46,7 +46,7 @@ namespace CSharpFunctionalExtensions
         /// </summary>
         public static async Task<Result> Bind(this Task<Result> resultTask, Func<Result> func)
         {
-            Result result = await resultTask.ConfigureAwait(Result.DefaultConfigureAwait);
+            Result result = await resultTask.DefaultAwait();
             return result.Bind(func);
         }
     }

--- a/CSharpFunctionalExtensions/Result/Extensions/BindAsyncRight.cs
+++ b/CSharpFunctionalExtensions/Result/Extensions/BindAsyncRight.cs
@@ -8,56 +8,56 @@ namespace CSharpFunctionalExtensions
         /// <summary>
         ///     Selects result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.
         /// </summary>
-        public static async Task<Result<K, E>> Bind<T, K, E>(this Result<T, E> result, Func<T, Task<Result<K, E>>> func)
+        public static Task<Result<K, E>> Bind<T, K, E>(this Result<T, E> result, Func<T, Task<Result<K, E>>> func)
         {
             if (result.IsFailure)
-                return Result.Failure<K, E>(result.Error);
+                return Result.Failure<K, E>(result.Error).AsCompletedTask();
 
-            return await func(result.Value).ConfigureAwait(Result.DefaultConfigureAwait);
+            return func(result.Value);
         }
 
         /// <summary>
         ///     Selects result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.
         /// </summary>
-        public static async Task<Result<K>> Bind<T, K>(this Result<T> result, Func<T, Task<Result<K>>> func)
+        public static Task<Result<K>> Bind<T, K>(this Result<T> result, Func<T, Task<Result<K>>> func)
         {
             if (result.IsFailure)
-                return Result.Failure<K>(result.Error);
+                return Result.Failure<K>(result.Error).AsCompletedTask();
 
-            return await func(result.Value).ConfigureAwait(Result.DefaultConfigureAwait);
+            return func(result.Value);
         }
 
         /// <summary>
         ///     Selects result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.
         /// </summary>
-        public static async Task<Result<K>> Bind<K>(this Result result, Func<Task<Result<K>>> func)
+        public static Task<Result<K>> Bind<K>(this Result result, Func<Task<Result<K>>> func)
         {
             if (result.IsFailure)
-                return Result.Failure<K>(result.Error);
+                return Result.Failure<K>(result.Error).AsCompletedTask();
 
-            return await func().ConfigureAwait(Result.DefaultConfigureAwait);
+            return func();
         }
 
         /// <summary>
         ///     Selects result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.
         /// </summary>
-        public static async Task<Result> Bind<T>(this Result<T> result, Func<T, Task<Result>> func)
+        public static Task<Result> Bind<T>(this Result<T> result, Func<T, Task<Result>> func)
         {
             if (result.IsFailure)
-                return Result.Failure(result.Error);
+                return Result.Failure(result.Error).AsCompletedTask();
 
-            return await func(result.Value).ConfigureAwait(Result.DefaultConfigureAwait);
+            return func(result.Value);
         }
 
         /// <summary>
         ///     Selects result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.
         /// </summary>
-        public static async Task<Result> Bind(this Result result, Func<Task<Result>> func)
+        public static Task<Result> Bind(this Result result, Func<Task<Result>> func)
         {
             if (result.IsFailure)
-                return result;
+                return result.AsCompletedTask();
 
-            return await func().ConfigureAwait(Result.DefaultConfigureAwait);
+            return func();
         }
     }
 }

--- a/CSharpFunctionalExtensions/Result/Extensions/CombineAsyncLeft.cs
+++ b/CSharpFunctionalExtensions/Result/Extensions/CombineAsyncLeft.cs
@@ -14,115 +14,115 @@ namespace CSharpFunctionalExtensions
     {
         public static async Task<Result> Combine(this IEnumerable<Task<Result>> tasks, string errorMessageSeparator = null)
         {
-            Result[] results = await Task.WhenAll(tasks).ConfigureAwait(Result.DefaultConfigureAwait);
+            Result[] results = await Task.WhenAll(tasks).DefaultAwait();
             return results.Combine(errorMessageSeparator);
         }
 
         public static async Task<Result<IEnumerable<T>, E>> Combine<T, E>(this IEnumerable<Task<Result<T, E>>> tasks, Func<IEnumerable<E>, E> composerError)
         {
-            Result<T, E>[] results = await Task.WhenAll(tasks).ConfigureAwait(Result.DefaultConfigureAwait);
+            Result<T, E>[] results = await Task.WhenAll(tasks).DefaultAwait();
             return results.Combine(composerError);
         }
 
         public static async Task<Result<IEnumerable<T>, E>> Combine<T, E>(this IEnumerable<Task<Result<T, E>>> tasks)
             where E : ICombine
         {
-            Result<T, E>[] results = await Task.WhenAll(tasks).ConfigureAwait(Result.DefaultConfigureAwait);
+            Result<T, E>[] results = await Task.WhenAll(tasks).DefaultAwait();
             return results.Combine();
         }
 
         public static async Task<Result<IEnumerable<T>>> Combine<T>(this IEnumerable<Task<Result<T>>> tasks, string errorMessageSeparator = null)
         {
-            Result<T>[] results = await Task.WhenAll(tasks).ConfigureAwait(Result.DefaultConfigureAwait);
+            Result<T>[] results = await Task.WhenAll(tasks).DefaultAwait();
             return results.Combine(errorMessageSeparator);
         }
 
         public static async Task<Result> Combine(this Task<IEnumerable<Result>> task, string errorMessageSeparator = null)
         {
-            IEnumerable<Result> results = await task.ConfigureAwait(Result.DefaultConfigureAwait);
+            IEnumerable<Result> results = await task.DefaultAwait();
             return results.Combine(errorMessageSeparator);
         }
 
         public static async Task<Result<IEnumerable<T>, E>> Combine<T, E>(this Task<IEnumerable<Result<T, E>>> task, Func<IEnumerable<E>, E> composerError)
         {
-            IEnumerable<Result<T, E>> results = await task.ConfigureAwait(Result.DefaultConfigureAwait);
+            IEnumerable<Result<T, E>> results = await task.DefaultAwait();
             return results.Combine(composerError);
         }
 
         public static async Task<Result<IEnumerable<T>, E>> Combine<T, E>(this Task<IEnumerable<Result<T, E>>> task)
             where E : ICombine
         {
-            IEnumerable<Result<T, E>> results = await task.ConfigureAwait(Result.DefaultConfigureAwait);
+            IEnumerable<Result<T, E>> results = await task.DefaultAwait();
             return results.Combine();
         }
 
         public static async Task<Result<IEnumerable<T>>> Combine<T>(this Task<IEnumerable<Result<T>>> task, string errorMessageSeparator = null)
         {
-            IEnumerable<Result<T>> results = await task.ConfigureAwait(Result.DefaultConfigureAwait);
+            IEnumerable<Result<T>> results = await task.DefaultAwait();
             return results.Combine(errorMessageSeparator);
         }
 
         public static async Task<Result> Combine(this Task<IEnumerable<Task<Result>>> task, string errorMessageSeparator = null)
         {
-            IEnumerable<Task<Result>> tasks = await task.ConfigureAwait(Result.DefaultConfigureAwait);
-            return await tasks.Combine(errorMessageSeparator).ConfigureAwait(Result.DefaultConfigureAwait);
+            IEnumerable<Task<Result>> tasks = await task.DefaultAwait();
+            return await tasks.Combine(errorMessageSeparator).DefaultAwait();
         }
 
         public static async Task<Result<IEnumerable<T>, E>> Combine<T, E>(this Task<IEnumerable<Task<Result<T, E>>>> task, Func<IEnumerable<E>, E> composerError)
         {
-            IEnumerable<Task<Result<T, E>>> tasks = await task.ConfigureAwait(Result.DefaultConfigureAwait);
-            return await tasks.Combine(composerError).ConfigureAwait(Result.DefaultConfigureAwait);
+            IEnumerable<Task<Result<T, E>>> tasks = await task.DefaultAwait();
+            return await tasks.Combine(composerError).DefaultAwait();
         }
 
         public static async Task<Result<IEnumerable<T>, E>> Combine<T, E>(this Task<IEnumerable<Task<Result<T, E>>>> task)
             where E : ICombine
         {
-            IEnumerable<Task<Result<T, E>>> tasks = await task.ConfigureAwait(Result.DefaultConfigureAwait);
-            return await tasks.Combine().ConfigureAwait(Result.DefaultConfigureAwait);
+            IEnumerable<Task<Result<T, E>>> tasks = await task.DefaultAwait();
+            return await tasks.Combine().DefaultAwait();
         }
 
         public static async Task<Result<IEnumerable<T>>> Combine<T>(this Task<IEnumerable<Task<Result<T>>>> task, string errorMessageSeparator = null)
         {
-            IEnumerable<Task<Result<T>>> tasks = await task.ConfigureAwait(Result.DefaultConfigureAwait);
-            return await tasks.Combine(errorMessageSeparator).ConfigureAwait(Result.DefaultConfigureAwait);
+            IEnumerable<Task<Result<T>>> tasks = await task.DefaultAwait();
+            return await tasks.Combine(errorMessageSeparator).DefaultAwait();
         }
 
         public static async Task<Result<K, E>> Combine<T, K, E>(this IEnumerable<Task<Result<T, E>>> tasks, Func<IEnumerable<T>, K> composer, Func<IEnumerable<E>, E> composerError)
         {
-            IEnumerable<Result<T, E>> results = await Task.WhenAll(tasks).ConfigureAwait(Result.DefaultConfigureAwait);
+            IEnumerable<Result<T, E>> results = await Task.WhenAll(tasks).DefaultAwait();
             return results.Combine(composer, composerError);
         }
 
         public static async Task<Result<K, E>> Combine<T, K, E>(this IEnumerable<Task<Result<T, E>>> tasks, Func<IEnumerable<T>, K> composer)
             where E : ICombine
         {
-            IEnumerable<Result<T, E>> results = await Task.WhenAll(tasks).ConfigureAwait(Result.DefaultConfigureAwait);
+            IEnumerable<Result<T, E>> results = await Task.WhenAll(tasks).DefaultAwait();
             return results.Combine(composer);
         }
 
         public static async Task<Result<K>> Combine<T, K>(this IEnumerable<Task<Result<T>>> tasks, Func<IEnumerable<T>, K> composer, string errorMessageSeparator = null)
         {
-            IEnumerable<Result<T>> results = await Task.WhenAll(tasks).ConfigureAwait(Result.DefaultConfigureAwait);
+            IEnumerable<Result<T>> results = await Task.WhenAll(tasks).DefaultAwait();
             return results.Combine(composer, errorMessageSeparator);
         }
 
         public static async Task<Result<K, E>> Combine<T, K, E>(this Task<IEnumerable<Task<Result<T, E>>>> task, Func<IEnumerable<T>, K> composer, Func<IEnumerable<E>, E> composerError)
         {
-            IEnumerable<Task<Result<T, E>>> tasks = await task.ConfigureAwait(Result.DefaultConfigureAwait);
-            return await tasks.Combine(composer, composerError).ConfigureAwait(Result.DefaultConfigureAwait);
+            IEnumerable<Task<Result<T, E>>> tasks = await task.DefaultAwait();
+            return await tasks.Combine(composer, composerError).DefaultAwait();
         }
 
         public static async Task<Result<K, E>> Combine<T, K, E>(this Task<IEnumerable<Task<Result<T, E>>>> task, Func<IEnumerable<T>, K> composer)
             where E : ICombine
         {
-            IEnumerable<Task<Result<T, E>>> tasks = await task.ConfigureAwait(Result.DefaultConfigureAwait);
-            return await tasks.Combine(composer).ConfigureAwait(Result.DefaultConfigureAwait);
+            IEnumerable<Task<Result<T, E>>> tasks = await task.DefaultAwait();
+            return await tasks.Combine(composer).DefaultAwait();
         }
 
         public static async Task<Result<K>> Combine<T, K>(this Task<IEnumerable<Task<Result<T>>>> task, Func<IEnumerable<T>, K> composer, string errorMessageSeparator = null)
         {
-            IEnumerable<Task<Result<T>>> tasks = await task.ConfigureAwait(Result.DefaultConfigureAwait);
-            return await tasks.Combine(composer, errorMessageSeparator).ConfigureAwait(Result.DefaultConfigureAwait);
+            IEnumerable<Task<Result<T>>> tasks = await task.DefaultAwait();
+            return await tasks.Combine(composer, errorMessageSeparator).DefaultAwait();
         }
     }
 }

--- a/CSharpFunctionalExtensions/Result/Extensions/EnsureAsyncBoth.cs
+++ b/CSharpFunctionalExtensions/Result/Extensions/EnsureAsyncBoth.cs
@@ -10,12 +10,12 @@ namespace CSharpFunctionalExtensions
         /// </summary>
         public static async Task<Result<T>> Ensure<T>(this Task<Result<T>> resultTask, Func<T, Task<bool>> predicate, string errorMessage)
         {
-            Result<T> result = await resultTask.ConfigureAwait(Result.DefaultConfigureAwait);
+            Result<T> result = await resultTask.DefaultAwait();
 
             if (result.IsFailure)
                 return result;
 
-            if (!await predicate(result.Value).ConfigureAwait(Result.DefaultConfigureAwait))
+            if (!await predicate(result.Value).DefaultAwait())
                 return Result.Failure<T>(errorMessage);
 
             return result;
@@ -26,12 +26,12 @@ namespace CSharpFunctionalExtensions
         /// </summary>
         public static async Task<Result<T, E>> Ensure<T, E>(this Task<Result<T, E>> resultTask, Func<T, Task<bool>> predicate, E error)
         {
-            Result<T, E> result = await resultTask.ConfigureAwait(Result.DefaultConfigureAwait);
+            Result<T, E> result = await resultTask.DefaultAwait();
 
             if (result.IsFailure)
                 return result;
 
-            if (!await predicate(result.Value).ConfigureAwait(Result.DefaultConfigureAwait))
+            if (!await predicate(result.Value).DefaultAwait())
                 return Result.Failure<T, E>(error);
 
             return result;
@@ -42,12 +42,12 @@ namespace CSharpFunctionalExtensions
         /// </summary>
         public static async Task<Result> Ensure(this Task<Result> resultTask, Func<Task<bool>> predicate, string errorMessage)
         {
-            Result result = await resultTask.ConfigureAwait(Result.DefaultConfigureAwait);
+            Result result = await resultTask.DefaultAwait();
 
             if (result.IsFailure)
                 return result;
 
-            if (!await predicate().ConfigureAwait(Result.DefaultConfigureAwait))
+            if (!await predicate().DefaultAwait())
                 return Result.Failure(errorMessage);
 
             return result;

--- a/CSharpFunctionalExtensions/Result/Extensions/EnsureAsyncLeft.cs
+++ b/CSharpFunctionalExtensions/Result/Extensions/EnsureAsyncLeft.cs
@@ -10,7 +10,7 @@ namespace CSharpFunctionalExtensions
         /// </summary>
         public static async Task<Result<T>> Ensure<T>(this Task<Result<T>> resultTask, Func<T, bool> predicate, string errorMessage)
         {
-            Result<T> result = await resultTask.ConfigureAwait(Result.DefaultConfigureAwait);
+            Result<T> result = await resultTask.DefaultAwait();
             return result.Ensure(predicate, errorMessage);
         }
 
@@ -20,7 +20,7 @@ namespace CSharpFunctionalExtensions
         public static async Task<Result<T, E>> Ensure<T, E>(this Task<Result<T, E>> resultTask,
             Func<T, bool> predicate, E error)
         {
-            Result<T, E> result = await resultTask.ConfigureAwait(Result.DefaultConfigureAwait);
+            Result<T, E> result = await resultTask.DefaultAwait();
             return result.Ensure(predicate, error);
         }
 
@@ -29,7 +29,7 @@ namespace CSharpFunctionalExtensions
         /// </summary>
         public static async Task<Result> Ensure(this Task<Result> resultTask, Func<bool> predicate, string errorMessage)
         {
-            Result result = await resultTask.ConfigureAwait(Result.DefaultConfigureAwait);
+            Result result = await resultTask.DefaultAwait();
             return result.Ensure(predicate, errorMessage);
         }
     }

--- a/CSharpFunctionalExtensions/Result/Extensions/EnsureAsyncRight.cs
+++ b/CSharpFunctionalExtensions/Result/Extensions/EnsureAsyncRight.cs
@@ -13,7 +13,7 @@ namespace CSharpFunctionalExtensions
             if (result.IsFailure)
                 return result;
 
-            if (!await predicate(result.Value).ConfigureAwait(Result.DefaultConfigureAwait))
+            if (!await predicate(result.Value).DefaultAwait())
                 return Result.Failure<T>(errorMessage);
 
             return result;
@@ -28,7 +28,7 @@ namespace CSharpFunctionalExtensions
             if (result.IsFailure)
                 return result;
 
-            if (!await predicate(result.Value).ConfigureAwait(Result.DefaultConfigureAwait))
+            if (!await predicate(result.Value).DefaultAwait())
                 return Result.Failure<T, E>(error);
 
             return result;
@@ -42,7 +42,7 @@ namespace CSharpFunctionalExtensions
             if (result.IsFailure)
                 return result;
 
-            if (!await predicate().ConfigureAwait(Result.DefaultConfigureAwait))
+            if (!await predicate().DefaultAwait())
                 return Result.Failure(errorMessage);
 
             return result;

--- a/CSharpFunctionalExtensions/Result/Extensions/FinallyAsyncBoth.cs
+++ b/CSharpFunctionalExtensions/Result/Extensions/FinallyAsyncBoth.cs
@@ -10,8 +10,8 @@ namespace CSharpFunctionalExtensions
         /// </summary>
         public static async Task<T> Finally<T>(this Task<Result> resultTask, Func<Result, Task<T>> func)
         {
-            Result result = await resultTask.ConfigureAwait(Result.DefaultConfigureAwait);
-            return await func(result).ConfigureAwait(Result.DefaultConfigureAwait);
+            Result result = await resultTask.DefaultAwait();
+            return await func(result).DefaultAwait();
         }
 
         /// <summary>
@@ -19,8 +19,8 @@ namespace CSharpFunctionalExtensions
         /// </summary>
         public static async Task<K> Finally<T, K>(this Task<Result<T>> resultTask, Func<Result<T>, Task<K>> func)
         {
-            Result<T> result = await resultTask.ConfigureAwait(Result.DefaultConfigureAwait);
-            return await func(result).ConfigureAwait(Result.DefaultConfigureAwait);
+            Result<T> result = await resultTask.DefaultAwait();
+            return await func(result).DefaultAwait();
         }
 
         /// <summary>
@@ -29,8 +29,8 @@ namespace CSharpFunctionalExtensions
         public static async Task<K> Finally<T, K, E>(this Task<Result<T, E>> resultTask,
             Func<Result<T, E>, Task<K>> func)
         {
-            Result<T, E> result = await resultTask.ConfigureAwait(Result.DefaultConfigureAwait);
-            return await func(result).ConfigureAwait(Result.DefaultConfigureAwait);
+            Result<T, E> result = await resultTask.DefaultAwait();
+            return await func(result).DefaultAwait();
         }
     }
 }

--- a/CSharpFunctionalExtensions/Result/Extensions/FinallyAsyncLeft.cs
+++ b/CSharpFunctionalExtensions/Result/Extensions/FinallyAsyncLeft.cs
@@ -10,7 +10,7 @@ namespace CSharpFunctionalExtensions
         /// </summary>
         public static async Task<T> Finally<T>(this Task<Result> resultTask, Func<Result, T> func)
         {
-            Result result = await resultTask.ConfigureAwait(Result.DefaultConfigureAwait);
+            Result result = await resultTask.DefaultAwait();
             return result.Finally(func);
         }
 
@@ -19,7 +19,7 @@ namespace CSharpFunctionalExtensions
         /// </summary>
         public static async Task<K> Finally<T, K>(this Task<Result<T>> resultTask, Func<Result<T>, K> func)
         {
-            Result<T> result = await resultTask.ConfigureAwait(Result.DefaultConfigureAwait);
+            Result<T> result = await resultTask.DefaultAwait();
             return result.Finally(func);
         }
 
@@ -29,7 +29,7 @@ namespace CSharpFunctionalExtensions
         public static async Task<K> Finally<T, K, E>(this Task<Result<T, E>> resultTask,
             Func<Result<T, E>, K> func)
         {
-            Result<T, E> result = await resultTask.ConfigureAwait(Result.DefaultConfigureAwait);
+            Result<T, E> result = await resultTask.DefaultAwait();
             return result.Finally(func);
         }
     }

--- a/CSharpFunctionalExtensions/Result/Extensions/MapAsyncBoth.cs
+++ b/CSharpFunctionalExtensions/Result/Extensions/MapAsyncBoth.cs
@@ -10,12 +10,12 @@ namespace CSharpFunctionalExtensions
         /// </summary>
         public static async Task<Result<K, E>> Map<T, K, E>(this Task<Result<T, E>> resultTask, Func<T, Task<K>> func)
         {
-            Result<T, E> result = await resultTask.ConfigureAwait(Result.DefaultConfigureAwait);
+            Result<T, E> result = await resultTask.DefaultAwait();
 
             if (result.IsFailure)
                 return Result.Failure<K, E>(result.Error);
 
-            K value = await func(result.Value).ConfigureAwait(Result.DefaultConfigureAwait);
+            K value = await func(result.Value).DefaultAwait();
 
             return Result.Success<K, E>(value);
         }
@@ -25,12 +25,12 @@ namespace CSharpFunctionalExtensions
         /// </summary>
         public static async Task<Result<K>> Map<T, K>(this Task<Result<T>> resultTask, Func<T, Task<K>> func)
         {
-            Result<T> result = await resultTask.ConfigureAwait(Result.DefaultConfigureAwait);
+            Result<T> result = await resultTask.DefaultAwait();
 
             if (result.IsFailure)
                 return Result.Failure<K>(result.Error);
 
-            K value = await func(result.Value).ConfigureAwait(Result.DefaultConfigureAwait);
+            K value = await func(result.Value).DefaultAwait();
 
             return Result.Success(value);
         }
@@ -40,12 +40,12 @@ namespace CSharpFunctionalExtensions
         /// </summary>
         public static async Task<Result<K>> Map<K>(this Task<Result> resultTask, Func<Task<K>> func)
         {
-            Result result = await resultTask.ConfigureAwait(Result.DefaultConfigureAwait);
+            Result result = await resultTask.DefaultAwait();
 
             if (result.IsFailure)
                 return Result.Failure<K>(result.Error);
 
-            K value = await func().ConfigureAwait(Result.DefaultConfigureAwait);
+            K value = await func().DefaultAwait();
 
             return Result.Success(value);
         }

--- a/CSharpFunctionalExtensions/Result/Extensions/MapAsyncLeft.cs
+++ b/CSharpFunctionalExtensions/Result/Extensions/MapAsyncLeft.cs
@@ -10,7 +10,7 @@ namespace CSharpFunctionalExtensions
         /// </summary>
         public static async Task<Result<K, E>> Map<T, K, E>(this Task<Result<T, E>> resultTask, Func<T, K> func)
         {
-            Result<T, E> result = await resultTask.ConfigureAwait(Result.DefaultConfigureAwait);
+            Result<T, E> result = await resultTask.DefaultAwait();
             return result.Map(func);
         }
 
@@ -19,7 +19,7 @@ namespace CSharpFunctionalExtensions
         /// </summary>
         public static async Task<Result<K>> Map<T, K>(this Task<Result<T>> resultTask, Func<T, K> func)
         {
-            Result<T> result = await resultTask.ConfigureAwait(Result.DefaultConfigureAwait);
+            Result<T> result = await resultTask.DefaultAwait();
             return result.Map(func);
         }
 
@@ -28,7 +28,7 @@ namespace CSharpFunctionalExtensions
         /// </summary>
         public static async Task<Result<K>> Map<K>(this Task<Result> resultTask, Func<K> func)
         {
-            Result result = await resultTask.ConfigureAwait(Result.DefaultConfigureAwait);
+            Result result = await resultTask.DefaultAwait();
             return result.Map(func);
         }
     }

--- a/CSharpFunctionalExtensions/Result/Extensions/MapAsyncRight.cs
+++ b/CSharpFunctionalExtensions/Result/Extensions/MapAsyncRight.cs
@@ -13,7 +13,7 @@ namespace CSharpFunctionalExtensions
             if (result.IsFailure)
                 return Result.Failure<K, E>(result.Error);
 
-            K value = await func(result.Value).ConfigureAwait(Result.DefaultConfigureAwait);
+            K value = await func(result.Value).DefaultAwait();
 
             return Result.Success<K, E>(value);
         }
@@ -26,7 +26,7 @@ namespace CSharpFunctionalExtensions
             if (result.IsFailure)
                 return Result.Failure<K>(result.Error);
 
-            K value = await func(result.Value).ConfigureAwait(Result.DefaultConfigureAwait);
+            K value = await func(result.Value).DefaultAwait();
 
             return Result.Success(value);
         }
@@ -39,7 +39,7 @@ namespace CSharpFunctionalExtensions
             if (result.IsFailure)
                 return Result.Failure<K>(result.Error);
 
-            K value = await func().ConfigureAwait(Result.DefaultConfigureAwait);
+            K value = await func().DefaultAwait();
 
             return Result.Success(value);
         }

--- a/CSharpFunctionalExtensions/Result/Extensions/OnFailureAsyncBoth.cs
+++ b/CSharpFunctionalExtensions/Result/Extensions/OnFailureAsyncBoth.cs
@@ -10,11 +10,11 @@ namespace CSharpFunctionalExtensions
         /// </summary>
         public static async Task<Result<T, E>> OnFailure<T, E>(this Task<Result<T, E>> resultTask, Func<Task> func)
         {
-            Result<T, E> result = await resultTask.ConfigureAwait(Result.DefaultConfigureAwait);
+            Result<T, E> result = await resultTask.DefaultAwait();
 
             if (result.IsFailure)
             {
-                await func().ConfigureAwait(Result.DefaultConfigureAwait);
+                await func().DefaultAwait();
             }
 
             return result;
@@ -25,11 +25,11 @@ namespace CSharpFunctionalExtensions
         /// </summary>
         public static async Task<Result<T>> OnFailure<T>(this Task<Result<T>> resultTask, Func<Task> func)
         {
-            Result<T> result = await resultTask.ConfigureAwait(Result.DefaultConfigureAwait);
+            Result<T> result = await resultTask.DefaultAwait();
 
             if (result.IsFailure)
             {
-                await func().ConfigureAwait(Result.DefaultConfigureAwait);
+                await func().DefaultAwait();
             }
 
             return result;
@@ -40,11 +40,11 @@ namespace CSharpFunctionalExtensions
         /// </summary>
         public static async Task<Result> OnFailure(this Task<Result> resultTask, Func<Task> func)
         {
-            Result result = await resultTask.ConfigureAwait(Result.DefaultConfigureAwait);
+            Result result = await resultTask.DefaultAwait();
 
             if (result.IsFailure)
             {
-                await func().ConfigureAwait(Result.DefaultConfigureAwait);
+                await func().DefaultAwait();
             }
 
             return result;
@@ -55,11 +55,11 @@ namespace CSharpFunctionalExtensions
         /// </summary>
         public static async Task<Result<T>> OnFailure<T>(this Task<Result<T>> resultTask, Func<string, Task> func)
         {
-            Result<T> result = await resultTask.ConfigureAwait(Result.DefaultConfigureAwait);
+            Result<T> result = await resultTask.DefaultAwait();
 
             if (result.IsFailure)
             {
-                await func(result.Error).ConfigureAwait(Result.DefaultConfigureAwait);
+                await func(result.Error).DefaultAwait();
             }
 
             return result;
@@ -70,11 +70,11 @@ namespace CSharpFunctionalExtensions
         /// </summary>
         public static async Task<Result<T, E>> OnFailure<T, E>(this Task<Result<T, E>> resultTask, Func<E, Task> func)
         {
-            Result<T, E> result = await resultTask.ConfigureAwait(Result.DefaultConfigureAwait);
+            Result<T, E> result = await resultTask.DefaultAwait();
 
             if (result.IsFailure)
             {
-                await func(result.Error).ConfigureAwait(Result.DefaultConfigureAwait);
+                await func(result.Error).DefaultAwait();
             }
 
             return result;

--- a/CSharpFunctionalExtensions/Result/Extensions/OnFailureAsyncLeft.cs
+++ b/CSharpFunctionalExtensions/Result/Extensions/OnFailureAsyncLeft.cs
@@ -10,7 +10,7 @@ namespace CSharpFunctionalExtensions
         /// </summary>
         public static async Task<Result<T>> OnFailure<T>(this Task<Result<T>> resultTask, Action action)
         {
-            Result<T> result = await resultTask.ConfigureAwait(Result.DefaultConfigureAwait);
+            Result<T> result = await resultTask.DefaultAwait();
             return result.OnFailure(action);
         }
 
@@ -19,7 +19,7 @@ namespace CSharpFunctionalExtensions
         /// </summary>
         public static async Task<Result> OnFailure(this Task<Result> resultTask, Action action)
         {
-            Result result = await resultTask.ConfigureAwait(Result.DefaultConfigureAwait);
+            Result result = await resultTask.DefaultAwait();
             return result.OnFailure(action);
         }
 
@@ -28,7 +28,7 @@ namespace CSharpFunctionalExtensions
         /// </summary>
         public static async Task<Result<T>> OnFailure<T>(this Task<Result<T>> resultTask, Action<string> action)
         {
-            Result<T> result = await resultTask.ConfigureAwait(Result.DefaultConfigureAwait);
+            Result<T> result = await resultTask.DefaultAwait();
             return result.OnFailure(action);
         }
 
@@ -37,7 +37,7 @@ namespace CSharpFunctionalExtensions
         /// </summary>
         public static async Task<Result<T, E>> OnFailure<T, E>(this Task<Result<T, E>> resultTask, Action<E> action)
         {
-            Result<T, E> result = await resultTask.ConfigureAwait(Result.DefaultConfigureAwait);
+            Result<T, E> result = await resultTask.DefaultAwait();
             return result.OnFailure(action);
         }
 
@@ -46,7 +46,7 @@ namespace CSharpFunctionalExtensions
         /// </summary>
         public static async Task<Result> OnFailure(this Task<Result> resultTask, Action<string> action)
         {
-            Result result = await resultTask.ConfigureAwait(Result.DefaultConfigureAwait);
+            Result result = await resultTask.DefaultAwait();
             return result.OnFailure(action);
         }
     }

--- a/CSharpFunctionalExtensions/Result/Extensions/OnFailureAsyncRight.cs
+++ b/CSharpFunctionalExtensions/Result/Extensions/OnFailureAsyncRight.cs
@@ -12,7 +12,7 @@ namespace CSharpFunctionalExtensions
         {
             if (result.IsFailure)
             {
-                await func().ConfigureAwait(Result.DefaultConfigureAwait);
+                await func().DefaultAwait();
             }
 
             return result;
@@ -25,7 +25,7 @@ namespace CSharpFunctionalExtensions
         {
             if (result.IsFailure)
             {
-                await func().ConfigureAwait(Result.DefaultConfigureAwait);
+                await func().DefaultAwait();
             }
 
             return result;
@@ -38,7 +38,7 @@ namespace CSharpFunctionalExtensions
         {
             if (result.IsFailure)
             {
-                await func().ConfigureAwait(Result.DefaultConfigureAwait);
+                await func().DefaultAwait();
             }
 
             return result;
@@ -51,7 +51,7 @@ namespace CSharpFunctionalExtensions
         {
             if (result.IsFailure)
             {
-                await func(result.Error).ConfigureAwait(Result.DefaultConfigureAwait);
+                await func(result.Error).DefaultAwait();
             }
 
             return result;
@@ -64,7 +64,7 @@ namespace CSharpFunctionalExtensions
         {
             if (result.IsFailure)
             {
-                await func(result.Error).ConfigureAwait(Result.DefaultConfigureAwait);
+                await func(result.Error).DefaultAwait();
             }
 
             return result;

--- a/CSharpFunctionalExtensions/Result/Extensions/OnFailureCompensateAsyncBoth.cs
+++ b/CSharpFunctionalExtensions/Result/Extensions/OnFailureCompensateAsyncBoth.cs
@@ -8,40 +8,40 @@ namespace CSharpFunctionalExtensions
         public static async Task<Result<T, E>> OnFailureCompensate<T, E>(this Task<Result<T, E>> resultTask,
             Func<Task<Result<T, E>>> func)
         {
-            Result<T, E> result = await resultTask.ConfigureAwait(Result.DefaultConfigureAwait);
+            Result<T, E> result = await resultTask.DefaultAwait();
 
             if (result.IsFailure)
-                return await func().ConfigureAwait(Result.DefaultConfigureAwait);
+                return await func().DefaultAwait();
 
             return result;
         }
 
         public static async Task<Result<T>> OnFailureCompensate<T>(this Task<Result<T>> resultTask, Func<Task<Result<T>>> func)
         {
-            Result<T> result = await resultTask.ConfigureAwait(Result.DefaultConfigureAwait);
+            Result<T> result = await resultTask.DefaultAwait();
 
             if (result.IsFailure)
-                return await func().ConfigureAwait(Result.DefaultConfigureAwait);
+                return await func().DefaultAwait();
 
             return result;
         }
 
         public static async Task<Result> OnFailureCompensate(this Task<Result> resultTask, Func<Task<Result>> func)
         {
-            Result result = await resultTask.ConfigureAwait(Result.DefaultConfigureAwait);
+            Result result = await resultTask.DefaultAwait();
 
             if (result.IsFailure)
-                return await func().ConfigureAwait(Result.DefaultConfigureAwait);
+                return await func().DefaultAwait();
 
             return result;
         }
 
         public static async Task<Result<T>> OnFailureCompensate<T>(this Task<Result<T>> resultTask, Func<string, Task<Result<T>>> func)
         {
-            Result<T> result = await resultTask.ConfigureAwait(Result.DefaultConfigureAwait);
+            Result<T> result = await resultTask.DefaultAwait();
 
             if (result.IsFailure)
-                return await func(result.Error).ConfigureAwait(Result.DefaultConfigureAwait);
+                return await func(result.Error).DefaultAwait();
 
             return result;
         }
@@ -49,10 +49,10 @@ namespace CSharpFunctionalExtensions
         public static async Task<Result<T, E>> OnFailureCompensate<T, E>(this Task<Result<T, E>> resultTask,
             Func<E, Task<Result<T, E>>> func)
         {
-            Result<T, E> result = await resultTask.ConfigureAwait(Result.DefaultConfigureAwait);
+            Result<T, E> result = await resultTask.DefaultAwait();
 
             if (result.IsFailure)
-                return await func(result.Error).ConfigureAwait(Result.DefaultConfigureAwait);
+                return await func(result.Error).DefaultAwait();
 
             return result;
         }

--- a/CSharpFunctionalExtensions/Result/Extensions/OnFailureCompensateAsyncLeft.cs
+++ b/CSharpFunctionalExtensions/Result/Extensions/OnFailureCompensateAsyncLeft.cs
@@ -7,32 +7,32 @@ namespace CSharpFunctionalExtensions
     {
         public static async Task<Result<T>> OnFailureCompensate<T>(this Task<Result<T>> resultTask, Func<Result<T>> func)
         {
-            Result<T> result = await resultTask.ConfigureAwait(Result.DefaultConfigureAwait);
+            Result<T> result = await resultTask.DefaultAwait();
             return result.OnFailureCompensate(func);
         }
 
         public static async Task<Result> OnFailureCompensate(this Task<Result> resultTask, Func<Result> func)
         {
-            Result result = await resultTask.ConfigureAwait(Result.DefaultConfigureAwait);
+            Result result = await resultTask.DefaultAwait();
             return result.OnFailureCompensate(func);
         }
 
         public static async Task<Result<T>> OnFailureCompensate<T>(this Task<Result<T>> resultTask, Func<string, Result<T>> func)
         {
-            Result<T> result = await resultTask.ConfigureAwait(Result.DefaultConfigureAwait);
+            Result<T> result = await resultTask.DefaultAwait();
             return result.OnFailureCompensate(func);
         }
 
         public static async Task<Result<T, E>> OnFailureCompensate<T, E>(this Task<Result<T, E>> resultTask,
             Func<E, Result<T, E>> func)
         {
-            Result<T, E> result = await resultTask.ConfigureAwait(Result.DefaultConfigureAwait);
+            Result<T, E> result = await resultTask.DefaultAwait();
             return result.OnFailureCompensate(func);
         }
 
         public static async Task<Result> OnFailureCompensate(this Task<Result> resultTask, Func<string, Result> func)
         {
-            Result result = await resultTask.ConfigureAwait(Result.DefaultConfigureAwait);
+            Result result = await resultTask.DefaultAwait();
             return result.OnFailureCompensate(func);
         }
     }

--- a/CSharpFunctionalExtensions/Result/Extensions/OnFailureCompensateAsyncRight.cs
+++ b/CSharpFunctionalExtensions/Result/Extensions/OnFailureCompensateAsyncRight.cs
@@ -8,7 +8,7 @@ namespace CSharpFunctionalExtensions
         public static async Task<Result<T>> OnFailureCompensate<T>(this Result<T> result, Func<Task<Result<T>>> func)
         {
             if (result.IsFailure)
-                return await func().ConfigureAwait(Result.DefaultConfigureAwait);
+                return await func().DefaultAwait();
 
             return result;
         }
@@ -16,7 +16,7 @@ namespace CSharpFunctionalExtensions
         public static async Task<Result<T, E>> OnFailureCompensate<T, E>(this Result<T, E> result, Func<Task<Result<T, E>>> func)
         {
             if (result.IsFailure)
-                return await func().ConfigureAwait(Result.DefaultConfigureAwait);
+                return await func().DefaultAwait();
 
             return result;
         }
@@ -24,7 +24,7 @@ namespace CSharpFunctionalExtensions
         public static async Task<Result> OnFailureCompensate(this Result result, Func<Task<Result>> func)
         {
             if (result.IsFailure)
-                return await func().ConfigureAwait(Result.DefaultConfigureAwait);
+                return await func().DefaultAwait();
 
             return result;
         }
@@ -32,7 +32,7 @@ namespace CSharpFunctionalExtensions
         public static async Task<Result<T>> OnFailureCompensate<T>(this Result<T> result, Func<string, Task<Result<T>>> func)
         {
             if (result.IsFailure)
-                return await func(result.Error).ConfigureAwait(Result.DefaultConfigureAwait);
+                return await func(result.Error).DefaultAwait();
 
             return result;
         }
@@ -41,7 +41,7 @@ namespace CSharpFunctionalExtensions
             Func<E, Task<Result<T, E>>> func)
         {
             if (result.IsFailure)
-                return await func(result.Error).ConfigureAwait(Result.DefaultConfigureAwait);
+                return await func(result.Error).DefaultAwait();
 
             return result;
         }

--- a/CSharpFunctionalExtensions/Result/Extensions/OnSuccessTryAsyncLeft.cs
+++ b/CSharpFunctionalExtensions/Result/Extensions/OnSuccessTryAsyncLeft.cs
@@ -8,28 +8,28 @@ namespace CSharpFunctionalExtensions
         public static async Task<Result> OnSuccessTry(this Task<Result> task, Action action,
             Func<Exception, string> errorHandler = null)
         {
-            var result = await task.ConfigureAwait(Result.DefaultConfigureAwait);
+            var result = await task.DefaultAwait();
             return result.OnSuccessTry(action, errorHandler);
         }
 
         public static async Task<Result<T>> OnSuccessTry<T>(this Task<Result> task, Func<T> func,
             Func<Exception, string> errorHandler = null)
         {
-            var result = await task.ConfigureAwait(Result.DefaultConfigureAwait);
+            var result = await task.DefaultAwait();
             return result.OnSuccessTry(func, errorHandler);
         }
 
         public static async Task<Result> OnSuccessTry<T>(this Task<Result<T>> task, Action<T> action,
             Func<Exception, string> errorHandler = null)
         {
-            var result = await task.ConfigureAwait(Result.DefaultConfigureAwait);
+            var result = await task.DefaultAwait();
             return result.OnSuccessTry(action, errorHandler);
         }
 
         public static async Task<Result<K>> OnSuccessTry<T, K>(this Task<Result<T>> task, Func<T, K> action,
             Func<Exception, string> errorHandler = null)
         {
-            var result = await task.ConfigureAwait(Result.DefaultConfigureAwait);
+            var result = await task.DefaultAwait();
             return result.OnSuccessTry(action, errorHandler);
         }
     }

--- a/CSharpFunctionalExtensions/Result/Extensions/SelectManyAsyncBoth.cs
+++ b/CSharpFunctionalExtensions/Result/Extensions/SelectManyAsyncBoth.cs
@@ -13,8 +13,8 @@ namespace CSharpFunctionalExtensions
             Func<T, Task<Result<TK>>> func,
             Func<T, TK, TR> project)
         {
-            Result<T> result = await resultTask.ConfigureAwait(Result.DefaultConfigureAwait);
-            return await result.SelectMany(func, project);
+            Result<T> result = await resultTask.DefaultAwait();
+            return await result.SelectMany(func, project).DefaultAwait();
         }
 
         /// <summary>
@@ -25,8 +25,8 @@ namespace CSharpFunctionalExtensions
             Func<T, Task<Result<TK, TE>>> func,
             Func<T, TK, TR> project)
         {
-            Result<T, TE> result = await resultTask.ConfigureAwait(Result.DefaultConfigureAwait);
-            return await result.SelectMany(func, project);
+            Result<T, TE> result = await resultTask.DefaultAwait();
+            return await result.SelectMany(func, project).DefaultAwait();
         }
     }
 }

--- a/CSharpFunctionalExtensions/Result/Extensions/SelectManyAsyncLeft.cs
+++ b/CSharpFunctionalExtensions/Result/Extensions/SelectManyAsyncLeft.cs
@@ -13,7 +13,7 @@ namespace CSharpFunctionalExtensions
             Func<T, Result<TK>> func,
             Func<T, TK, TR> project)
         {
-            Result<T> result = await resultTask.ConfigureAwait(Result.DefaultConfigureAwait);
+            Result<T> result = await resultTask.DefaultAwait();
             return result.SelectMany(func, project);
         }
 
@@ -25,7 +25,7 @@ namespace CSharpFunctionalExtensions
             Func<T, Result<TK, TE>> func,
             Func<T, TK, TR> project)
         {
-            Result<T, TE> result = await resultTask.ConfigureAwait(Result.DefaultConfigureAwait);
+            Result<T, TE> result = await resultTask.DefaultAwait();
             return result.SelectMany(func, project);
         }
     }

--- a/CSharpFunctionalExtensions/Result/Extensions/TapAsyncBoth.cs
+++ b/CSharpFunctionalExtensions/Result/Extensions/TapAsyncBoth.cs
@@ -10,10 +10,10 @@ namespace CSharpFunctionalExtensions
         /// </summary>
         public static async Task<Result> Tap(this Task<Result> resultTask, Func<Task> func)
         {
-            Result result = await resultTask.ConfigureAwait(Result.DefaultConfigureAwait);
+            Result result = await resultTask.DefaultAwait();
 
             if (result.IsSuccess)
-                await func().ConfigureAwait(Result.DefaultConfigureAwait);
+                await func().DefaultAwait();
 
             return result;
         }
@@ -23,10 +23,10 @@ namespace CSharpFunctionalExtensions
         /// </summary>
         public static async Task<Result<T>> Tap<T>(this Task<Result<T>> resultTask, Func<Task> func)
         {
-            Result<T> result = await resultTask.ConfigureAwait(Result.DefaultConfigureAwait);
+            Result<T> result = await resultTask.DefaultAwait();
 
             if (result.IsSuccess)
-                await func().ConfigureAwait(Result.DefaultConfigureAwait);
+                await func().DefaultAwait();
 
             return result;
         }
@@ -36,10 +36,10 @@ namespace CSharpFunctionalExtensions
         /// </summary>
         public static async Task<Result<T>> Tap<T>(this Task<Result<T>> resultTask, Func<T, Task> func)
         {
-            Result<T> result = await resultTask.ConfigureAwait(Result.DefaultConfigureAwait);
+            Result<T> result = await resultTask.DefaultAwait();
 
             if (result.IsSuccess)
-                await func(result.Value).ConfigureAwait(Result.DefaultConfigureAwait);
+                await func(result.Value).DefaultAwait();
 
             return result;
         }
@@ -49,10 +49,10 @@ namespace CSharpFunctionalExtensions
         /// </summary>
         public static async Task<Result<T, E>> Tap<T, E>(this Task<Result<T, E>> resultTask, Func<Task> func)
         {
-            Result<T, E> result = await resultTask.ConfigureAwait(Result.DefaultConfigureAwait);
+            Result<T, E> result = await resultTask.DefaultAwait();
 
             if (result.IsSuccess)
-                await func().ConfigureAwait(Result.DefaultConfigureAwait);
+                await func().DefaultAwait();
 
             return result;
         }
@@ -62,10 +62,10 @@ namespace CSharpFunctionalExtensions
         /// </summary>
         public static async Task<Result<T, E>> Tap<T, E>(this Task<Result<T, E>> resultTask, Func<T, Task> func)
         {
-            Result<T, E> result = await resultTask.ConfigureAwait(Result.DefaultConfigureAwait);
+            Result<T, E> result = await resultTask.DefaultAwait();
 
             if (result.IsSuccess)
-                await func(result.Value).ConfigureAwait(Result.DefaultConfigureAwait);
+                await func(result.Value).DefaultAwait();
 
             return result;
         }

--- a/CSharpFunctionalExtensions/Result/Extensions/TapAsyncLeft.cs
+++ b/CSharpFunctionalExtensions/Result/Extensions/TapAsyncLeft.cs
@@ -10,7 +10,7 @@ namespace CSharpFunctionalExtensions
         /// </summary>
         public static async Task<Result> Tap(this Task<Result> resultTask, Action action)
         {
-            Result result = await resultTask.ConfigureAwait(Result.DefaultConfigureAwait);
+            Result result = await resultTask.DefaultAwait();
             return result.Tap(action);
         }
 
@@ -19,7 +19,7 @@ namespace CSharpFunctionalExtensions
         /// </summary>
         public static async Task<Result<T>> Tap<T>(this Task<Result<T>> resultTask, Action action)
         {
-            Result<T> result = await resultTask.ConfigureAwait(Result.DefaultConfigureAwait);
+            Result<T> result = await resultTask.DefaultAwait();
             return result.Tap(action);
         }
 
@@ -28,7 +28,7 @@ namespace CSharpFunctionalExtensions
         /// </summary>
         public static async Task<Result<T>> Tap<T>(this Task<Result<T>> resultTask, Action<T> action)
         {
-            Result<T> result = await resultTask.ConfigureAwait(Result.DefaultConfigureAwait);
+            Result<T> result = await resultTask.DefaultAwait();
             return result.Tap(action);
         }
 
@@ -37,7 +37,7 @@ namespace CSharpFunctionalExtensions
         /// </summary>
         public static async Task<Result<T, E>> Tap<T, E>(this Task<Result<T, E>> resultTask, Action action)
         {
-            Result<T, E> result = await resultTask.ConfigureAwait(Result.DefaultConfigureAwait);
+            Result<T, E> result = await resultTask.DefaultAwait();
             return result.Tap(action);
         }
 
@@ -46,7 +46,7 @@ namespace CSharpFunctionalExtensions
         /// </summary>
         public static async Task<Result<T, E>> Tap<T, E>(this Task<Result<T, E>> resultTask, Action<T> action)
         {
-            Result<T, E> result = await resultTask.ConfigureAwait(Result.DefaultConfigureAwait);
+            Result<T, E> result = await resultTask.DefaultAwait();
             return result.Tap(action);
         }
 
@@ -55,7 +55,7 @@ namespace CSharpFunctionalExtensions
         /// </summary>
         public static async Task<Result> Tap<_>(this Task<Result> resultTask, Func<_> func)
         {
-            Result result = await resultTask.ConfigureAwait(Result.DefaultConfigureAwait);
+            Result result = await resultTask.DefaultAwait();
             return result.Tap(func);
         }
 
@@ -64,7 +64,7 @@ namespace CSharpFunctionalExtensions
         /// </summary>
         public static async Task<Result<T>> Tap<T, _>(this Task<Result<T>> resultTask, Func<_> func)
         {
-            Result<T> result = await resultTask.ConfigureAwait(Result.DefaultConfigureAwait);
+            Result<T> result = await resultTask.DefaultAwait();
             return result.Tap(func);
         }
 
@@ -73,7 +73,7 @@ namespace CSharpFunctionalExtensions
         /// </summary>
         public static async Task<Result<T>> Tap<T, _>(this Task<Result<T>> resultTask, Func<T, _> func)
         {
-            Result<T> result = await resultTask.ConfigureAwait(Result.DefaultConfigureAwait);
+            Result<T> result = await resultTask.DefaultAwait();
             return result.Tap(func);
         }
 
@@ -82,7 +82,7 @@ namespace CSharpFunctionalExtensions
         /// </summary>
         public static async Task<Result<T, E>> Tap<T, E, _>(this Task<Result<T, E>> resultTask, Func<_> func)
         {
-            Result<T, E> result = await resultTask.ConfigureAwait(Result.DefaultConfigureAwait);
+            Result<T, E> result = await resultTask.DefaultAwait();
             return result.Tap(func);
         }
 
@@ -91,7 +91,7 @@ namespace CSharpFunctionalExtensions
         /// </summary>
         public static async Task<Result<T, E>> Tap<T, E, _>(this Task<Result<T, E>> resultTask, Func<T, _> func)
         {
-            Result<T, E> result = await resultTask.ConfigureAwait(Result.DefaultConfigureAwait);
+            Result<T, E> result = await resultTask.DefaultAwait();
             return result.Tap(func);
         }
     }

--- a/CSharpFunctionalExtensions/Result/Extensions/TapAsyncRight.cs
+++ b/CSharpFunctionalExtensions/Result/Extensions/TapAsyncRight.cs
@@ -11,7 +11,7 @@ namespace CSharpFunctionalExtensions
         public static async Task<Result> Tap(this Result result, Func<Task> func)
         {
             if (result.IsSuccess)
-                await func().ConfigureAwait(Result.DefaultConfigureAwait);
+                await func().DefaultAwait();
 
             return result;
         }
@@ -22,7 +22,7 @@ namespace CSharpFunctionalExtensions
         public static async Task<Result> Tap<_>(this Result result, Func<Task<_>> func)
         {
             if (result.IsSuccess)
-                await func().ConfigureAwait(Result.DefaultConfigureAwait);
+                await func().DefaultAwait();
 
             return result;
         }
@@ -33,7 +33,7 @@ namespace CSharpFunctionalExtensions
         public static async Task<Result<T>> Tap<T>(this Result<T> result, Func<Task> func)
         {
             if (result.IsSuccess)
-                await func().ConfigureAwait(Result.DefaultConfigureAwait);
+                await func().DefaultAwait();
 
             return result;
         }
@@ -44,7 +44,7 @@ namespace CSharpFunctionalExtensions
         public static async Task<Result<T>> Tap<T, _>(this Result<T> result, Func<Task<_>> func)
         {
             if (result.IsSuccess)
-                await func().ConfigureAwait(Result.DefaultConfigureAwait);
+                await func().DefaultAwait();
 
             return result;
         }
@@ -55,7 +55,7 @@ namespace CSharpFunctionalExtensions
         public static async Task<Result<T>> Tap<T, _>(this Result<T> result, Func<T, Task<_>> func)
         {
             if (result.IsSuccess)
-                await func(result.Value).ConfigureAwait(Result.DefaultConfigureAwait);
+                await func(result.Value).DefaultAwait();
 
             return result;
         }
@@ -66,7 +66,7 @@ namespace CSharpFunctionalExtensions
         public static async Task<Result<T, E>> Tap<T, E>(this Result<T, E> result, Func<Task> func)
         {
             if (result.IsSuccess)
-                await func().ConfigureAwait(Result.DefaultConfigureAwait);
+                await func().DefaultAwait();
 
             return result;
         }
@@ -77,7 +77,7 @@ namespace CSharpFunctionalExtensions
         public static async Task<Result<T, E>> Tap<T, E, _>(this Result<T, E> result, Func<Task<_>> func)
         {
             if (result.IsSuccess)
-                await func().ConfigureAwait(Result.DefaultConfigureAwait);
+                await func().DefaultAwait();
 
             return result;
         }
@@ -88,7 +88,7 @@ namespace CSharpFunctionalExtensions
         public static async Task<Result<T>> Tap<T>(this Result<T> result, Func<T, Task> func)
         {
             if (result.IsSuccess)
-                await func(result.Value).ConfigureAwait(Result.DefaultConfigureAwait);
+                await func(result.Value).DefaultAwait();
 
             return result;
         }
@@ -99,7 +99,7 @@ namespace CSharpFunctionalExtensions
         public static async Task<Result<T, E>> Tap<T, E>(this Result<T, E> result, Func<T, Task> func)
         {
             if (result.IsSuccess)
-                await func(result.Value).ConfigureAwait(Result.DefaultConfigureAwait);
+                await func(result.Value).DefaultAwait();
 
             return result;
         }
@@ -110,7 +110,7 @@ namespace CSharpFunctionalExtensions
         public static async Task<Result<T, E>> Tap<T, E, _>(this Result<T, E> result, Func<T, Task<_>> func)
         {
             if (result.IsSuccess)
-                await func(result.Value).ConfigureAwait(Result.DefaultConfigureAwait);
+                await func(result.Value).DefaultAwait();
 
             return result;
         }

--- a/CSharpFunctionalExtensions/Result/Extensions/WithTransactionScope.cs
+++ b/CSharpFunctionalExtensions/Result/Extensions/WithTransactionScope.cs
@@ -26,7 +26,7 @@ namespace CSharpFunctionalExtensions
         {
             using (var trans = new TransactionScope(TransactionScopeAsyncFlowOption.Enabled))
             {
-                var result = await f().ConfigureAwait(Result.DefaultConfigureAwait);
+                var result = await f().DefaultAwait();
                 if (result.IsSuccess)
                 {
                     trans.Complete();

--- a/CSharpFunctionalExtensions/Result/Internal/TaskExtensions.cs
+++ b/CSharpFunctionalExtensions/Result/Internal/TaskExtensions.cs
@@ -1,0 +1,15 @@
+﻿using System.Threading.Tasks;
+
+#if NET40
+using Task = System.Threading.Tasks.TaskEx;
+#else
+using Task = System.Threading.Tasks.Task;
+#endif
+
+namespace CSharpFunctionalExtensions
+{
+    internal static class TaskExtensions
+    {
+        public static Task<T> AsCompletedTask<T>(this T obj) => Task.FromResult(obj);
+    }
+}

--- a/CSharpFunctionalExtensions/Result/Internal/TaskExtensions.cs
+++ b/CSharpFunctionalExtensions/Result/Internal/TaskExtensions.cs
@@ -2,8 +2,10 @@
 
 #if NET40
 using Task = System.Threading.Tasks.TaskEx;
+using Microsoft.Runtime.CompilerServices;
 #else
 using Task = System.Threading.Tasks.Task;
+using System.Runtime.CompilerServices;
 #endif
 
 namespace CSharpFunctionalExtensions
@@ -11,5 +13,9 @@ namespace CSharpFunctionalExtensions
     internal static class TaskExtensions
     {
         public static Task<T> AsCompletedTask<T>(this T obj) => Task.FromResult(obj);
+
+        public static ConfiguredTaskAwaitable DefaultAwait(this System.Threading.Tasks.Task task) => task.ConfigureAwait(Result.DefaultConfigureAwait);
+
+        public static ConfiguredTaskAwaitable<T> DefaultAwait<T>(this Task<T> task) => task.ConfigureAwait(Result.DefaultConfigureAwait);
     }
 }

--- a/CSharpFunctionalExtensions/Result/Methods/FailureIf.cs
+++ b/CSharpFunctionalExtensions/Result/Methods/FailureIf.cs
@@ -22,7 +22,7 @@ namespace CSharpFunctionalExtensions
         /// </summary>
         public static async Task<Result> FailureIf(Func<Task<bool>> failurePredicate, string error)
         {
-            bool isFailure = await failurePredicate().ConfigureAwait(DefaultConfigureAwait);
+            bool isFailure = await failurePredicate().DefaultAwait();
             return SuccessIf(!isFailure, error);
         }
 
@@ -43,7 +43,7 @@ namespace CSharpFunctionalExtensions
         /// </summary>
         public static async Task<Result<T>> FailureIf<T>(Func<Task<bool>> failurePredicate, T value, string error)
         {
-            bool isFailure = await failurePredicate().ConfigureAwait(DefaultConfigureAwait);
+            bool isFailure = await failurePredicate().DefaultAwait();
             return SuccessIf(!isFailure, value, error);
         }
 
@@ -64,7 +64,7 @@ namespace CSharpFunctionalExtensions
         /// </summary>
         public static async Task<Result<T, E>> FailureIf<T, E>(Func<Task<bool>> failurePredicate, T value, E error)
         {
-            bool isFailure = await failurePredicate().ConfigureAwait(DefaultConfigureAwait);
+            bool isFailure = await failurePredicate().DefaultAwait();
             return SuccessIf(!isFailure, value, error);
         }
     }

--- a/CSharpFunctionalExtensions/Result/Methods/SuccessIf.cs
+++ b/CSharpFunctionalExtensions/Result/Methods/SuccessIf.cs
@@ -28,7 +28,7 @@ namespace CSharpFunctionalExtensions
         /// </summary>
         public static async Task<Result> SuccessIf(Func<Task<bool>> predicate, string error)
         {
-            bool isSuccess = await predicate().ConfigureAwait(DefaultConfigureAwait);
+            bool isSuccess = await predicate().DefaultAwait();
             return SuccessIf(isSuccess, error);
         }
 
@@ -55,7 +55,7 @@ namespace CSharpFunctionalExtensions
         /// </summary>
         public static async Task<Result<T>> SuccessIf<T>(Func<Task<bool>> predicate, T value, string error)
         {
-            bool isSuccess = await predicate().ConfigureAwait(DefaultConfigureAwait);
+            bool isSuccess = await predicate().DefaultAwait();
             return SuccessIf(isSuccess, value, error);
         }
 
@@ -82,7 +82,7 @@ namespace CSharpFunctionalExtensions
         /// </summary>
         public static async Task<Result<T, E>> SuccessIf<T, E>(Func<Task<bool>> predicate, T value, E error)
         {
-            bool isSuccess = await predicate().ConfigureAwait(DefaultConfigureAwait);
+            bool isSuccess = await predicate().DefaultAwait();
             return SuccessIf(isSuccess, value, error);
         }
     }

--- a/CSharpFunctionalExtensions/Result/Methods/Try.cs
+++ b/CSharpFunctionalExtensions/Result/Methods/Try.cs
@@ -35,7 +35,7 @@ namespace CSharpFunctionalExtensions
 
             try
             {
-                await action().ConfigureAwait(DefaultConfigureAwait);
+                await action().DefaultAwait();
                 return Success();
             }
             catch (Exception exc)
@@ -74,7 +74,7 @@ namespace CSharpFunctionalExtensions
 
             try
             {
-                var result = await func().ConfigureAwait(DefaultConfigureAwait);
+                var result = await func().DefaultAwait();
                 return Success(result);
             }
             catch (Exception exc)
@@ -109,7 +109,7 @@ namespace CSharpFunctionalExtensions
         {
             try
             {
-                var result = await func().ConfigureAwait(DefaultConfigureAwait);
+                var result = await func().DefaultAwait();
                 return Success<T, E>(result);
             }
             catch (Exception exc)

--- a/CSharpFunctionalExtensionsNet4.0/CSharpFunctionalExtensionsNet4.0.csproj
+++ b/CSharpFunctionalExtensionsNet4.0/CSharpFunctionalExtensionsNet4.0.csproj
@@ -14,7 +14,7 @@
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
     <Version>2.2.0</Version>
     <AssemblyName>CSharpFunctionalExtensions</AssemblyName>
-    <LangVersion>7.1</LangVersion>
+    <LangVersion>8.0</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/CSharpFunctionalExtensionsNet4.0/CSharpFunctionalExtensionsNet4.0.csproj
+++ b/CSharpFunctionalExtensionsNet4.0/CSharpFunctionalExtensionsNet4.0.csproj
@@ -60,6 +60,7 @@
     <Compile Include="..\CSharpFunctionalExtensions\Result\Extensions\TapAsyncRight.cs" Link="Result\Extensions\TapAsyncRight.cs" />
     <Compile Include="..\CSharpFunctionalExtensions\Result\Internal\ResultCommonLogic.cs" Link="Result\Internal\ResultCommonLogic.cs" />
     <Compile Include="..\CSharpFunctionalExtensions\Result\Internal\Result.Messages.cs" Link="Result\Internal\Result.Messages.cs" />
+    <Compile Include="..\CSharpFunctionalExtensions\Result\Internal\TaskExtensions.cs" Link="Result\Internal\TaskExtensions.cs" />
     <Compile Include="..\CSharpFunctionalExtensions\Result\Methods\Combine.cs" Link="Result\Methods\Combine.cs" />
     <Compile Include="..\CSharpFunctionalExtensions\Result\Methods\ConvertFailure.cs" Link="Result\Methods\ConvertFailure.cs" />
     <Compile Include="..\CSharpFunctionalExtensions\Result\Methods\Failure.cs" Link="Result\Methods\Failure.cs" />


### PR DESCRIPTION
Please cast your eye over these ideas; I expect there will be similar opportunities on other extension methods.

I don't see why `BindAsyncRight` needs to await.

There is now much better alignment/reuse between `BindAsyncBoth`/`BindAsyncLeft`, and between `BindAsyncRight`/`Bind`.