### PR TITLE
TapIf overloads for handling result-returning funcs

### DIFF
--- a/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/TapIfAsyncBothTests.cs
+++ b/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/TapIfAsyncBothTests.cs
@@ -85,6 +85,51 @@ namespace CSharpFunctionalExtensions.Tests.ResultTests.Extensions
         [InlineData(true, false)]
         [InlineData(false, true)]
         [InlineData(false, false)]
+        public void TapIf_T_AsyncBoth_executes_func_result_T_conditionally_and_returns_self(bool isSuccess, bool condition)
+        {
+            Result<bool> result = Result.SuccessIf(isSuccess, condition, ErrorMessage);
+
+            var returned = result.AsTask().TapIf(condition, Task_Func_Result).Result;
+
+            actionExecuted.Should().Be(isSuccess && condition);
+            result.Should().Be(returned);
+        }
+
+        [Theory]
+        [InlineData(true, true)]
+        [InlineData(true, false)]
+        [InlineData(false, true)]
+        [InlineData(false, false)]
+        public void TapIf_T_AsyncBoth_executes_func_result_K_conditionally_and_returns_self(bool isSuccess, bool condition)
+        {
+            Result<bool> result = Result.SuccessIf(isSuccess, condition, ErrorMessage);
+
+            var returned = result.AsTask().TapIf(condition, Task_Func_Result_K).Result;
+
+            actionExecuted.Should().Be(isSuccess && condition);
+            result.Should().Be(returned);
+        }
+
+        [Theory]
+        [InlineData(true, true)]
+        [InlineData(true, false)]
+        [InlineData(false, true)]
+        [InlineData(false, false)]
+        public void TapIf_T_AsyncBoth_executes_func_result_K_E_conditionally_and_returns_self(bool isSuccess, bool condition)
+        {
+            Result<bool, E> result = Result.SuccessIf(isSuccess, condition, E.Value);
+
+            var returned = result.AsTask().TapIf(condition, Task_Func_Result_K_E).Result;
+
+            actionExecuted.Should().Be(isSuccess && condition);
+            result.Should().Be(returned);
+        }
+
+        [Theory]
+        [InlineData(true, true)]
+        [InlineData(true, false)]
+        [InlineData(false, true)]
+        [InlineData(false, false)]
         public void TapIf_T_AsyncBoth_executes_action_per_predicate_and_returns_self(bool isSuccess, bool condition)
         {
             Result<bool> result = Result.SuccessIf(isSuccess, condition, ErrorMessage);
@@ -140,6 +185,51 @@ namespace CSharpFunctionalExtensions.Tests.ResultTests.Extensions
             var returned = result.AsTask().TapIf(Predicate, Task_Action_T).Result;
 
             predicateExecuted.Should().Be(isSuccess);
+            actionExecuted.Should().Be(isSuccess && condition);
+            result.Should().Be(returned);
+        }
+
+        [Theory]
+        [InlineData(true, true)]
+        [InlineData(true, false)]
+        [InlineData(false, true)]
+        [InlineData(false, false)]
+        public void TapIf_T_AsyncBoth_executes_func_result_T_per_predicate_and_returns_self(bool isSuccess, bool condition)
+        {
+            Result<bool> result = Result.SuccessIf(isSuccess, condition, ErrorMessage);
+
+            var returned = result.AsTask().TapIf(Predicate, Task_Func_Result).Result;
+
+            actionExecuted.Should().Be(isSuccess && condition);
+            result.Should().Be(returned);
+        }
+
+        [Theory]
+        [InlineData(true, true)]
+        [InlineData(true, false)]
+        [InlineData(false, true)]
+        [InlineData(false, false)]
+        public void TapIf_T_AsyncBoth_executes_func_result_K_per_predicate_and_returns_self(bool isSuccess, bool condition)
+        {
+            Result<bool> result = Result.SuccessIf(isSuccess, condition, ErrorMessage);
+
+            var returned = result.AsTask().TapIf(Predicate, Task_Func_Result_K).Result;
+
+            actionExecuted.Should().Be(isSuccess && condition);
+            result.Should().Be(returned);
+        }
+
+        [Theory]
+        [InlineData(true, true)]
+        [InlineData(true, false)]
+        [InlineData(false, true)]
+        [InlineData(false, false)]
+        public void TapIf_T_AsyncBoth_executes_func_result_K_E_per_predicate_and_returns_self(bool isSuccess, bool condition)
+        {
+            Result<bool, E> result = Result.SuccessIf(isSuccess, condition, E.Value);
+
+            var returned = result.AsTask().TapIf(Predicate, Task_Func_Result_K_E).Result;
+
             actionExecuted.Should().Be(isSuccess && condition);
             result.Should().Be(returned);
         }

