### PR TITLE
Calling .Combine() and getting its value on a Result leads to multiple enumeration

### DIFF
--- a/CSharpFunctionalExtensions.Tests/ResultTests/CombineMethodTests.cs
+++ b/CSharpFunctionalExtensions.Tests/ResultTests/CombineMethodTests.cs
@@ -1,8 +1,10 @@
-﻿using FluentAssertions;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using FluentAssertions;
 using Xunit;
+using static CSharpFunctionalExtensions.Tests.ResultTests.CombineWithErrorMethodTests;
 
 namespace CSharpFunctionalExtensions.Tests.ResultTests
 {
@@ -183,6 +185,114 @@ namespace CSharpFunctionalExtensions.Tests.ResultTests
 
             result.IsSuccess.Should().BeFalse();
             result.Error.Should().Be("m;o");
+        }
+
+        [Fact]
+        public void Combine_T_E_results_in_only_one_iteration_over_input_enumerable()
+        {
+            var count = 0;
+            Result<int, Error> CountIterations(int input)
+            {
+                count++;
+                return input;
+            };
+
+            IEnumerable<Result<int, Error>> results = Enumerable.Range(0, 1)
+                .Select(i => CountIterations(i));
+
+            var result = results.Combine().Value.ToList();
+
+            count.Should().Be(1);
+        }
+
+        [Fact]
+        public void Combine_T_E_with_composer_results_in_only_one_iteration_over_input_enumerable()
+        {
+            var count = 0;
+            Result<int, Exception> CountIterations(int input)
+            {
+                count++;
+                return input;
+            };
+
+            IEnumerable<Result<int, Exception>> results = Enumerable.Range(0, 1)
+                .Select(i => CountIterations(i));
+
+            var result = results.Combine(exs => new AggregateException(exs)).Value.ToList();
+
+            count.Should().Be(1);
+        }
+
+        [Fact]
+        public void Combine_T_results_in_only_one_iteration_over_input_enumerable()
+        {
+            var count = 0;
+            Result<int> CountIterations(int input)
+            {
+                count++;
+                return input;
+            };
+
+            IEnumerable<Result<int>> results = Enumerable.Range(0, 1)
+                .Select(i => CountIterations(i));
+
+            var result = results.Combine().Value.ToList();
+
+            count.Should().Be(1);
+        }
+
+        [Fact]
+        public void Combine_T_K_E_with_composer_error_results_in_only_one_iteration_over_input_enumerable()
+        {
+            var count = 0;
+            Result<int, Exception> CountIterations(int input)
+            {
+                count++;
+                return input;
+            };
+
+            IEnumerable<Result<int, Exception>> results = Enumerable.Range(0, 1)
+                .Select(i => CountIterations(i));
+
+            var result = results.Combine(v => v.Sum(), exs => new AggregateException(exs)).Value;
+
+            count.Should().Be(1);
+        }
+
+        [Fact]
+        public void Combine_T_K_E_results_in_only_one_iteration_over_input_enumerable()
+        {
+            var count = 0;
+            Result<int, Error> CountIterations(int input)
+            {
+                count++;
+                return input;
+            };
+
+            IEnumerable<Result<int, Error>> results = Enumerable.Range(0, 1)
+                .Select(i => CountIterations(i));
+
+            var result = results.Combine(v => v.Sum()).Value;
+
+            count.Should().Be(1);
+        }
+
+        [Fact]
+        public void Combine_T_K_results_in_only_one_iteration_over_input_enumerable()
+        {
+            var count = 0;
+            Result<int> CountIterations(int input)
+            {
+                count++;
+                return input;
+            };
+
+            IEnumerable<Result<int>> results = Enumerable.Range(0, 1)
+                .Select(i => CountIterations(i));
+
+            var result = results.Combine(v => v.Sum()).Value;
+
+            count.Should().Be(1);
         }
 
         [Fact]

--- a/CSharpFunctionalExtensions/Result/Extensions/Combine.cs
+++ b/CSharpFunctionalExtensions/Result/Extensions/Combine.cs
@@ -12,6 +12,7 @@ namespace CSharpFunctionalExtensions
         public static Result<IEnumerable<T>, E> Combine<T, E>(this IEnumerable<Result<T, E>> results)
             where E : ICombine
         {
+            results = results.ToList();
             Result<bool, E> result = Result.Combine(results);
 
             return result.IsSuccess
@@ -22,6 +23,7 @@ namespace CSharpFunctionalExtensions
 
         public static Result<IEnumerable<T>, E> Combine<T, E>(this IEnumerable<Result<T, E>> results, Func<IEnumerable<E>, E> composerError)
         {
+            results = results.ToList();
             Result<bool, E> result = Result.Combine(results, composerError);
 
             return result.IsSuccess
@@ -31,6 +33,7 @@ namespace CSharpFunctionalExtensions
 
         public static Result<IEnumerable<T>> Combine<T>(this IEnumerable<Result<T>> results, string errorMessageSeparator = null)
         {
+            results = results.ToList();
             Result result = Result.Combine(results, errorMessageSeparator);
 
             return result.IsSuccess


### PR DESCRIPTION
Pull request for issue #215.