### PR TITLE
Remove unnecessary generic constraints and add tests

### DIFF
--- a/CSharpFunctionalExtensions.Tests/MaybeTests/AsyncExtensionsTests.cs
+++ b/CSharpFunctionalExtensions.Tests/MaybeTests/AsyncExtensionsTests.cs
@@ -8,6 +8,89 @@ namespace CSharpFunctionalExtensions.Tests.MaybeTests
     public class AsyncExtensionsTests
     {
         [Fact]
+        public async Task ToResult_returns_failure_if_has_no_value()
+        {
+            var maybeTask = GetMaybeTask(Maybe<MyClass>.None);
+
+            Result<MyClass> result = await maybeTask.ToResult("Error");
+
+            result.IsSuccess.Should().BeFalse();
+            result.Error.Should().Be("Error");
+        }
+
+        [Fact]
+        public async Task ToResult_returns_success_if_has_value()
+        {
+            var instance = new MyClass();
+            var maybeTask = GetMaybeTask(instance);
+
+            Result<MyClass> result = await maybeTask.ToResult("Error");
+
+            result.IsSuccess.Should().BeTrue();
+            result.Value.Should().Be(instance);
+        }
+
+        [Fact]
+        public async Task ToResult_value_type_returns_success_if_has_value()
+        {
+            var instance = Guid.NewGuid();
+            var maybeTask = Maybe<Guid>.From(instance).AsTask();
+
+            Result<Guid> result = await maybeTask.ToResult("Error");
+
+            result.IsSuccess.Should().BeTrue();
+            result.Value.Should().Be(instance);
+        }
+
+        [Fact]
+        public async Task ToResult_returns_custom_failure_if_has_no_value()
+        {
+            var maybeTask = GetMaybeTask(Maybe<MyClass>.None);
+            var error = new MyErrorClass();
+
+            Result<MyClass, MyErrorClass> result = await maybeTask.ToResult(error);
+
+            result.IsSuccess.Should().BeFalse();
+            result.Error.Should().Be(error);
+        }
+
+        [Fact]
+        public async Task ToResult_returns_custom_value_type_failure_if_has_no_value()
+        {
+            var maybeTask = GetMaybeTask(Maybe<MyClass>.None);
+            var error = Guid.NewGuid();
+
+            Result<MyClass, Guid> result = await maybeTask.ToResult(error);
+
+            result.IsSuccess.Should().BeFalse();
+            result.Error.Should().Be(error);
+        }
+
+        [Fact]
+        public async Task ToResult_custom_failure_returns_success_if_has_value()
+        {
+            var instance = new MyClass();
+            var maybeTask = GetMaybeTask(instance);
+
+            Result<MyClass, MyErrorClass> result = await maybeTask.ToResult(new MyErrorClass());
+
+            result.IsSuccess.Should().BeTrue();
+            result.Value.Should().Be(instance);
+        }
+
+        [Fact]
+        public async Task ToResult_custom_failure_value_type_returns_success_if_has_value()
+        {
+            var instance = Guid.NewGuid();
+            var maybeTask = Maybe<Guid>.From(instance).AsTask();
+
+            Result<Guid, MyErrorClass> result = await maybeTask.ToResult(new MyErrorClass());
+
+            result.IsSuccess.Should().BeTrue();
+            result.Value.Should().Be(instance);
+        }
+
+        [Fact]
         public async Task Async_Left_Where_returns_value_if_predicate_returns_true()
         {
             var instance = new MyClass { Property = "Some value" };
@@ -319,6 +402,10 @@ namespace CSharpFunctionalExtensions.Tests.MaybeTests
         {
             public string Property { get; set; }
             public int IntProperty { get; set; }
+        }
+
+        private class MyErrorClass
+        {
         }
     }
 }

--- a/CSharpFunctionalExtensions/Maybe/AsyncMaybeExtensions.cs
+++ b/CSharpFunctionalExtensions/Maybe/AsyncMaybeExtensions.cs
@@ -6,13 +6,12 @@ namespace CSharpFunctionalExtensions
     public static class AsyncMaybeExtensions
     {
         public static async Task<Result<T>> ToResult<T>(this Task<Maybe<T>> maybeTask, string errorMessage)
-            where T : class
         {
             Maybe<T> maybe = await maybeTask.DefaultAwait();
             return maybe.ToResult(errorMessage);
         }
 
-        public static async Task<Result<T, E>> ToResult<T, E>(this Task<Maybe<T>> maybeTask, E error) where T : class
+        public static async Task<Result<T, E>> ToResult<T, E>(this Task<Maybe<T>> maybeTask, E error)
         {
             Maybe<T> maybe = await maybeTask.DefaultAwait();
             return maybe.ToResult(error);


### PR DESCRIPTION
`ToResult` extensions for `Task<Maybe<T>>` have `T: class` generic constraint (I believe because of historical reasons). This PR removes them and add tests for these extensions (they were not covered previously).