### PR TITLE
Adding unit tests for tap result funcs

### DIFF
--- a/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/TapAsyncBothTests.cs
+++ b/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/TapAsyncBothTests.cs
@@ -69,5 +69,47 @@ namespace CSharpFunctionalExtensions.Tests.ResultTests.Extensions
             actionExecuted.Should().Be(isSuccess);
             result.Should().Be(returned);
         }
+
+        [Theory]
+        [InlineData(true, true)]
+        [InlineData(true, false)]
+        [InlineData(false, false)]
+        public void Tap_T_AsyncBoth_func_result(bool resultSuccess, bool funcSuccess)
+        {
+            Result<T> result = Result.SuccessIf(resultSuccess, T.Value, ErrorMessage);
+
+            var returned = result.AsTask().Tap(Func_Task_Result(funcSuccess)).Result;
+
+            actionExecuted.Should().Be(resultSuccess);
+            returned.Should().Be(funcSuccess ? result : FailedResultT);
+        }
+
+        [Theory]
+        [InlineData(true, true)]
+        [InlineData(true, false)]
+        [InlineData(false, false)]
+        public void Tap_T_AsyncBoth_func_result_K(bool resultSuccess, bool funcSuccess)
+        {
+            Result<T> result = Result.SuccessIf(resultSuccess, T.Value, ErrorMessage);
+
+            var returned = result.AsTask().Tap(Func_Task_Result_K(funcSuccess)).Result;
+
+            actionExecuted.Should().Be(resultSuccess);
+            returned.Should().Be(funcSuccess ? result : FailedResultT);
+        }
+
+        [Theory]
+        [InlineData(true, true)]
+        [InlineData(true, false)]
+        [InlineData(false, false)]
+        public void Tap_T_AsyncBoth_func_result_KE(bool resultSuccess, bool funcSuccess)
+        {
+            Result<T, E> result = Result.SuccessIf(resultSuccess, T.Value, E.Value);
+
+            var returned = result.AsTask().Tap(Func_Task_Result_KE(funcSuccess)).Result;
+
+            actionExecuted.Should().Be(resultSuccess);
+            returned.Should().Be(funcSuccess ? result : returned);
+        }
     }
 }

--- a/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/TapAsyncLeftTests.cs
+++ b/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/TapAsyncLeftTests.cs
@@ -69,5 +69,47 @@ namespace CSharpFunctionalExtensions.Tests.ResultTests.Extensions
             actionExecuted.Should().Be(isSuccess);
             result.Should().Be(returned);
         }
+
+        [Theory]
+        [InlineData(true, true)]
+        [InlineData(true, false)]
+        [InlineData(false, false)]
+        public void Tap_T_AsyncLeft_func_result(bool resultSuccess, bool funcSuccess)
+        {
+            Result<T> result = Result.SuccessIf(resultSuccess, T.Value, ErrorMessage);
+
+            var returned = result.AsTask().Tap(Func_Result(funcSuccess)).Result;
+
+            actionExecuted.Should().Be(resultSuccess);
+            returned.Should().Be(funcSuccess ? result : FailedResultT);
+        }
+
+        [Theory]
+        [InlineData(true, true)]
+        [InlineData(true, false)]
+        [InlineData(false, false)]
+        public void Tap_T_AsyncLeft_func_result_K(bool resultSuccess, bool funcSuccess)
+        {
+            Result<T> result = Result.SuccessIf(resultSuccess, T.Value, ErrorMessage);
+
+            var returned = result.AsTask().Tap(Func_Result_K(funcSuccess)).Result;
+
+            actionExecuted.Should().Be(resultSuccess);
+            returned.Should().Be(funcSuccess ? result : FailedResultT);
+        }
+
+        [Theory]
+        [InlineData(true, true)]
+        [InlineData(true, false)]
+        [InlineData(false, false)]
+        public void Tap_T_AsyncLeft_func_result_KE(bool resultSuccess, bool funcSuccess)
+        {
+            Result<T, E> result = Result.SuccessIf(resultSuccess, T.Value, E.Value);
+
+            var returned = result.AsTask().Tap(Func_Result_KE(funcSuccess)).Result;
+
+            actionExecuted.Should().Be(resultSuccess);
+            returned.Should().Be(funcSuccess ? result : returned);
+        }
     }
 }

