### PR TITLE
Fix Maybe.TryFirst with predicate for types where null is not the default

### DIFF
--- a/CSharpFunctionalExtensions.Tests/MaybeTests/ExtensionsTests.cs
+++ b/CSharpFunctionalExtensions.Tests/MaybeTests/ExtensionsTests.cs
@@ -335,9 +335,9 @@ namespace CSharpFunctionalExtensions.Tests.MaybeTests
         }
         
         [Fact]
-        public void TryFirst_predicate_source_empty()
+        public void TryFirst_source_predicate_not_contains_default_is_not_null()
         {
-            var source = new int[0];
+            var source = new[] { 1, 2, 3 };
 
             var maybe = source.TryFirst(x => x == 5);
 

--- a/CSharpFunctionalExtensions.Tests/MaybeTests/ExtensionsTests.cs
+++ b/CSharpFunctionalExtensions.Tests/MaybeTests/ExtensionsTests.cs
@@ -333,6 +333,16 @@ namespace CSharpFunctionalExtensions.Tests.MaybeTests
 
             maybe.HasValue.Should().BeFalse();
         }
+        
+        [Fact]
+        public void TryFirst_predicate_source_empty()
+        {
+            var source = new int[0];
+
+            var maybe = source.TryFirst(x => x == 5);
+
+            maybe.HasValue.Should().BeFalse();
+        }
 
         [Fact]
         public void TryLast_source_has_elements()

--- a/CSharpFunctionalExtensions/Maybe/MaybeExtensions.cs
+++ b/CSharpFunctionalExtensions/Maybe/MaybeExtensions.cs
@@ -145,10 +145,10 @@ namespace CSharpFunctionalExtensions
 
         public static Maybe<T> TryFirst<T>(this IEnumerable<T> source, Func<T, bool> predicate)
         {
-            var first = source.FirstOrDefault(predicate);
-            if (first != null)
+            var firstOrEmpty = source.Where(predicate).Take(1).ToList();
+            if (firstOrEmpty.Any())
             {
-                return Maybe<T>.From(first);
+                return Maybe<T>.From(firstOrEmpty[0]);
             }
             return Maybe<T>.None;
         }


### PR DESCRIPTION
It would return a Maybe with Value for any type for which type default is not 0, eg primitives, tuples, even though there was no item in the enumerable matching the predicate.