--- a/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/TapIfAsyncLeftTests.cs
+++ b/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/TapIfAsyncLeftTests.cs
@@ -85,6 +85,51 @@ namespace CSharpFunctionalExtensions.Tests.ResultTests.Extensions
         [InlineData(true, false)]
         [InlineData(false, true)]
         [InlineData(false, false)]
+        public void TapIf_T_AsyncLeft_executes_func_result_T_conditionally_and_returns_self(bool isSuccess, bool condition)
+        {
+            Result<bool> result = Result.SuccessIf(isSuccess, condition, ErrorMessage);
+
+            var returned = result.AsTask().TapIf(condition, Func_Result).Result;
+
+            actionExecuted.Should().Be(isSuccess && condition);
+            result.Should().Be(returned);
+        }
+
+        [Theory]
+        [InlineData(true, true)]
+        [InlineData(true, false)]
+        [InlineData(false, true)]
+        [InlineData(false, false)]
+        public void TapIf_T_AsyncLeft_executes_func_result_K_conditionally_and_returns_self(bool isSuccess, bool condition)
+        {
+            Result<bool> result = Result.SuccessIf(isSuccess, condition, ErrorMessage);
+
+            var returned = result.AsTask().TapIf(condition, Func_Result_K).Result;
+
+            actionExecuted.Should().Be(isSuccess && condition);
+            result.Should().Be(returned);
+        }
+
+        [Theory]
+        [InlineData(true, true)]
+        [InlineData(true, false)]
+        [InlineData(false, true)]
+        [InlineData(false, false)]
+        public void TapIf_T_AsyncLeft_executes_func_result_K_E_conditionally_and_returns_self(bool isSuccess, bool condition)
+        {
+            Result<bool, E> result = Result.SuccessIf(isSuccess, condition, E.Value);
+
+            var returned = result.AsTask().TapIf(condition, Func_Result_K_E).Result;
+
+            actionExecuted.Should().Be(isSuccess && condition);
+            result.Should().Be(returned);
+        }
+
+        [Theory]
+        [InlineData(true, true)]
+        [InlineData(true, false)]
+        [InlineData(false, true)]
+        [InlineData(false, false)]
         public void TapIf_T_AsyncLeft_executes_action_per_predicate_and_returns_self(bool isSuccess, bool condition)
         {
             Result<bool> result = Result.SuccessIf(isSuccess, condition, ErrorMessage);
@@ -140,6 +185,51 @@ namespace CSharpFunctionalExtensions.Tests.ResultTests.Extensions
             var returned = result.AsTask().TapIf(Predicate, Action_T).Result;
 
             predicateExecuted.Should().Be(isSuccess);
+            actionExecuted.Should().Be(isSuccess && condition);
+            result.Should().Be(returned);
+        }
+
+        [Theory]
+        [InlineData(true, true)]
+        [InlineData(true, false)]
+        [InlineData(false, true)]
+        [InlineData(false, false)]
+        public void TapIf_T_AsyncLeft_executes_func_result_T_per_predicate_and_returns_self(bool isSuccess, bool condition)
+        {
+            Result<bool> result = Result.SuccessIf(isSuccess, condition, ErrorMessage);
+
+            var returned = result.AsTask().TapIf(Predicate, Func_Result).Result;
+
+            actionExecuted.Should().Be(isSuccess && condition);
+            result.Should().Be(returned);
+        }
+
+        [Theory]
+        [InlineData(true, true)]
+        [InlineData(true, false)]
+        [InlineData(false, true)]
+        [InlineData(false, false)]
+        public void TapIf_T_AsyncLeft_executes_func_result_K_per_predicate_and_returns_self(bool isSuccess, bool condition)
+        {
+            Result<bool> result = Result.SuccessIf(isSuccess, condition, ErrorMessage);
+
+            var returned = result.AsTask().TapIf(Predicate, Func_Result_K).Result;
+
+            actionExecuted.Should().Be(isSuccess && condition);
+            result.Should().Be(returned);
+        }
+
+        [Theory]
+        [InlineData(true, true)]
+        [InlineData(true, false)]
+        [InlineData(false, true)]
+        [InlineData(false, false)]
+        public void TapIf_T_AsyncLeft_executes_func_result_K_E_per_predicate_and_returns_self(bool isSuccess, bool condition)
+        {
+            Result<bool, E> result = Result.SuccessIf(isSuccess, condition, E.Value);
+
+            var returned = result.AsTask().TapIf(Predicate, Func_Result_K_E).Result;
+
             actionExecuted.Should().Be(isSuccess && condition);
             result.Should().Be(returned);
         }