--- a/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/TapAsyncRightTests.cs
+++ b/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/TapAsyncRightTests.cs
@@ -69,5 +69,47 @@ namespace CSharpFunctionalExtensions.Tests.ResultTests.Extensions
             actionExecuted.Should().Be(isSuccess);
             result.Should().Be(returned);
         }
+
+        [Theory]
+        [InlineData(true, true)]
+        [InlineData(true, false)]
+        [InlineData(false, false)]
+        public void Tap_T_AsyncRight_func_result(bool resultSuccess, bool funcSuccess)
+        {
+            Result<T> result = Result.SuccessIf(resultSuccess, T.Value, ErrorMessage);
+
+            var returned = result.Tap(Func_Task_Result(funcSuccess)).Result;
+
+            actionExecuted.Should().Be(resultSuccess);
+            returned.Should().Be(funcSuccess ? result : FailedResultT);
+        }
+
+        [Theory]
+        [InlineData(true, true)]
+        [InlineData(true, false)]
+        [InlineData(false, false)]
+        public void Tap_T_AsyncRight_func_result_K(bool resultSuccess, bool funcSuccess)
+        {
+            Result<T> result = Result.SuccessIf(resultSuccess, T.Value, ErrorMessage);
+
+            var returned = result.Tap(Func_Task_Result_K(funcSuccess)).Result;
+
+            actionExecuted.Should().Be(resultSuccess);
+            returned.Should().Be(funcSuccess ? result : FailedResultT);
+        }
+
+        [Theory]
+        [InlineData(true, true)]
+        [InlineData(true, false)]
+        [InlineData(false, false)]
+        public void Tap_T_AsyncRight_func_result_KE(bool resultSuccess, bool funcSuccess)
+        {
+            Result<T, E> result = Result.SuccessIf(resultSuccess, T.Value, E.Value);
+
+            var returned = result.Tap(Func_Task_Result_KE(funcSuccess)).Result;
+
+            actionExecuted.Should().Be(resultSuccess);
+            returned.Should().Be(funcSuccess ? result : returned);
+        }
     }
 }

--- a/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/TapTests.cs
+++ b/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/TapTests.cs
@@ -69,5 +69,47 @@ namespace CSharpFunctionalExtensions.Tests.ResultTests.Extensions
             actionExecuted.Should().Be(isSuccess);
             result.Should().Be(returned);
         }
+
+        [Theory]
+        [InlineData(true, true)]
+        [InlineData(true, false)]
+        [InlineData(false, false)]
+        public void Tap_T_func_result(bool resultSuccess, bool funcSuccess)
+        {
+            Result<T> result = Result.SuccessIf(resultSuccess, T.Value, ErrorMessage);
+
+            var returned = result.Tap(Func_Result(funcSuccess));
+
+            actionExecuted.Should().Be(resultSuccess);
+            returned.Should().Be(funcSuccess ? result : FailedResultT);
+        }
+
+        [Theory]
+        [InlineData(true, true)]
+        [InlineData(true, false)]
+        [InlineData(false, false)]
+        public void Tap_T_func_result_K(bool resultSuccess, bool funcSuccess)
+        {
+            Result<T> result = Result.SuccessIf(resultSuccess, T.Value, ErrorMessage);
+
+            var returned = result.Tap(Func_Result_K(funcSuccess));
+
+            actionExecuted.Should().Be(resultSuccess);
+            returned.Should().Be(funcSuccess ? result : FailedResultT);
+        }
+
+        [Theory]
+        [InlineData(true, true)]
+        [InlineData(true, false)]
+        [InlineData(false, false)]
+        public void Tap_T_func_result_KE(bool resultSuccess, bool funcSuccess)
+        {
+            Result<T, E> result = Result.SuccessIf(resultSuccess, T.Value, E.Value);
+
+            var returned = result.Tap(Func_Result_KE(funcSuccess));
+
+            actionExecuted.Should().Be(resultSuccess);
+            returned.Should().Be(funcSuccess ? result : returned);
+        }
     }
 }

