### PR TITLE
Implement ToString() for Result<T>, Result<T,E>, Result

### DIFF
--- a/CSharpFunctionalExtensions.Tests/ResultTests/ToStringTests.cs
+++ b/CSharpFunctionalExtensions.Tests/ResultTests/ToStringTests.cs
@@ -1,0 +1,56 @@
+﻿using System;
+using Xunit;
+
+namespace CSharpFunctionalExtensions.Tests.ResultTests
+{
+    public class ToStringTests
+    {
+        [Fact]
+        public void ToString_returns_failure_with_error_when_failure()
+        {
+            var subject = Result.Failure("BigError");
+            Assert.Equal("Failure(BigError)", subject.ToString());
+        }
+
+        [Fact]
+        public void ToString_returns_failure_with_generic_result_error_when_failure()
+        {
+            var subject = Result.Failure<string>("BigError");
+            Assert.Equal("Failure(BigError)", subject.ToString());
+        }
+
+        [Fact]
+        public void ToString_returns_failure_with_generic_error_when_failure()
+        {
+            var subject = Result.Failure<String, ErrorType>(ErrorType.Error1);
+            Assert.Equal("Failure(Error1)", subject.ToString());
+        }
+
+        [Fact]
+        public void ToString_returns_success()
+        {
+            var subject = Result.Success();
+            Assert.Equal("Success", subject.ToString());
+        }
+
+        [Fact]
+        public void ToString_returns_success_with_generic_result()
+        {
+            var subject = Result.Success(1);
+            Assert.Equal("Success(1)", subject.ToString());
+        }
+
+        [Fact]
+        public void ToString_returns_success_with_generic_result_and_generic_error()
+        {
+            var subject = Result.Success<int, ErrorType>(1);
+            Assert.Equal("Success(1)", subject.ToString());
+        }
+
+
+        enum ErrorType
+        {
+            Error1
+        }
+    }
+}

--- a/CSharpFunctionalExtensions/Result/Methods/ToString.cs
+++ b/CSharpFunctionalExtensions/Result/Methods/ToString.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace CSharpFunctionalExtensions
+{
+    public partial struct Result
+    {
+        public override string ToString()
+        {
+            return IsSuccess ? "Success" : $"Failure({Error})";
+        }
+    }
+
+
+    public partial struct Result<T>
+    {
+        public override string ToString()
+        {
+            return IsSuccess ? $"Success({Value})" : $"Failure({Error})";
+        }
+    }
+
+
+    public partial struct Result<T, E>
+    {
+        public override string ToString()
+        {
+            return IsSuccess ? $"Success({Value})" : $"Failure({Error})";
+        }
+    }
+}


### PR DESCRIPTION
#194 

Implement ToString() for Result<T>, Result<T,E>, Result to make the debugging experience more pleasant for the clients of this library