--- a/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/TapIfAsyncRightTests.cs
+++ b/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/TapIfAsyncRightTests.cs
@@ -85,6 +85,51 @@ namespace CSharpFunctionalExtensions.Tests.ResultTests.Extensions
         [InlineData(true, false)]
         [InlineData(false, true)]
         [InlineData(false, false)]
+        public void TapIf_T_AsyncRight_executes_func_result_T_conditionally_and_returns_self(bool isSuccess, bool condition)
+        {
+            Result<bool> result = Result.SuccessIf(isSuccess, condition, ErrorMessage);
+
+            var returned = result.TapIf(condition, Task_Func_Result).Result;
+
+            actionExecuted.Should().Be(isSuccess && condition);
+            result.Should().Be(returned);
+        }
+
+        [Theory]
+        [InlineData(true, true)]
+        [InlineData(true, false)]
+        [InlineData(false, true)]
+        [InlineData(false, false)]
+        public void TapIf_T_AsyncRight_executes_func_result_K_conditionally_and_returns_self(bool isSuccess, bool condition)
+        {
+            Result<bool> result = Result.SuccessIf(isSuccess, condition, ErrorMessage);
+
+            var returned = result.TapIf(condition, Task_Func_Result_K).Result;
+
+            actionExecuted.Should().Be(isSuccess && condition);
+            result.Should().Be(returned);
+        }
+
+        [Theory]
+        [InlineData(true, true)]
+        [InlineData(true, false)]
+        [InlineData(false, true)]
+        [InlineData(false, false)]
+        public void TapIf_T_AsyncRight_executes_func_result_K_E_conditionally_and_returns_self(bool isSuccess, bool condition)
+        {
+            Result<bool, E> result = Result.SuccessIf(isSuccess, condition, E.Value);
+
+            var returned = result.TapIf(condition, Task_Func_Result_K_E).Result;
+
+            actionExecuted.Should().Be(isSuccess && condition);
+            result.Should().Be(returned);
+        }
+
+        [Theory]
+        [InlineData(true, true)]
+        [InlineData(true, false)]
+        [InlineData(false, true)]
+        [InlineData(false, false)]
         public void TapIf_T_AsyncRight_executes_action_per_func_condition_and_returns_self(bool isSuccess, bool condition)
         {
             Result<bool> result = Result.SuccessIf(isSuccess, condition, ErrorMessage);
@@ -140,6 +185,51 @@ namespace CSharpFunctionalExtensions.Tests.ResultTests.Extensions
             var returned = result.TapIf(Predicate, Task_Action_T).Result;
 
             predicateExecuted.Should().Be(isSuccess);
+            actionExecuted.Should().Be(isSuccess && condition);
+            result.Should().Be(returned);
+        }
+
+        [Theory]
+        [InlineData(true, true)]
+        [InlineData(true, false)]
+        [InlineData(false, true)]
+        [InlineData(false, false)]
+        public void TapIf_T_AsyncRight_executes_func_result_T_per_func_condition_and_returns_self(bool isSuccess, bool condition)
+        {
+            Result<bool> result = Result.SuccessIf(isSuccess, condition, ErrorMessage);
+
+            var returned = result.TapIf(Predicate, Task_Func_Result).Result;
+
+            actionExecuted.Should().Be(isSuccess && condition);
+            result.Should().Be(returned);
+        }
+
+        [Theory]
+        [InlineData(true, true)]
+        [InlineData(true, false)]
+        [InlineData(false, true)]
+        [InlineData(false, false)]
+        public void TapIf_T_AsyncRight_executes_func_result_K_per_func_condition_and_returns_self(bool isSuccess, bool condition)
+        {
+            Result<bool> result = Result.SuccessIf(isSuccess, condition, ErrorMessage);
+
+            var returned = result.TapIf(Predicate, Task_Func_Result_K).Result;
+
+            actionExecuted.Should().Be(isSuccess && condition);
+            result.Should().Be(returned);
+        }
+
+        [Theory]
+        [InlineData(true, true)]
+        [InlineData(true, false)]
+        [InlineData(false, true)]
+        [InlineData(false, false)]
+        public void TapIf_T_AsyncRight_executes_func_result_K_E_per_func_condition_and_returns_self(bool isSuccess, bool condition)
+        {
+            Result<bool, E> result = Result.SuccessIf(isSuccess, condition, E.Value);
+
+            var returned = result.TapIf(Predicate, Task_Func_Result_K_E).Result;
+
             actionExecuted.Should().Be(isSuccess && condition);
             result.Should().Be(returned);
         }