--- a/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/TapTestsBase.cs
+++ b/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/TapTestsBase.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading.Tasks;
+﻿using System;
+using System.Threading.Tasks;
 
 namespace CSharpFunctionalExtensions.Tests.ResultTests.Extensions
 {
@@ -13,8 +14,102 @@ namespace CSharpFunctionalExtensions.Tests.ResultTests.Extensions
 
         protected void Action() { actionExecuted = true; }
         protected void Action_T(T _) { actionExecuted = true; }
-
         protected async Task Task_Action() { actionExecuted = true; }
         protected async Task Task_Action_T(T _) { actionExecuted = true; }
+
+        protected Result FailedResult = Result.Failure<T>(ErrorMessage);
+        protected Result<T> FailedResultT = Result.Failure<T>(ErrorMessage);
+        protected Result<K> FailedResultK = Result.Failure<K>(ErrorMessage);
+        protected Result<K, E> FailedResultKE = Result.Failure<K, E>(E.Value);
+
+        protected Func<T, Result> Func_Result(bool isSuccess)
+        {
+            return isSuccess
+                ? new Func<T, Result>(t =>
+                {
+                    actionExecuted = true;
+                    return Result.Success();
+                })
+                : t =>
+                {
+                    actionExecuted = true;
+                    return FailedResult;
+                };
+        }
+
+        protected Func<T, Result<K>> Func_Result_K(bool isSuccess)
+        {
+            return isSuccess
+                ? new Func<T, Result<K>>(t =>
+                {
+                    actionExecuted = true;
+                    return Result.Success(K.Value);
+                })
+                : t =>
+                {
+                    actionExecuted = true;
+                    return FailedResultK;
+                };
+        }
+
+        protected Func<T, Result<K, E>> Func_Result_KE(bool isSuccess)
+        {
+            return isSuccess
+                ? new Func<T, Result<K, E>>(t =>
+                 {
+                     actionExecuted = true;
+                     return Result.Success<K, E>(K.Value);
+                 })
+                : t =>
+                {
+                    actionExecuted = true;
+                    return FailedResultKE;
+                };
+        }
+
+        protected Func<T, Task<Result>> Func_Task_Result(bool isSuccess)
+        {
+            return isSuccess
+                ? new Func<T, Task<Result>>(t =>
+                {
+                    actionExecuted = true;
+                    return Result.Success().AsTask();
+                })
+                : t =>
+                {
+                    actionExecuted = true;
+                    return FailedResult.AsTask();
+                };
+        }
+
+        protected Func<T, Task<Result<K>>> Func_Task_Result_K(bool isSuccess)
+        {
+            return isSuccess
+                ? new Func<T, Task<Result<K>>>(t =>
+                {
+                    actionExecuted = true;
+                    return Result.Success(K.Value).AsTask();
+                })
+                : t =>
+                {
+                    actionExecuted = true;
+                    return FailedResultK.AsTask();
+                };
+        }
+
+        protected Func<T, Task<Result<K, E>>> Func_Task_Result_KE(bool isSuccess)
+        {
+            return isSuccess
+                ? new Func<T, Task<Result<K, E>>>(t =>
+                {
+                    actionExecuted = true;
+                    return Result.Success<K, E>(K.Value).AsTask();
+                })
+                : t =>
+                {
+                    actionExecuted = true;
+                    return FailedResultKE.AsTask();
+                };
+        }
     }
 }


### PR DESCRIPTION
Here I have provided unit tests for the result-returning tap signatures. I attempted to follow the patterns you had in place. Please let me know if you would like any changes.

@space-alien  @vkhorikov Question: Do we also need to add the func signatures to `TapIf`?