### PR TITLE
Add OnSuccessTry returning Task

### DIFF
--- a/CSharpFunctionalExtensions.Tests/ResultTests/ResultTests.cs
+++ b/CSharpFunctionalExtensions.Tests/ResultTests/ResultTests.cs
@@ -674,5 +674,35 @@ namespace CSharpFunctionalExtensions.Tests.ResultTests
         private class Error
         {
         }
+
+        [Fact]
+        public async Task When_Asynchronous_Continuation_Passed_To_On_Success_Try_Then_Needs_To_Be_Handled_As_Awaitable() {
+            var content = "my key";
+            var result = Result.Success<string>(content);
+
+            await result
+                .OnSuccessTry(async (key) => {
+                    await Task.Delay(10);
+                    var task = Task.FromResult(key);
+                    var k = await task;
+                    k.Should().Be(content);
+                });
+        }
+
+        [Fact]
+        public async Task When_Asynchronous_Continuation_Passed_With_Typed_Error_To_On_Success_Try_Then_Needs_To_Be_Handled_As_Awaitable()
+        {
+            var content = "my key";
+            var result = Result.Success<string, Error>(content);
+
+            await result
+                .OnSuccessTry(async (key) =>
+                {
+                    await Task.Delay(10);
+                    var task = Task.FromResult(key);
+                    var k = await task;
+                    k.Should().Be(content);
+                });
+        }
     }
 }

--- a/CSharpFunctionalExtensions/Result/Extensions/OnSuccessTryAsyncLeft.cs
+++ b/CSharpFunctionalExtensions/Result/Extensions/OnSuccessTryAsyncLeft.cs
@@ -32,5 +32,21 @@ namespace CSharpFunctionalExtensions
             var result = await task.DefaultAwait();
             return result.OnSuccessTry(action, errorHandler);
         }
+
+        public static async Task OnSuccessTry<T>(this Result<T> result, Func<T, Task> func)
+        {
+            if (result.IsSuccess)
+            {
+                await func(result.Value);
+            }
+        }
+
+        public static async Task OnSuccessTry<T, E>(this Result<T, E> result, Func<T, Task> func)
+        {
+            if (result.IsSuccess)
+            {
+                await func(result.Value);
+            }
+        }
     }
 }


### PR DESCRIPTION
This PR fixes the scenario when there's async method/function returning `Task` and we're feeding our `OnSuccessTry` with async lambda. I lost three days debugging and turned out I was missing `await` before my `Result<T>`, but compiler didn't complain. Hopefully it will save someone's time in the future ;-)