--- a/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/TapIfTests.cs
+++ b/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/TapIfTests.cs
@@ -85,6 +85,51 @@ namespace CSharpFunctionalExtensions.Tests.ResultTests.Extensions
         [InlineData(true, false)]
         [InlineData(false, true)]
         [InlineData(false, false)]
+        public void TapIf_T_executes_func_result_T_conditionally_and_returns_self(bool isSuccess, bool condition)
+        {
+            Result<bool> result = Result.SuccessIf(isSuccess, condition, ErrorMessage);
+
+            var returned = result.TapIf(condition, Func_Result);
+
+            actionExecuted.Should().Be(isSuccess && condition);
+            result.Should().Be(returned);
+        }
+
+        [Theory]
+        [InlineData(true, true)]
+        [InlineData(true, false)]
+        [InlineData(false, true)]
+        [InlineData(false, false)]
+        public void TapIf_T_executes_func_result_K_conditionally_and_returns_self(bool isSuccess, bool condition)
+        {
+            Result<bool> result = Result.SuccessIf(isSuccess, condition, ErrorMessage);
+
+            var returned = result.TapIf(condition, Func_Result_K);
+
+            actionExecuted.Should().Be(isSuccess && condition);
+            result.Should().Be(returned);
+        }
+
+        [Theory]
+        [InlineData(true, true)]
+        [InlineData(true, false)]
+        [InlineData(false, true)]
+        [InlineData(false, false)]
+        public void TapIf_T_executes_func_result_K_E_conditionally_and_returns_self(bool isSuccess, bool condition)
+        {
+            Result<bool, E> result = Result.SuccessIf(isSuccess, condition, E.Value);
+
+            var returned = result.TapIf(condition, Func_Result_K_E);
+
+            actionExecuted.Should().Be(isSuccess && condition);
+            result.Should().Be(returned);
+        }
+
+        [Theory]
+        [InlineData(true, true)]
+        [InlineData(true, false)]
+        [InlineData(false, true)]
+        [InlineData(false, false)]
         public void TapIf_T_executes_action_per_predicate_and_returns_self(bool isSuccess, bool condition)
         {
             Result<bool> result = Result.SuccessIf(isSuccess, condition, ErrorMessage);
@@ -140,6 +185,51 @@ namespace CSharpFunctionalExtensions.Tests.ResultTests.Extensions
             var returned = result.TapIf(Predicate, Action_T);
 
             predicateExecuted.Should().Be(isSuccess);
+            actionExecuted.Should().Be(isSuccess && condition);
+            result.Should().Be(returned);
+        }
+
+        [Theory]
+        [InlineData(true, true)]
+        [InlineData(true, false)]
+        [InlineData(false, true)]
+        [InlineData(false, false)]
+        public void TapIf_T_executes_func_result_T_per_predicate_and_returns_self(bool isSuccess, bool condition)
+        {
+            Result<bool> result = Result.SuccessIf(isSuccess, condition, ErrorMessage);
+
+            var returned = result.TapIf(Predicate, Func_Result);
+
+            actionExecuted.Should().Be(isSuccess && condition);
+            result.Should().Be(returned);
+        }
+
+        [Theory]
+        [InlineData(true, true)]
+        [InlineData(true, false)]
+        [InlineData(false, true)]
+        [InlineData(false, false)]
+        public void TapIf_T_executes_func_result_K_per_predicate_and_returns_self(bool isSuccess, bool condition)
+        {
+            Result<bool> result = Result.SuccessIf(isSuccess, condition, ErrorMessage);
+
+            var returned = result.TapIf(Predicate, Func_Result_K);
+
+            actionExecuted.Should().Be(isSuccess && condition);
+            result.Should().Be(returned);
+        }
+
+        [Theory]
+        [InlineData(true, true)]
+        [InlineData(true, false)]
+        [InlineData(false, true)]
+        [InlineData(false, false)]
+        public void TapIf_T_executes_func_result_K_E_per_predicate_and_returns_self(bool isSuccess, bool condition)
+        {
+            Result<bool, E> result = Result.SuccessIf(isSuccess, condition, E.Value);
+
+            var returned = result.TapIf(Predicate, Func_Result_K_E);
+
             actionExecuted.Should().Be(isSuccess && condition);
             result.Should().Be(returned);
         }

