### PR TITLE
Added Aggregate function for Result array

### DIFF
--- a/CSharpFunctionalExtensions/Result/Extensions/Aggregate.cs
+++ b/CSharpFunctionalExtensions/Result/Extensions/Aggregate.cs
@@ -1,0 +1,38 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+
+namespace CSharpFunctionalExtensions
+{
+    public static partial class ResultExtensions
+    {
+        /// <summary>
+        ///     Creates a new result from a enumeration of results. If one fails the new result will have the combined result
+        /// </summary>
+        public static Result<IEnumerable<TValue>> Aggregate<TValue>(this IEnumerable<Result<TValue>> results, string errorMessagesSeparator = null)
+        {
+            Result<TValue>[] resultsArray = results.ToArray();
+            Result combined = Result.Combine(resultsArray, errorMessagesSeparator);
+            if (combined.IsFailure)
+            {
+                return Result.Failure<IEnumerable<TValue>>(combined.Error);
+            }
+
+            return Result.Success<IEnumerable<TValue>>(resultsArray.Select(result => result.Value).ToList());
+        }
+
+        /// <summary>
+        ///     Creates a new result from a enumeration of results. If one fails the new result will have the combined result
+        /// </summary>
+        public static Result Aggregate(this IEnumerable<Result> results, string errorMessagesSeparator = null)
+        {
+            Result[] resultsArray = results.ToArray();
+            Result combined = Result.Combine(resultsArray, errorMessagesSeparator);
+            if (combined.IsFailure)
+            {
+                return Result.Failure(combined.Error);
+            }
+
+            return Result.Success();
+        }
+    }
+}

--- a/CSharpFunctionalExtensions/Result/Extensions/Aggregate.cs
+++ b/CSharpFunctionalExtensions/Result/Extensions/Aggregate.cs
@@ -17,7 +17,7 @@ namespace CSharpFunctionalExtensions
                 return Result.Failure<IEnumerable<TValue>>(combined.Error);
             }
 
-            return Result.Success<IEnumerable<TValue>>(resultsArray.Select(result => result.Value).ToList());
+            return Result.Success(resultsArray.Select(result => result.Value));
         }
 
         /// <summary>


### PR DESCRIPTION
This will introduce a new extension method: `Aggregate`.

Sometimes you will run in the following situation:
```csharp
private static Result<MyObject> CreateMyObjects(IList<CreateParameter> createParameter)
{
    var results = createParameter.Select(CreateMyObject);
```

This will give you a list / enumeration of results. But for later uses you just wanna know if one of those have failed or not.

This where `Aggregate` comes in handy:
```csharp
private static Result<MyObject> CreateMyObjects(IList<CreateParameter> createParameter)
{
    var results = createParameter.Select(CreateMyObject).Aggregate();
    if (results.IsFailure)
```