### PR TITLE
Added Ensure method where the object is available to generate error message.

### DIFF
--- a/CSharpFunctionalExtensions/Result/Extensions/Ensure.cs
+++ b/CSharpFunctionalExtensions/Result/Extensions/Ensure.cs
@@ -35,6 +35,20 @@ namespace CSharpFunctionalExtensions
         /// <summary>
         ///     Returns a new failure result if the predicate is false. Otherwise returns the starting result.
         /// </summary>
+        public static Result<T> Ensure<T>(this Result<T> result, Func<T, bool> predicate, Func<T, string> errorMessage)
+        {
+            if (result.IsFailure)
+                return result;
+
+            if (!predicate(result.Value))
+                return Result.Failure<T>(errorMessage(result.Value));
+
+            return result;
+        }
+
+        /// <summary>
+        ///     Returns a new failure result if the predicate is false. Otherwise returns the starting result.
+        /// </summary>
         public static Result Ensure(this Result result, Func<bool> predicate, string errorMessage)
         {
             if (result.IsFailure)


### PR DESCRIPTION
There have been times where I would like the object I am using in the ensure method available to generate the error message. For example..
```
 return GetById(id)
                .ToResult("Customer with such Id is not found: " + id)
                .Ensure(customer => customer.CanBePromoted(), customer => $"The customer {customer.Email} has the highest status possible")
                .Tap(customer => customer.Promote())
                .Bind(customer => gateway.SendPromotionNotification(customer.Email))
                .Finally(result => result.IsSuccess ? "Ok" : result.Error);
```