--- a/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/TapIfTestsBase.cs
+++ b/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/TapIfTestsBase.cs
@@ -21,6 +21,14 @@ namespace CSharpFunctionalExtensions.Tests.ResultTests.Extensions
         protected async Task Task_Action_T(T _) { actionExecuted = true; }
         protected async Task Task_Action_T(bool _) { actionExecuted = true; }
 
+        protected Result Func_Result(bool _) { actionExecuted = true; return Result.Success(); } 
+        protected Result<K> Func_Result_K(bool _) { actionExecuted = true; return Result.Success<K>(K.Value); }
+        protected Result<K,E> Func_Result_K_E(bool _) { actionExecuted = true; return Result.Success<K, E>(K.Value); }
+
+        protected Task<Result> Task_Func_Result(bool _) { actionExecuted = true; return Result.Success().AsTask(); }
+        protected Task<Result<K>> Task_Func_Result_K(bool _) { actionExecuted = true; return Result.Success<K>(K.Value).AsTask(); }
+        protected Task<Result<K, E>> Task_Func_Result_K_E(bool _) { actionExecuted = true; return Result.Success<K, E>(K.Value).AsTask(); }
+
         protected bool Predicate(bool b) { predicateExecuted = true; return b; }
     }
 }

--- a/CSharpFunctionalExtensions/Result/Extensions/TapIf.cs
+++ b/CSharpFunctionalExtensions/Result/Extensions/TapIf.cs
@@ -59,6 +59,30 @@ namespace CSharpFunctionalExtensions
                 return result;
         }
 
+        public static Result<T> TapIf<T>(this Result<T> result, bool condition, Func<T, Result> func)
+        {
+            if (condition)
+                return result.Tap(func);
+            else
+                return result;
+        }
+
+        public static Result<T> TapIf<T, K>(this Result<T> result, bool condition, Func<T, Result<K>> func)
+        {
+            if (condition)
+                return result.Tap(func);
+            else
+                return result;
+        }
+
+        public static Result<T, E> TapIf<T, K, E>(this Result<T, E> result, bool condition, Func<T, Result<K, E>> func)
+        {
+            if (condition)
+                return result.Tap(func);
+            else
+                return result;
+        }
+
         /// <summary>
         ///     Executes the given action if the calling result is a success and condition is true. Returns the calling result.
         /// </summary>
@@ -99,6 +123,30 @@ namespace CSharpFunctionalExtensions
         {
             if (result.IsSuccess && predicate(result.Value))
                 return result.Tap(action);
+            else
+                return result;
+        }
+
+        public static Result<T> TapIf<T>(this Result<T> result, Func<T, bool> predicate, Func<T, Result> func)
+        {
+            if (result.IsSuccess && predicate(result.Value))
+                return result.Tap(func);
+            else
+                return result;
+        }
+
+        public static Result<T> TapIf<T, K>(this Result<T> result, Func<T, bool> predicate, Func<T, Result<K>> func)
+        {
+            if (result.IsSuccess && predicate(result.Value))
+                return result.Tap(func);
+            else
+                return result;
+        }
+
+        public static Result<T, E> TapIf<T, K, E>(this Result<T, E> result, Func<T, bool> predicate, Func<T, Result<K, E>> func)
+        {
+            if (result.IsSuccess && predicate(result.Value))
+                return result.Tap(func);
             else
                 return result;
         }

--- a/CSharpFunctionalExtensions/Result/Extensions/TapIfAsyncBoth.cs
+++ b/CSharpFunctionalExtensions/Result/Extensions/TapIfAsyncBoth.cs
@@ -60,6 +60,30 @@ namespace CSharpFunctionalExtensions
                 return resultTask;
         }
 
+        public static Task<Result<T>> TapIf<T>(this Task<Result<T>> resultTask, bool condition, Func<T, Task<Result>> func)
+        {
+            if (condition)
+                return resultTask.Tap(func);
+            else
+                return resultTask;
+        }
+
+        public static Task<Result<T>> TapIf<T, K>(this Task<Result<T>> resultTask, bool condition, Func<T, Task<Result<K>>> func)
+        {
+            if (condition)
+                return resultTask.Tap(func);
+            else
+                return resultTask;
+        }
+
+        public static Task<Result<T, E>> TapIf<T, K, E>(this Task<Result<T, E>> resultTask, bool condition, Func<T, Task<Result<K, E>>> func)
+        {
+            if (condition)
+                return resultTask.Tap(func);
+            else
+                return resultTask;
+        }
+
         /// <summary>
         ///     Executes the given action if the calling result is a success and condition is true. Returns the calling result.
         /// </summary>
@@ -103,6 +127,36 @@ namespace CSharpFunctionalExtensions
         ///     Executes the given action if the calling result is a success and condition is true. Returns the calling result.
         /// </summary>
         public static async Task<Result<T, E>> TapIf<T, E>(this Task<Result<T, E>> resultTask, Func<T, bool> predicate, Func<T, Task> func)
+        {
+            Result<T, E> result = await resultTask.DefaultAwait();
+
+            if (result.IsSuccess && predicate(result.Value))
+                return await result.Tap(func).DefaultAwait();
+            else
+                return result;
+        }
+
+        public static async Task<Result<T>> TapIf<T>(this Task<Result<T>> resultTask, Func<T, bool> predicate, Func<T, Task<Result>> func)
+        {
+            Result<T> result = await resultTask.DefaultAwait();
+
+            if (result.IsSuccess && predicate(result.Value))
+                return await result.Tap(func).DefaultAwait();
+            else
+                return result;
+        }
+
+        public static async Task<Result<T>> TapIf<T, K>(this Task<Result<T>> resultTask, Func<T, bool> predicate, Func<T, Task<Result<K>>> func)
+        {
+            Result<T> result = await resultTask.DefaultAwait();
+
+            if (result.IsSuccess && predicate(result.Value))
+                return await result.Tap(func).DefaultAwait();
+            else
+                return result;
+        }
+
+        public static async Task<Result<T, E>> TapIf<T, K, E>(this Task<Result<T, E>> resultTask, Func<T, bool> predicate, Func<T, Task<Result<K, E>>> func)
         {
             Result<T, E> result = await resultTask.DefaultAwait();
 

--- a/CSharpFunctionalExtensions/Result/Extensions/TapIfAsyncLeft.cs
+++ b/CSharpFunctionalExtensions/Result/Extensions/TapIfAsyncLeft.cs
@@ -60,6 +60,30 @@ namespace CSharpFunctionalExtensions
                 return resultTask;
         }
 
+        public static Task<Result<T>> TapIf<T>(this Task<Result<T>> resultTask, bool condition, Func<T, Result> func)
+        {
+            if (condition)
+                return resultTask.Tap(func);
+            else
+                return resultTask;
+        }
+
+        public static Task<Result<T>> TapIf<T, K>(this Task<Result<T>> resultTask, bool condition, Func<T, Result<K>> func)
+        {
+            if (condition)
+                return resultTask.Tap(func);
+            else
+                return resultTask;
+        }
+
+        public static Task<Result<T, E>> TapIf<T, K, E>(this Task<Result<T, E>> resultTask, bool condition, Func<T, Result<K, E>> func)
+        {
+            if (condition)
+                return resultTask.Tap(func);
+            else
+                return resultTask;
+        }
+
         /// <summary>
         ///     Executes the given action if the calling result is a success and condition is true. Returns the calling result.
         /// </summary>
@@ -108,6 +132,36 @@ namespace CSharpFunctionalExtensions
 
             if (result.IsSuccess && predicate(result.Value))
                 return result.Tap(action);
+            else
+                return result;
+        }
+
+        public static async Task<Result<T>> TapIf<T>(this Task<Result<T>> resultTask, Func<T, bool> predicate, Func<T, Result> func)
+        {
+            Result<T> result = await resultTask.DefaultAwait();
+
+            if (result.IsSuccess && predicate(result.Value))
+                return result.Tap(func);
+            else
+                return result;
+        }
+
+        public static async Task<Result<T>> TapIf<T, K>(this Task<Result<T>> resultTask, Func<T, bool> predicate, Func<T, Result<K>> func)
+        {
+            Result<T> result = await resultTask.DefaultAwait();
+
+            if (result.IsSuccess && predicate(result.Value))
+                return result.Tap(func);
+            else
+                return result;
+        }
+
+        public static async Task<Result<T, E>> TapIf<T, K, E>(this Task<Result<T, E>> resultTask, Func<T, bool> predicate, Func<T, Result<K, E>> func)
+        {
+            Result<T, E> result = await resultTask.DefaultAwait();
+
+            if (result.IsSuccess && predicate(result.Value))
+                return result.Tap(func);
             else
                 return result;
         }

--- a/CSharpFunctionalExtensions/Result/Extensions/TapIfAsyncRight.cs
+++ b/CSharpFunctionalExtensions/Result/Extensions/TapIfAsyncRight.cs
@@ -60,6 +60,30 @@ namespace CSharpFunctionalExtensions
                 return Task.FromResult(result);
         }
 
+        public static Task<Result<T>> TapIf<T>(this Result<T> result, bool condition, Func<T, Task<Result>> func)
+        {
+            if (condition)
+                return result.Tap(func);
+            else
+                return Task.FromResult(result);
+        }
+
+        public static Task<Result<T>> TapIf<T, K>(this Result<T> result, bool condition, Func<T, Task<Result<K>>> func)
+        {
+            if (condition)
+                return result.Tap(func);
+            else
+                return Task.FromResult(result);
+        }
+
+        public static Task<Result<T, E>> TapIf<T, K, E>(this Result<T, E> result, bool condition, Func<T, Task<Result<K, E>>> func)
+        {
+            if (condition)
+                return result.Tap(func);
+            else
+                return Task.FromResult(result);
+        }
+
         /// <summary>
         ///     Executes the given action if the calling result is a success and condition is true. Returns the calling result.
         /// </summary>
@@ -97,6 +121,30 @@ namespace CSharpFunctionalExtensions
         ///     Executes the given action if the calling result is a success and condition is true. Returns the calling result.
         /// </summary>
         public static Task<Result<T, E>> TapIf<T, E>(this Result<T, E> result, Func<T, bool> predicate, Func<T, Task> func)
+        {
+            if (result.IsSuccess && predicate(result.Value))
+                return result.Tap(func);
+            else
+                return Task.FromResult(result);
+        }
+
+        public static Task<Result<T>> TapIf<T>(this Result<T> result, Func<T, bool> predicate, Func<T, Task<Result>> func)
+        {
+            if (result.IsSuccess && predicate(result.Value))
+                return result.Tap(func);
+            else
+                return Task.FromResult(result);
+        }
+
+        public static Task<Result<T>> TapIf<T, K>(this Result<T> result, Func<T, bool> predicate, Func<T, Task<Result<K>>> func)
+        {
+            if (result.IsSuccess && predicate(result.Value))
+                return result.Tap(func);
+            else
+                return Task.FromResult(result);
+        }
+
+        public static Task<Result<T, E>> TapIf<T, K, E>(this Result<T, E> result, Func<T, bool> predicate, Func<T, Task<Result<K, E>>> func)
         {
             if (result.IsSuccess && predicate(result.Value))
                 return result.Tap(func);


### PR DESCRIPTION
TapIf overloads to handle result-returning funcs and associated tests.

@space-alien @vkhorikov  These should include all the related overloads for TapIf