### PR TITLE
Changed some Tap and TapIf overloads to Check and CheckIf

### DIFF
--- a/CSharpFunctionalExtensions.Examples/ResultExtensions/ExampleWithOnFailureMethod.cs
+++ b/CSharpFunctionalExtensions.Examples/ResultExtensions/ExampleWithOnFailureMethod.cs
@@ -12,7 +12,7 @@ namespace CSharpFunctionalExtensions.Examples.ResultExtensions
             return GetById(customerId)
                 .ToResult("Customer with such Id is not found: " + customerId)
                 .Tap(customer => customer.AddBalance(moneyAmount))
-                .Tap(customer => paymentGateway.ChargePayment(customer, moneyAmount))
+                .Check(customer => paymentGateway.ChargePayment(customer, moneyAmount))
                 .Bind(
                     customer => database.Save(customer)
                         .OnFailure(() => paymentGateway.RollbackLastTransaction()))

--- a/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/CheckAsyncBothTests.cs
+++ b/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/CheckAsyncBothTests.cs
@@ -1,0 +1,50 @@
+using FluentAssertions;
+using Xunit;
+
+namespace CSharpFunctionalExtensions.Tests.ResultTests.Extensions
+{
+    public class CheckAsyncBothTests : CheckTestsBase
+    {
+        [Theory]
+        [InlineData(true, true)]
+        [InlineData(true, false)]
+        [InlineData(false, false)]
+        public void Tap_T_AsyncBoth_func_result(bool resultSuccess, bool funcSuccess)
+        {
+            Result<T> result = Result.SuccessIf(resultSuccess, T.Value, ErrorMessage);
+
+            var returned = result.AsTask().Check(_ => GetResult(funcSuccess).AsTask()).Result;
+
+            actionExecuted.Should().Be(resultSuccess);
+            returned.Should().Be(funcSuccess ? result : FailedResultT);
+        }
+
+        [Theory]
+        [InlineData(true, true)]
+        [InlineData(true, false)]
+        [InlineData(false, false)]
+        public void Tap_T_AsyncBoth_func_result_K(bool resultSuccess, bool funcSuccess)
+        {
+            Result<T> result = Result.SuccessIf(resultSuccess, T.Value, ErrorMessage);
+
+            var returned = result.AsTask().Check(Func_Task_Result_K(funcSuccess)).Result;
+
+            actionExecuted.Should().Be(resultSuccess);
+            returned.Should().Be(funcSuccess ? result : FailedResultT);
+        }
+
+        [Theory]
+        [InlineData(true, true)]
+        [InlineData(true, false)]
+        [InlineData(false, false)]
+        public void Tap_T_AsyncBoth_func_result_KE(bool resultSuccess, bool funcSuccess)
+        {
+            Result<T, E> result = Result.SuccessIf(resultSuccess, T.Value, E.Value);
+
+            var returned = result.AsTask().Check(Func_Task_Result_KE(funcSuccess)).Result;
+
+            actionExecuted.Should().Be(resultSuccess);
+            returned.Should().Be(funcSuccess ? result : returned);
+        }
+    }
+}

--- a/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/CheckAsyncBothTests.cs
+++ b/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/CheckAsyncBothTests.cs
@@ -9,7 +9,7 @@ namespace CSharpFunctionalExtensions.Tests.ResultTests.Extensions
         [InlineData(true, true)]
         [InlineData(true, false)]
         [InlineData(false, false)]
-        public void Tap_T_AsyncBoth_func_result(bool resultSuccess, bool funcSuccess)
+        public void Check_T_AsyncBoth_func_result(bool resultSuccess, bool funcSuccess)
         {
             Result<T> result = Result.SuccessIf(resultSuccess, T.Value, ErrorMessage);
 
@@ -23,7 +23,7 @@ namespace CSharpFunctionalExtensions.Tests.ResultTests.Extensions
         [InlineData(true, true)]
         [InlineData(true, false)]
         [InlineData(false, false)]
-        public void Tap_T_AsyncBoth_func_result_K(bool resultSuccess, bool funcSuccess)
+        public void Check_T_AsyncBoth_func_result_K(bool resultSuccess, bool funcSuccess)
         {
             Result<T> result = Result.SuccessIf(resultSuccess, T.Value, ErrorMessage);
 
@@ -37,7 +37,7 @@ namespace CSharpFunctionalExtensions.Tests.ResultTests.Extensions
         [InlineData(true, true)]
         [InlineData(true, false)]
         [InlineData(false, false)]
-        public void Tap_T_AsyncBoth_func_result_KE(bool resultSuccess, bool funcSuccess)
+        public void Check_T_AsyncBoth_func_result_KE(bool resultSuccess, bool funcSuccess)
         {
             Result<T, E> result = Result.SuccessIf(resultSuccess, T.Value, E.Value);
 

--- a/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/CheckAsyncLeftTests.cs
+++ b/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/CheckAsyncLeftTests.cs
@@ -9,7 +9,7 @@ namespace CSharpFunctionalExtensions.Tests.ResultTests.Extensions
         [InlineData(true, true)]
         [InlineData(true, false)]
         [InlineData(false, false)]
-        public void Tap_T_AsyncLeft_func_result(bool resultSuccess, bool funcSuccess)
+        public void Check_T_AsyncLeft_func_result(bool resultSuccess, bool funcSuccess)
         {
             Result<T> result = Result.SuccessIf(resultSuccess, T.Value, ErrorMessage);
 
@@ -23,7 +23,7 @@ namespace CSharpFunctionalExtensions.Tests.ResultTests.Extensions
         [InlineData(true, true)]
         [InlineData(true, false)]
         [InlineData(false, false)]
-        public void Tap_T_AsyncLeft_func_result_KE(bool resultSuccess, bool funcSuccess)
+        public void Check_T_AsyncLeft_func_result_KE(bool resultSuccess, bool funcSuccess)
         {
             Result<T, E> result = Result.SuccessIf(resultSuccess, T.Value, E.Value);
 
@@ -37,7 +37,7 @@ namespace CSharpFunctionalExtensions.Tests.ResultTests.Extensions
         [InlineData(true, true)]
         [InlineData(true, false)]
         [InlineData(false, false)]
-        public void Tap_T_AsyncLeft_func_result_K(bool resultSuccess, bool funcSuccess)
+        public void Check_T_AsyncLeft_func_result_K(bool resultSuccess, bool funcSuccess)
         {
             Result<T> result = Result.SuccessIf(resultSuccess, T.Value, ErrorMessage);
 

--- a/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/CheckAsyncLeftTests.cs
+++ b/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/CheckAsyncLeftTests.cs
@@ -1,0 +1,50 @@
+using FluentAssertions;
+using Xunit;
+
+namespace CSharpFunctionalExtensions.Tests.ResultTests.Extensions
+{
+    public class CheckAsyncLeftTests : CheckTestsBase
+    {
+        [Theory]
+        [InlineData(true, true)]
+        [InlineData(true, false)]
+        [InlineData(false, false)]
+        public void Tap_T_AsyncLeft_func_result(bool resultSuccess, bool funcSuccess)
+        {
+            Result<T> result = Result.SuccessIf(resultSuccess, T.Value, ErrorMessage);
+
+            var returned = result.AsTask().Check(_ => GetResult(funcSuccess)).Result;
+
+            actionExecuted.Should().Be(resultSuccess);
+            returned.Should().Be(funcSuccess ? result : FailedResultT);
+        }
+        
+        [Theory]
+        [InlineData(true, true)]
+        [InlineData(true, false)]
+        [InlineData(false, false)]
+        public void Tap_T_AsyncLeft_func_result_KE(bool resultSuccess, bool funcSuccess)
+        {
+            Result<T, E> result = Result.SuccessIf(resultSuccess, T.Value, E.Value);
+
+            var returned = result.AsTask().Check(Func_Result_KE(funcSuccess)).Result;
+
+            actionExecuted.Should().Be(resultSuccess);
+            returned.Should().Be(funcSuccess ? result : returned);
+        }
+        
+        [Theory]
+        [InlineData(true, true)]
+        [InlineData(true, false)]
+        [InlineData(false, false)]
+        public void Tap_T_AsyncLeft_func_result_K(bool resultSuccess, bool funcSuccess)
+        {
+            Result<T> result = Result.SuccessIf(resultSuccess, T.Value, ErrorMessage);
+
+            var returned = result.AsTask().Check(Func_Result_K(funcSuccess)).Result;
+
+            actionExecuted.Should().Be(resultSuccess);
+            returned.Should().Be(funcSuccess ? result : FailedResultT);
+        }
+    }
+}

--- a/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/CheckAsyncRightTests.cs
+++ b/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/CheckAsyncRightTests.cs
@@ -1,0 +1,50 @@
+using FluentAssertions;
+using Xunit;
+
+namespace CSharpFunctionalExtensions.Tests.ResultTests.Extensions
+{
+    public class CheckAsyncRightTests : CheckTestsBase
+    {
+        [Theory]
+        [InlineData(true, true)]
+        [InlineData(true, false)]
+        [InlineData(false, false)]
+        public void Tap_T_AsyncRight_func_result(bool resultSuccess, bool funcSuccess)
+        {
+            Result<T> result = Result.SuccessIf(resultSuccess, T.Value, ErrorMessage);
+
+            var returned = result.Check(_ => GetResult(funcSuccess).AsTask()).Result;
+
+            actionExecuted.Should().Be(resultSuccess);
+            returned.Should().Be(funcSuccess ? result : FailedResultT);
+        }
+        
+        [Theory]
+        [InlineData(true, true)]
+        [InlineData(true, false)]
+        [InlineData(false, false)]
+        public void Tap_T_AsyncRight_func_result_KE(bool resultSuccess, bool funcSuccess)
+        {
+            Result<T, E> result = Result.SuccessIf(resultSuccess, T.Value, E.Value);
+
+            var returned = result.Check(Func_Task_Result_KE(funcSuccess)).Result;
+
+            actionExecuted.Should().Be(resultSuccess);
+            returned.Should().Be(funcSuccess ? result : returned);
+        }
+        
+        [Theory]
+        [InlineData(true, true)]
+        [InlineData(true, false)]
+        [InlineData(false, false)]
+        public void Tap_T_AsyncRight_func_result_K(bool resultSuccess, bool funcSuccess)
+        {
+            Result<T> result = Result.SuccessIf(resultSuccess, T.Value, ErrorMessage);
+
+            var returned = result.Check(Func_Task_Result_K(funcSuccess)).Result;
+
+            actionExecuted.Should().Be(resultSuccess);
+            returned.Should().Be(funcSuccess ? result : FailedResultT);
+        }
+    }
+}

--- a/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/CheckAsyncRightTests.cs
+++ b/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/CheckAsyncRightTests.cs
@@ -9,7 +9,7 @@ namespace CSharpFunctionalExtensions.Tests.ResultTests.Extensions
         [InlineData(true, true)]
         [InlineData(true, false)]
         [InlineData(false, false)]
-        public void Tap_T_AsyncRight_func_result(bool resultSuccess, bool funcSuccess)
+        public void Check_T_AsyncRight_func_result(bool resultSuccess, bool funcSuccess)
         {
             Result<T> result = Result.SuccessIf(resultSuccess, T.Value, ErrorMessage);
 
@@ -23,7 +23,7 @@ namespace CSharpFunctionalExtensions.Tests.ResultTests.Extensions
         [InlineData(true, true)]
         [InlineData(true, false)]
         [InlineData(false, false)]
-        public void Tap_T_AsyncRight_func_result_KE(bool resultSuccess, bool funcSuccess)
+        public void Check_T_AsyncRight_func_result_KE(bool resultSuccess, bool funcSuccess)
         {
             Result<T, E> result = Result.SuccessIf(resultSuccess, T.Value, E.Value);
 
@@ -37,7 +37,7 @@ namespace CSharpFunctionalExtensions.Tests.ResultTests.Extensions
         [InlineData(true, true)]
         [InlineData(true, false)]
         [InlineData(false, false)]
-        public void Tap_T_AsyncRight_func_result_K(bool resultSuccess, bool funcSuccess)
+        public void Check_T_AsyncRight_func_result_K(bool resultSuccess, bool funcSuccess)
         {
             Result<T> result = Result.SuccessIf(resultSuccess, T.Value, ErrorMessage);
 

--- a/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/CheckIfAsyncBothTests.cs
+++ b/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/CheckIfAsyncBothTests.cs
@@ -10,7 +10,7 @@ namespace CSharpFunctionalExtensions.Tests.ResultTests.Extensions
         [InlineData(true, false)]
         [InlineData(false, true)]
         [InlineData(false, false)]
-        public void TapIf_T_AsyncBoth_executes_func_result_T_conditionally_and_returns_self(bool isSuccess, bool condition)
+        public void CheckIf_T_AsyncBoth_executes_func_result_T_conditionally_and_returns_self(bool isSuccess, bool condition)
         {
             Result<bool> result = Result.SuccessIf(isSuccess, condition, ErrorMessage);
 
@@ -25,7 +25,7 @@ namespace CSharpFunctionalExtensions.Tests.ResultTests.Extensions
         [InlineData(true, false)]
         [InlineData(false, true)]
         [InlineData(false, false)]
-        public void TapIf_T_AsyncBoth_executes_func_result_K_conditionally_and_returns_self(bool isSuccess, bool condition)
+        public void CheckIf_T_AsyncBoth_executes_func_result_K_conditionally_and_returns_self(bool isSuccess, bool condition)
         {
             Result<bool> result = Result.SuccessIf(isSuccess, condition, ErrorMessage);
 
@@ -40,7 +40,7 @@ namespace CSharpFunctionalExtensions.Tests.ResultTests.Extensions
         [InlineData(true, false)]
         [InlineData(false, true)]
         [InlineData(false, false)]
-        public void TapIf_T_AsyncBoth_executes_func_result_K_E_conditionally_and_returns_self(bool isSuccess, bool condition)
+        public void CheckIf_T_AsyncBoth_executes_func_result_K_E_conditionally_and_returns_self(bool isSuccess, bool condition)
         {
             Result<bool, E> result = Result.SuccessIf(isSuccess, condition, E.Value);
 
@@ -55,7 +55,7 @@ namespace CSharpFunctionalExtensions.Tests.ResultTests.Extensions
         [InlineData(true, false)]
         [InlineData(false, true)]
         [InlineData(false, false)]
-        public void TapIf_T_AsyncBoth_executes_func_result_T_per_predicate_and_returns_self(bool isSuccess, bool condition)
+        public void CheckIf_T_AsyncBoth_executes_func_result_T_per_predicate_and_returns_self(bool isSuccess, bool condition)
         {
             Result<bool> result = Result.SuccessIf(isSuccess, condition, ErrorMessage);
 
@@ -70,7 +70,7 @@ namespace CSharpFunctionalExtensions.Tests.ResultTests.Extensions
         [InlineData(true, false)]
         [InlineData(false, true)]
         [InlineData(false, false)]
-        public void TapIf_T_AsyncBoth_executes_func_result_K_per_predicate_and_returns_self(bool isSuccess, bool condition)
+        public void CheckIf_T_AsyncBoth_executes_func_result_K_per_predicate_and_returns_self(bool isSuccess, bool condition)
         {
             Result<bool> result = Result.SuccessIf(isSuccess, condition, ErrorMessage);
 
@@ -85,7 +85,7 @@ namespace CSharpFunctionalExtensions.Tests.ResultTests.Extensions
         [InlineData(true, false)]
         [InlineData(false, true)]
         [InlineData(false, false)]
-        public void TapIf_T_AsyncBoth_executes_func_result_K_E_per_predicate_and_returns_self(bool isSuccess, bool condition)
+        public void CheckIf_T_AsyncBoth_executes_func_result_K_E_per_predicate_and_returns_self(bool isSuccess, bool condition)
         {
             Result<bool, E> result = Result.SuccessIf(isSuccess, condition, E.Value);
 

--- a/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/CheckIfAsyncBothTests.cs
+++ b/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/CheckIfAsyncBothTests.cs
@@ -1,0 +1,98 @@
+using FluentAssertions;
+using Xunit;
+
+namespace CSharpFunctionalExtensions.Tests.ResultTests.Extensions
+{
+    public class CheckIfAsyncBothTests : CheckIfTestsBase
+    {
+        [Theory]
+        [InlineData(true, true)]
+        [InlineData(true, false)]
+        [InlineData(false, true)]
+        [InlineData(false, false)]
+        public void TapIf_T_AsyncBoth_executes_func_result_T_conditionally_and_returns_self(bool isSuccess, bool condition)
+        {
+            Result<bool> result = Result.SuccessIf(isSuccess, condition, ErrorMessage);
+
+            var returned = result.AsTask().CheckIf(condition, Task_Func_Result).Result;
+
+            actionExecuted.Should().Be(isSuccess && condition);
+            result.Should().Be(returned);
+        }
+
+        [Theory]
+        [InlineData(true, true)]
+        [InlineData(true, false)]
+        [InlineData(false, true)]
+        [InlineData(false, false)]
+        public void TapIf_T_AsyncBoth_executes_func_result_K_conditionally_and_returns_self(bool isSuccess, bool condition)
+        {
+            Result<bool> result = Result.SuccessIf(isSuccess, condition, ErrorMessage);
+
+            var returned = result.AsTask().CheckIf(condition, Task_Func_Result_K).Result;
+
+            actionExecuted.Should().Be(isSuccess && condition);
+            result.Should().Be(returned);
+        }
+
+        [Theory]
+        [InlineData(true, true)]
+        [InlineData(true, false)]
+        [InlineData(false, true)]
+        [InlineData(false, false)]
+        public void TapIf_T_AsyncBoth_executes_func_result_K_E_conditionally_and_returns_self(bool isSuccess, bool condition)
+        {
+            Result<bool, E> result = Result.SuccessIf(isSuccess, condition, E.Value);
+
+            var returned = result.AsTask().CheckIf(condition, Task_Func_Result_K_E).Result;
+
+            actionExecuted.Should().Be(isSuccess && condition);
+            result.Should().Be(returned);
+        }
+        
+        [Theory]
+        [InlineData(true, true)]
+        [InlineData(true, false)]
+        [InlineData(false, true)]
+        [InlineData(false, false)]
+        public void TapIf_T_AsyncBoth_executes_func_result_T_per_predicate_and_returns_self(bool isSuccess, bool condition)
+        {
+            Result<bool> result = Result.SuccessIf(isSuccess, condition, ErrorMessage);
+
+            var returned = result.AsTask().CheckIf(Predicate, Task_Func_Result).Result;
+
+            actionExecuted.Should().Be(isSuccess && condition);
+            result.Should().Be(returned);
+        }
+
+        [Theory]
+        [InlineData(true, true)]
+        [InlineData(true, false)]
+        [InlineData(false, true)]
+        [InlineData(false, false)]
+        public void TapIf_T_AsyncBoth_executes_func_result_K_per_predicate_and_returns_self(bool isSuccess, bool condition)
+        {
+            Result<bool> result = Result.SuccessIf(isSuccess, condition, ErrorMessage);
+
+            var returned = result.AsTask().CheckIf(Predicate, Task_Func_Result_K).Result;
+
+            actionExecuted.Should().Be(isSuccess && condition);
+            result.Should().Be(returned);
+        }
+
+        [Theory]
+        [InlineData(true, true)]
+        [InlineData(true, false)]
+        [InlineData(false, true)]
+        [InlineData(false, false)]
+        public void TapIf_T_AsyncBoth_executes_func_result_K_E_per_predicate_and_returns_self(bool isSuccess, bool condition)
+        {
+            Result<bool, E> result = Result.SuccessIf(isSuccess, condition, E.Value);
+
+            var returned = result.AsTask().CheckIf(Predicate, Task_Func_Result_K_E).Result;
+
+            actionExecuted.Should().Be(isSuccess && condition);
+            result.Should().Be(returned);
+        }
+    }
+}

--- a/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/CheckIfTests.cs
+++ b/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/CheckIfTests.cs
@@ -1,0 +1,98 @@
+using FluentAssertions;
+using Xunit;
+
+namespace CSharpFunctionalExtensions.Tests.ResultTests.Extensions
+{
+    public class CheckIfTests : CheckIfTestsBase
+    {
+        [Theory]
+        [InlineData(true, true)]
+        [InlineData(true, false)]
+        [InlineData(false, true)]
+        [InlineData(false, false)]
+        public void TapIf_T_executes_func_result_T_conditionally_and_returns_self(bool isSuccess, bool condition)
+        {
+            Result<bool> result = Result.SuccessIf(isSuccess, condition, ErrorMessage);
+
+            var returned = result.CheckIf(condition, Func_Result);
+
+            actionExecuted.Should().Be(isSuccess && condition);
+            result.Should().Be(returned);
+        }
+
+        [Theory]
+        [InlineData(true, true)]
+        [InlineData(true, false)]
+        [InlineData(false, true)]
+        [InlineData(false, false)]
+        public void TapIf_T_executes_func_result_K_conditionally_and_returns_self(bool isSuccess, bool condition)
+        {
+            Result<bool> result = Result.SuccessIf(isSuccess, condition, ErrorMessage);
+
+            var returned = result.CheckIf(condition, Func_Result_K);
+
+            actionExecuted.Should().Be(isSuccess && condition);
+            result.Should().Be(returned);
+        }
+
+        [Theory]
+        [InlineData(true, true)]
+        [InlineData(true, false)]
+        [InlineData(false, true)]
+        [InlineData(false, false)]
+        public void TapIf_T_executes_func_result_K_E_conditionally_and_returns_self(bool isSuccess, bool condition)
+        {
+            Result<bool, E> result = Result.SuccessIf(isSuccess, condition, E.Value);
+
+            var returned = result.CheckIf(condition, Func_Result_K_E);
+
+            actionExecuted.Should().Be(isSuccess && condition);
+            result.Should().Be(returned);
+        }
+        
+        [Theory]
+        [InlineData(true, true)]
+        [InlineData(true, false)]
+        [InlineData(false, true)]
+        [InlineData(false, false)]
+        public void TapIf_T_executes_func_result_K_per_predicate_and_returns_self(bool isSuccess, bool condition)
+        {
+            Result<bool> result = Result.SuccessIf(isSuccess, condition, ErrorMessage);
+
+            var returned = result.CheckIf(Predicate, Func_Result_K);
+
+            actionExecuted.Should().Be(isSuccess && condition);
+            result.Should().Be(returned);
+        }
+
+        [Theory]
+        [InlineData(true, true)]
+        [InlineData(true, false)]
+        [InlineData(false, true)]
+        [InlineData(false, false)]
+        public void TapIf_T_executes_func_result_K_E_per_predicate_and_returns_self(bool isSuccess, bool condition)
+        {
+            Result<bool, E> result = Result.SuccessIf(isSuccess, condition, E.Value);
+
+            var returned = result.CheckIf(Predicate, Func_Result_K_E);
+
+            actionExecuted.Should().Be(isSuccess && condition);
+            result.Should().Be(returned);
+        }
+        
+        [Theory]
+        [InlineData(true, true)]
+        [InlineData(true, false)]
+        [InlineData(false, true)]
+        [InlineData(false, false)]
+        public void TapIf_T_executes_func_result_T_per_predicate_and_returns_self(bool isSuccess, bool condition)
+        {
+            Result<bool> result = Result.SuccessIf(isSuccess, condition, ErrorMessage);
+
+            var returned = result.CheckIf(Predicate, Func_Result);
+
+            actionExecuted.Should().Be(isSuccess && condition);
+            result.Should().Be(returned);
+        }
+    }
+}

--- a/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/CheckIfTests.cs
+++ b/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/CheckIfTests.cs
@@ -10,7 +10,7 @@ namespace CSharpFunctionalExtensions.Tests.ResultTests.Extensions
         [InlineData(true, false)]
         [InlineData(false, true)]
         [InlineData(false, false)]
-        public void TapIf_T_executes_func_result_T_conditionally_and_returns_self(bool isSuccess, bool condition)
+        public void CheckIf_T_executes_func_result_T_conditionally_and_returns_self(bool isSuccess, bool condition)
         {
             Result<bool> result = Result.SuccessIf(isSuccess, condition, ErrorMessage);
 
@@ -25,7 +25,7 @@ namespace CSharpFunctionalExtensions.Tests.ResultTests.Extensions
         [InlineData(true, false)]
         [InlineData(false, true)]
         [InlineData(false, false)]
-        public void TapIf_T_executes_func_result_K_conditionally_and_returns_self(bool isSuccess, bool condition)
+        public void CheckIf_T_executes_func_result_K_conditionally_and_returns_self(bool isSuccess, bool condition)
         {
             Result<bool> result = Result.SuccessIf(isSuccess, condition, ErrorMessage);
 
@@ -40,7 +40,7 @@ namespace CSharpFunctionalExtensions.Tests.ResultTests.Extensions
         [InlineData(true, false)]
         [InlineData(false, true)]
         [InlineData(false, false)]
-        public void TapIf_T_executes_func_result_K_E_conditionally_and_returns_self(bool isSuccess, bool condition)
+        public void CheckIf_T_executes_func_result_K_E_conditionally_and_returns_self(bool isSuccess, bool condition)
         {
             Result<bool, E> result = Result.SuccessIf(isSuccess, condition, E.Value);
 
@@ -55,7 +55,7 @@ namespace CSharpFunctionalExtensions.Tests.ResultTests.Extensions
         [InlineData(true, false)]
         [InlineData(false, true)]
         [InlineData(false, false)]
-        public void TapIf_T_executes_func_result_K_per_predicate_and_returns_self(bool isSuccess, bool condition)
+        public void CheckIf_T_executes_func_result_K_per_predicate_and_returns_self(bool isSuccess, bool condition)
         {
             Result<bool> result = Result.SuccessIf(isSuccess, condition, ErrorMessage);
 
@@ -70,7 +70,7 @@ namespace CSharpFunctionalExtensions.Tests.ResultTests.Extensions
         [InlineData(true, false)]
         [InlineData(false, true)]
         [InlineData(false, false)]
-        public void TapIf_T_executes_func_result_K_E_per_predicate_and_returns_self(bool isSuccess, bool condition)
+        public void CheckIf_T_executes_func_result_K_E_per_predicate_and_returns_self(bool isSuccess, bool condition)
         {
             Result<bool, E> result = Result.SuccessIf(isSuccess, condition, E.Value);
 
@@ -85,7 +85,7 @@ namespace CSharpFunctionalExtensions.Tests.ResultTests.Extensions
         [InlineData(true, false)]
         [InlineData(false, true)]
         [InlineData(false, false)]
-        public void TapIf_T_executes_func_result_T_per_predicate_and_returns_self(bool isSuccess, bool condition)
+        public void CheckIf_T_executes_func_result_T_per_predicate_and_returns_self(bool isSuccess, bool condition)
         {
             Result<bool> result = Result.SuccessIf(isSuccess, condition, ErrorMessage);
 

--- a/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/CheckIfTestsBase.cs
+++ b/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/CheckIfTestsBase.cs
@@ -1,35 +1,27 @@
-﻿using System.Threading.Tasks;
+using System.Threading.Tasks;
 
 namespace CSharpFunctionalExtensions.Tests.ResultTests.Extensions
 {
-    public abstract class TapIfTestsBase : TestBase
+    public class CheckIfTestsBase : TestBase
     {
         protected bool actionExecuted;
         protected bool predicateExecuted;
 
-        protected TapIfTestsBase()
+        protected CheckIfTestsBase()
         {
             actionExecuted = false;
             predicateExecuted = false;
         }
-
-        protected void Action() { actionExecuted = true; }
-        protected void Action_T(T _) { actionExecuted = true; }
-        protected void Action_T(bool _) { actionExecuted = true; }
-
-#pragma warning disable 1998
-        protected async Task Task_Action() { actionExecuted = true; }
-        protected async Task Task_Action_T(T _) { actionExecuted = true; }
-        protected async Task Task_Action_T(bool _) { actionExecuted = true; }
-#pragma warning restore 1998
+        
         protected Result Func_Result(bool _) { actionExecuted = true; return Result.Success(); } 
+        
         protected Result<K> Func_Result_K(bool _) { actionExecuted = true; return Result.Success<K>(K.Value); }
         protected Result<K,E> Func_Result_K_E(bool _) { actionExecuted = true; return Result.Success<K, E>(K.Value); }
-
+        
         protected Task<Result> Task_Func_Result(bool _) { actionExecuted = true; return Result.Success().AsTask(); }
         protected Task<Result<K>> Task_Func_Result_K(bool _) { actionExecuted = true; return Result.Success<K>(K.Value).AsTask(); }
         protected Task<Result<K, E>> Task_Func_Result_K_E(bool _) { actionExecuted = true; return Result.Success<K, E>(K.Value).AsTask(); }
-
+        
         protected bool Predicate(bool b) { predicateExecuted = true; return b; }
     }
 }

--- a/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/CheckIfTestsBase.cs
+++ b/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/CheckIfTestsBase.cs
@@ -2,7 +2,7 @@ using System.Threading.Tasks;
 
 namespace CSharpFunctionalExtensions.Tests.ResultTests.Extensions
 {
-    public class CheckIfTestsBase : TestBase
+    public abstract class CheckIfTestsBase : TestBase
     {
         protected bool actionExecuted;
         protected bool predicateExecuted;

--- a/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/CheckTests.cs
+++ b/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/CheckTests.cs
@@ -1,0 +1,51 @@
+using FluentAssertions;
+using Xunit;
+
+namespace CSharpFunctionalExtensions.Tests.ResultTests.Extensions
+{
+    public class CheckTests : CheckTestsBase
+    {
+        [Theory]
+        [InlineData(true, true)]
+        [InlineData(true, false)]
+        [InlineData(false, false)]
+        public void Tap_T_func_result(bool resultSuccess, bool funcSuccess)
+        {
+            Result<T> result = Result.SuccessIf(resultSuccess, T.Value, ErrorMessage);
+
+            var returned = result.Check(_ => GetResult(funcSuccess));
+
+            actionExecuted.Should().Be(resultSuccess);
+            returned.Should().Be(funcSuccess ? result : FailedResultT);
+        }
+        
+        
+        [Theory]
+        [InlineData(true, true)]
+        [InlineData(true, false)]
+        [InlineData(false, false)]
+        public void Tap_T_func_result_K(bool resultSuccess, bool funcSuccess)
+        {
+            Result<T> result = Result.SuccessIf(resultSuccess, T.Value, ErrorMessage);
+
+            var returned = result.Check(Func_Result_K(funcSuccess));
+
+            actionExecuted.Should().Be(resultSuccess);
+            returned.Should().Be(funcSuccess ? result : FailedResultT);
+        }
+        
+        [Theory]
+        [InlineData(true, true)]
+        [InlineData(true, false)]
+        [InlineData(false, false)]
+        public void Tap_T_func_result_KE(bool resultSuccess, bool funcSuccess)
+        {
+            Result<T, E> result = Result.SuccessIf(resultSuccess, T.Value, E.Value);
+
+            var returned = result.Check(Func_Result_KE(funcSuccess));
+
+            actionExecuted.Should().Be(resultSuccess);
+            returned.Should().Be(funcSuccess ? result : returned);
+        }
+    }
+}

--- a/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/CheckTests.cs
+++ b/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/CheckTests.cs
@@ -9,7 +9,7 @@ namespace CSharpFunctionalExtensions.Tests.ResultTests.Extensions
         [InlineData(true, true)]
         [InlineData(true, false)]
         [InlineData(false, false)]
-        public void Tap_T_func_result(bool resultSuccess, bool funcSuccess)
+        public void Check_T_func_result(bool resultSuccess, bool funcSuccess)
         {
             Result<T> result = Result.SuccessIf(resultSuccess, T.Value, ErrorMessage);
 
@@ -24,7 +24,7 @@ namespace CSharpFunctionalExtensions.Tests.ResultTests.Extensions
         [InlineData(true, true)]
         [InlineData(true, false)]
         [InlineData(false, false)]
-        public void Tap_T_func_result_K(bool resultSuccess, bool funcSuccess)
+        public void Check_T_func_result_K(bool resultSuccess, bool funcSuccess)
         {
             Result<T> result = Result.SuccessIf(resultSuccess, T.Value, ErrorMessage);
 
@@ -38,7 +38,7 @@ namespace CSharpFunctionalExtensions.Tests.ResultTests.Extensions
         [InlineData(true, true)]
         [InlineData(true, false)]
         [InlineData(false, false)]
-        public void Tap_T_func_result_KE(bool resultSuccess, bool funcSuccess)
+        public void Check_T_func_result_KE(bool resultSuccess, bool funcSuccess)
         {
             Result<T, E> result = Result.SuccessIf(resultSuccess, T.Value, E.Value);
 

--- a/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/CheckTestsBase.cs
+++ b/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/CheckTestsBase.cs
@@ -3,7 +3,7 @@ using System.Threading.Tasks;
 
 namespace CSharpFunctionalExtensions.Tests.ResultTests.Extensions
 {
-    public class CheckTestsBase : TestBase
+    public abstract class CheckTestsBase : TestBase
     {
         protected bool actionExecuted;
         

--- a/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/CheckTestsBase.cs
+++ b/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/CheckTestsBase.cs
@@ -1,0 +1,83 @@
+using System;
+using System.Threading.Tasks;
+
+namespace CSharpFunctionalExtensions.Tests.ResultTests.Extensions
+{
+    public class CheckTestsBase : TestBase
+    {
+        protected bool actionExecuted;
+        
+        protected Result GetResult(bool isSuccess)
+        {
+            actionExecuted = true;
+            return isSuccess
+                ? Result.Success()
+                : FailedResult;
+        }
+        
+        protected Func<T, Result<K>> Func_Result_K(bool isSuccess)
+        {
+            return isSuccess
+                ? new Func<T, Result<K>>(t =>
+                {
+                    actionExecuted = true;
+                    return Result.Success(K.Value);
+                })
+                : t =>
+                {
+                    actionExecuted = true;
+                    return FailedResultK;
+                };
+        }
+
+        protected Func<T, Result<K, E>> Func_Result_KE(bool isSuccess)
+        {
+            return isSuccess
+                ? new Func<T, Result<K, E>>(t =>
+                {
+                    actionExecuted = true;
+                    return Result.Success<K, E>(K.Value);
+                })
+                : t =>
+                {
+                    actionExecuted = true;
+                    return FailedResultKE;
+                };
+        }
+        
+        protected Func<T, Task<Result<K>>> Func_Task_Result_K(bool isSuccess)
+        {
+            return isSuccess
+                ? new Func<T, Task<Result<K>>>(t =>
+                {
+                    actionExecuted = true;
+                    return Result.Success(K.Value).AsTask();
+                })
+                : t =>
+                {
+                    actionExecuted = true;
+                    return FailedResultK.AsTask();
+                };
+        }
+
+        protected Func<T, Task<Result<K, E>>> Func_Task_Result_KE(bool isSuccess)
+        {
+            return isSuccess
+                ? new Func<T, Task<Result<K, E>>>(t =>
+                {
+                    actionExecuted = true;
+                    return Result.Success<K, E>(K.Value).AsTask();
+                })
+                : t =>
+                {
+                    actionExecuted = true;
+                    return FailedResultKE.AsTask();
+                };
+        }
+        
+        protected Result<T> FailedResultT => Result.Failure<T>(ErrorMessage);
+        protected Result<K> FailedResultK => Result.Failure<K>(ErrorMessage);
+        protected Result<K, E> FailedResultKE => Result.Failure<K, E>(E.Value);
+        protected Result FailedResult => Result.Failure(ErrorMessage);
+    }
+}

--- a/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/TapAsyncBothTests.cs
+++ b/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/TapAsyncBothTests.cs
@@ -69,47 +69,5 @@ namespace CSharpFunctionalExtensions.Tests.ResultTests.Extensions
             actionExecuted.Should().Be(isSuccess);
             result.Should().Be(returned);
         }
-
-        [Theory]
-        [InlineData(true, true)]
-        [InlineData(true, false)]
-        [InlineData(false, false)]
-        public void Tap_T_AsyncBoth_func_result(bool resultSuccess, bool funcSuccess)
-        {
-            Result<T> result = Result.SuccessIf(resultSuccess, T.Value, ErrorMessage);
-
-            var returned = result.AsTask().Tap(_ => GetResult(funcSuccess).AsTask()).Result;
-
-            actionExecuted.Should().Be(resultSuccess);
-            returned.Should().Be(funcSuccess ? result : FailedResultT);
-        }
-
-        [Theory]
-        [InlineData(true, true)]
-        [InlineData(true, false)]
-        [InlineData(false, false)]
-        public void Tap_T_AsyncBoth_func_result_K(bool resultSuccess, bool funcSuccess)
-        {
-            Result<T> result = Result.SuccessIf(resultSuccess, T.Value, ErrorMessage);
-
-            var returned = result.AsTask().Tap(Func_Task_Result_K(funcSuccess)).Result;
-
-            actionExecuted.Should().Be(resultSuccess);
-            returned.Should().Be(funcSuccess ? result : FailedResultT);
-        }
-
-        [Theory]
-        [InlineData(true, true)]
-        [InlineData(true, false)]
-        [InlineData(false, false)]
-        public void Tap_T_AsyncBoth_func_result_KE(bool resultSuccess, bool funcSuccess)
-        {
-            Result<T, E> result = Result.SuccessIf(resultSuccess, T.Value, E.Value);
-
-            var returned = result.AsTask().Tap(Func_Task_Result_KE(funcSuccess)).Result;
-
-            actionExecuted.Should().Be(resultSuccess);
-            returned.Should().Be(funcSuccess ? result : returned);
-        }
     }
 }

--- a/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/TapAsyncLeftTests.cs
+++ b/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/TapAsyncLeftTests.cs
@@ -69,47 +69,5 @@ namespace CSharpFunctionalExtensions.Tests.ResultTests.Extensions
             actionExecuted.Should().Be(isSuccess);
             result.Should().Be(returned);
         }
-
-        [Theory]
-        [InlineData(true, true)]
-        [InlineData(true, false)]
-        [InlineData(false, false)]
-        public void Tap_T_AsyncLeft_func_result(bool resultSuccess, bool funcSuccess)
-        {
-            Result<T> result = Result.SuccessIf(resultSuccess, T.Value, ErrorMessage);
-
-            var returned = result.AsTask().Tap(_ => GetResult(funcSuccess)).Result;
-
-            actionExecuted.Should().Be(resultSuccess);
-            returned.Should().Be(funcSuccess ? result : FailedResultT);
-        }
-
-        [Theory]
-        [InlineData(true, true)]
-        [InlineData(true, false)]
-        [InlineData(false, false)]
-        public void Tap_T_AsyncLeft_func_result_K(bool resultSuccess, bool funcSuccess)
-        {
-            Result<T> result = Result.SuccessIf(resultSuccess, T.Value, ErrorMessage);
-
-            var returned = result.AsTask().Tap(Func_Result_K(funcSuccess)).Result;
-
-            actionExecuted.Should().Be(resultSuccess);
-            returned.Should().Be(funcSuccess ? result : FailedResultT);
-        }
-
-        [Theory]
-        [InlineData(true, true)]
-        [InlineData(true, false)]
-        [InlineData(false, false)]
-        public void Tap_T_AsyncLeft_func_result_KE(bool resultSuccess, bool funcSuccess)
-        {
-            Result<T, E> result = Result.SuccessIf(resultSuccess, T.Value, E.Value);
-
-            var returned = result.AsTask().Tap(Func_Result_KE(funcSuccess)).Result;
-
-            actionExecuted.Should().Be(resultSuccess);
-            returned.Should().Be(funcSuccess ? result : returned);
-        }
     }
 }

--- a/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/TapAsyncRightTests.cs
+++ b/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/TapAsyncRightTests.cs
@@ -69,47 +69,5 @@ namespace CSharpFunctionalExtensions.Tests.ResultTests.Extensions
             actionExecuted.Should().Be(isSuccess);
             result.Should().Be(returned);
         }
-
-        [Theory]
-        [InlineData(true, true)]
-        [InlineData(true, false)]
-        [InlineData(false, false)]
-        public void Tap_T_AsyncRight_func_result(bool resultSuccess, bool funcSuccess)
-        {
-            Result<T> result = Result.SuccessIf(resultSuccess, T.Value, ErrorMessage);
-
-            var returned = result.Tap(_ => GetResult(funcSuccess).AsTask()).Result;
-
-            actionExecuted.Should().Be(resultSuccess);
-            returned.Should().Be(funcSuccess ? result : FailedResultT);
-        }
-
-        [Theory]
-        [InlineData(true, true)]
-        [InlineData(true, false)]
-        [InlineData(false, false)]
-        public void Tap_T_AsyncRight_func_result_K(bool resultSuccess, bool funcSuccess)
-        {
-            Result<T> result = Result.SuccessIf(resultSuccess, T.Value, ErrorMessage);
-
-            var returned = result.Tap(Func_Task_Result_K(funcSuccess)).Result;
-
-            actionExecuted.Should().Be(resultSuccess);
-            returned.Should().Be(funcSuccess ? result : FailedResultT);
-        }
-
-        [Theory]
-        [InlineData(true, true)]
-        [InlineData(true, false)]
-        [InlineData(false, false)]
-        public void Tap_T_AsyncRight_func_result_KE(bool resultSuccess, bool funcSuccess)
-        {
-            Result<T, E> result = Result.SuccessIf(resultSuccess, T.Value, E.Value);
-
-            var returned = result.Tap(Func_Task_Result_KE(funcSuccess)).Result;
-
-            actionExecuted.Should().Be(resultSuccess);
-            returned.Should().Be(funcSuccess ? result : returned);
-        }
     }
 }

--- a/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/TapIfAsyncBothTests.cs
+++ b/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/TapIfAsyncBothTests.cs
@@ -85,51 +85,6 @@ namespace CSharpFunctionalExtensions.Tests.ResultTests.Extensions
         [InlineData(true, false)]
         [InlineData(false, true)]
         [InlineData(false, false)]
-        public void TapIf_T_AsyncBoth_executes_func_result_T_conditionally_and_returns_self(bool isSuccess, bool condition)
-        {
-            Result<bool> result = Result.SuccessIf(isSuccess, condition, ErrorMessage);
-
-            var returned = result.AsTask().TapIf(condition, Task_Func_Result).Result;
-
-            actionExecuted.Should().Be(isSuccess && condition);
-            result.Should().Be(returned);
-        }
-
-        [Theory]
-        [InlineData(true, true)]
-        [InlineData(true, false)]
-        [InlineData(false, true)]
-        [InlineData(false, false)]
-        public void TapIf_T_AsyncBoth_executes_func_result_K_conditionally_and_returns_self(bool isSuccess, bool condition)
-        {
-            Result<bool> result = Result.SuccessIf(isSuccess, condition, ErrorMessage);
-
-            var returned = result.AsTask().TapIf(condition, Task_Func_Result_K).Result;
-
-            actionExecuted.Should().Be(isSuccess && condition);
-            result.Should().Be(returned);
-        }
-
-        [Theory]
-        [InlineData(true, true)]
-        [InlineData(true, false)]
-        [InlineData(false, true)]
-        [InlineData(false, false)]
-        public void TapIf_T_AsyncBoth_executes_func_result_K_E_conditionally_and_returns_self(bool isSuccess, bool condition)
-        {
-            Result<bool, E> result = Result.SuccessIf(isSuccess, condition, E.Value);
-
-            var returned = result.AsTask().TapIf(condition, Task_Func_Result_K_E).Result;
-
-            actionExecuted.Should().Be(isSuccess && condition);
-            result.Should().Be(returned);
-        }
-
-        [Theory]
-        [InlineData(true, true)]
-        [InlineData(true, false)]
-        [InlineData(false, true)]
-        [InlineData(false, false)]
         public void TapIf_T_AsyncBoth_executes_action_per_predicate_and_returns_self(bool isSuccess, bool condition)
         {
             Result<bool> result = Result.SuccessIf(isSuccess, condition, ErrorMessage);
@@ -185,51 +140,6 @@ namespace CSharpFunctionalExtensions.Tests.ResultTests.Extensions
             var returned = result.AsTask().TapIf(Predicate, Task_Action_T).Result;
 
             predicateExecuted.Should().Be(isSuccess);
-            actionExecuted.Should().Be(isSuccess && condition);
-            result.Should().Be(returned);
-        }
-
-        [Theory]
-        [InlineData(true, true)]
-        [InlineData(true, false)]
-        [InlineData(false, true)]
-        [InlineData(false, false)]
-        public void TapIf_T_AsyncBoth_executes_func_result_T_per_predicate_and_returns_self(bool isSuccess, bool condition)
-        {
-            Result<bool> result = Result.SuccessIf(isSuccess, condition, ErrorMessage);
-
-            var returned = result.AsTask().TapIf(Predicate, Task_Func_Result).Result;
-
-            actionExecuted.Should().Be(isSuccess && condition);
-            result.Should().Be(returned);
-        }
-
-        [Theory]
-        [InlineData(true, true)]
-        [InlineData(true, false)]
-        [InlineData(false, true)]
-        [InlineData(false, false)]
-        public void TapIf_T_AsyncBoth_executes_func_result_K_per_predicate_and_returns_self(bool isSuccess, bool condition)
-        {
-            Result<bool> result = Result.SuccessIf(isSuccess, condition, ErrorMessage);
-
-            var returned = result.AsTask().TapIf(Predicate, Task_Func_Result_K).Result;
-
-            actionExecuted.Should().Be(isSuccess && condition);
-            result.Should().Be(returned);
-        }
-
-        [Theory]
-        [InlineData(true, true)]
-        [InlineData(true, false)]
-        [InlineData(false, true)]
-        [InlineData(false, false)]
-        public void TapIf_T_AsyncBoth_executes_func_result_K_E_per_predicate_and_returns_self(bool isSuccess, bool condition)
-        {
-            Result<bool, E> result = Result.SuccessIf(isSuccess, condition, E.Value);
-
-            var returned = result.AsTask().TapIf(Predicate, Task_Func_Result_K_E).Result;
-
             actionExecuted.Should().Be(isSuccess && condition);
             result.Should().Be(returned);
         }

--- a/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/TapIfTests.cs
+++ b/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/TapIfTests.cs
@@ -85,51 +85,6 @@ namespace CSharpFunctionalExtensions.Tests.ResultTests.Extensions
         [InlineData(true, false)]
         [InlineData(false, true)]
         [InlineData(false, false)]
-        public void TapIf_T_executes_func_result_T_conditionally_and_returns_self(bool isSuccess, bool condition)
-        {
-            Result<bool> result = Result.SuccessIf(isSuccess, condition, ErrorMessage);
-
-            var returned = result.TapIf(condition, Func_Result);
-
-            actionExecuted.Should().Be(isSuccess && condition);
-            result.Should().Be(returned);
-        }
-
-        [Theory]
-        [InlineData(true, true)]
-        [InlineData(true, false)]
-        [InlineData(false, true)]
-        [InlineData(false, false)]
-        public void TapIf_T_executes_func_result_K_conditionally_and_returns_self(bool isSuccess, bool condition)
-        {
-            Result<bool> result = Result.SuccessIf(isSuccess, condition, ErrorMessage);
-
-            var returned = result.TapIf(condition, Func_Result_K);
-
-            actionExecuted.Should().Be(isSuccess && condition);
-            result.Should().Be(returned);
-        }
-
-        [Theory]
-        [InlineData(true, true)]
-        [InlineData(true, false)]
-        [InlineData(false, true)]
-        [InlineData(false, false)]
-        public void TapIf_T_executes_func_result_K_E_conditionally_and_returns_self(bool isSuccess, bool condition)
-        {
-            Result<bool, E> result = Result.SuccessIf(isSuccess, condition, E.Value);
-
-            var returned = result.TapIf(condition, Func_Result_K_E);
-
-            actionExecuted.Should().Be(isSuccess && condition);
-            result.Should().Be(returned);
-        }
-
-        [Theory]
-        [InlineData(true, true)]
-        [InlineData(true, false)]
-        [InlineData(false, true)]
-        [InlineData(false, false)]
         public void TapIf_T_executes_action_per_predicate_and_returns_self(bool isSuccess, bool condition)
         {
             Result<bool> result = Result.SuccessIf(isSuccess, condition, ErrorMessage);
@@ -185,51 +140,6 @@ namespace CSharpFunctionalExtensions.Tests.ResultTests.Extensions
             var returned = result.TapIf(Predicate, Action_T);
 
             predicateExecuted.Should().Be(isSuccess);
-            actionExecuted.Should().Be(isSuccess && condition);
-            result.Should().Be(returned);
-        }
-
-        [Theory]
-        [InlineData(true, true)]
-        [InlineData(true, false)]
-        [InlineData(false, true)]
-        [InlineData(false, false)]
-        public void TapIf_T_executes_func_result_T_per_predicate_and_returns_self(bool isSuccess, bool condition)
-        {
-            Result<bool> result = Result.SuccessIf(isSuccess, condition, ErrorMessage);
-
-            var returned = result.TapIf(Predicate, Func_Result);
-
-            actionExecuted.Should().Be(isSuccess && condition);
-            result.Should().Be(returned);
-        }
-
-        [Theory]
-        [InlineData(true, true)]
-        [InlineData(true, false)]
-        [InlineData(false, true)]
-        [InlineData(false, false)]
-        public void TapIf_T_executes_func_result_K_per_predicate_and_returns_self(bool isSuccess, bool condition)
-        {
-            Result<bool> result = Result.SuccessIf(isSuccess, condition, ErrorMessage);
-
-            var returned = result.TapIf(Predicate, Func_Result_K);
-
-            actionExecuted.Should().Be(isSuccess && condition);
-            result.Should().Be(returned);
-        }
-
-        [Theory]
-        [InlineData(true, true)]
-        [InlineData(true, false)]
-        [InlineData(false, true)]
-        [InlineData(false, false)]
-        public void TapIf_T_executes_func_result_K_E_per_predicate_and_returns_self(bool isSuccess, bool condition)
-        {
-            Result<bool, E> result = Result.SuccessIf(isSuccess, condition, E.Value);
-
-            var returned = result.TapIf(Predicate, Func_Result_K_E);
-
             actionExecuted.Should().Be(isSuccess && condition);
             result.Should().Be(returned);
         }

--- a/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/TapTests.cs
+++ b/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/TapTests.cs
@@ -69,47 +69,5 @@ namespace CSharpFunctionalExtensions.Tests.ResultTests.Extensions
             actionExecuted.Should().Be(isSuccess);
             result.Should().Be(returned);
         }
-
-        [Theory]
-        [InlineData(true, true)]
-        [InlineData(true, false)]
-        [InlineData(false, false)]
-        public void Tap_T_func_result(bool resultSuccess, bool funcSuccess)
-        {
-            Result<T> result = Result.SuccessIf(resultSuccess, T.Value, ErrorMessage);
-
-            var returned = result.Tap(_ => GetResult(funcSuccess));
-
-            actionExecuted.Should().Be(resultSuccess);
-            returned.Should().Be(funcSuccess ? result : FailedResultT);
-        }
-
-        [Theory]
-        [InlineData(true, true)]
-        [InlineData(true, false)]
-        [InlineData(false, false)]
-        public void Tap_T_func_result_K(bool resultSuccess, bool funcSuccess)
-        {
-            Result<T> result = Result.SuccessIf(resultSuccess, T.Value, ErrorMessage);
-
-            var returned = result.Tap(Func_Result_K(funcSuccess));
-
-            actionExecuted.Should().Be(resultSuccess);
-            returned.Should().Be(funcSuccess ? result : FailedResultT);
-        }
-
-        [Theory]
-        [InlineData(true, true)]
-        [InlineData(true, false)]
-        [InlineData(false, false)]
-        public void Tap_T_func_result_KE(bool resultSuccess, bool funcSuccess)
-        {
-            Result<T, E> result = Result.SuccessIf(resultSuccess, T.Value, E.Value);
-
-            var returned = result.Tap(Func_Result_KE(funcSuccess));
-
-            actionExecuted.Should().Be(resultSuccess);
-            returned.Should().Be(funcSuccess ? result : returned);
-        }
     }
 }

--- a/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/TapTestsBase.cs
+++ b/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/TapTestsBase.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 
 namespace CSharpFunctionalExtensions.Tests.ResultTests.Extensions
 {
@@ -14,95 +13,9 @@ namespace CSharpFunctionalExtensions.Tests.ResultTests.Extensions
 
         protected void Action() { actionExecuted = true; }
         protected void Action_T(T _) { actionExecuted = true; }
+#pragma warning disable 1998
         protected async Task Task_Action() { actionExecuted = true; }
         protected async Task Task_Action_T(T _) { actionExecuted = true; }
-
-        protected Result FailedResult => Result.Failure(ErrorMessage);
-        protected Result<T> FailedResultT => Result.Failure<T>(ErrorMessage);
-        protected Result<K> FailedResultK => Result.Failure<K>(ErrorMessage);
-        protected Result<K, E> FailedResultKE => Result.Failure<K, E>(E.Value);
-
-        protected Result GetResult(bool isSuccess)
-        {
-            actionExecuted = true;
-            return isSuccess
-                ? Result.Success()
-                : FailedResult;
-        }
-
-        protected Func<T, Result<K>> Func_Result_K(bool isSuccess)
-        {
-            return isSuccess
-                ? new Func<T, Result<K>>(t =>
-                {
-                    actionExecuted = true;
-                    return Result.Success(K.Value);
-                })
-                : t =>
-                {
-                    actionExecuted = true;
-                    return FailedResultK;
-                };
-        }
-
-        protected Func<T, Result<K, E>> Func_Result_KE(bool isSuccess)
-        {
-            return isSuccess
-                ? new Func<T, Result<K, E>>(t =>
-                 {
-                     actionExecuted = true;
-                     return Result.Success<K, E>(K.Value);
-                 })
-                : t =>
-                {
-                    actionExecuted = true;
-                    return FailedResultKE;
-                };
-        }
-
-        protected Func<T, Task<Result>> Func_Task_Result(bool isSuccess)
-        {
-            return isSuccess
-                ? new Func<T, Task<Result>>(t =>
-                {
-                    actionExecuted = true;
-                    return Result.Success().AsTask();
-                })
-                : t =>
-                {
-                    actionExecuted = true;
-                    return FailedResult.AsTask();
-                };
-        }
-
-        protected Func<T, Task<Result<K>>> Func_Task_Result_K(bool isSuccess)
-        {
-            return isSuccess
-                ? new Func<T, Task<Result<K>>>(t =>
-                {
-                    actionExecuted = true;
-                    return Result.Success(K.Value).AsTask();
-                })
-                : t =>
-                {
-                    actionExecuted = true;
-                    return FailedResultK.AsTask();
-                };
-        }
-
-        protected Func<T, Task<Result<K, E>>> Func_Task_Result_KE(bool isSuccess)
-        {
-            return isSuccess
-                ? new Func<T, Task<Result<K, E>>>(t =>
-                {
-                    actionExecuted = true;
-                    return Result.Success<K, E>(K.Value).AsTask();
-                })
-                : t =>
-                {
-                    actionExecuted = true;
-                    return FailedResultKE.AsTask();
-                };
-        }
+#pragma warning restore 1998
     }
 }

--- a/CSharpFunctionalExtensions.Tests/TaskExtensions.cs
+++ b/CSharpFunctionalExtensions.Tests/TaskExtensions.cs
@@ -4,6 +4,6 @@ namespace CSharpFunctionalExtensions.Tests
 {
     internal static class TaskExtensions
     {
-        public static async Task<T> AsTask<T>(this T obj) => obj;
+        public static Task<T> AsTask<T>(this T obj) => Task.FromResult(obj);
     }
 }

--- a/CSharpFunctionalExtensions/Result/Extensions/Check.cs
+++ b/CSharpFunctionalExtensions/Result/Extensions/Check.cs
@@ -1,0 +1,31 @@
+using System;
+
+namespace CSharpFunctionalExtensions
+{
+    public static partial class ResultExtensions
+    {
+        /// <summary>
+        ///     If the calling result is a success, the given function is executed and its Result is checked. If this Result is a failure, it is returned. Otherwise, the calling result is returned.
+        /// </summary>
+        public static Result<T> Check<T>(this Result<T> result, Func<T, Result> func)
+        {
+            return result.Bind(func).Map(() => result.Value);
+        }
+
+        /// <summary>
+        ///     If the calling result is a success, the given function is executed and its Result is checked. If this Result is a failure, it is returned. Otherwise, the calling result is returned.
+        /// </summary>
+        public static Result<T> Check<T, K>(this Result<T> result, Func<T, Result<K>> func)
+        {
+            return result.Bind(func).Map(_ => result.Value);
+        }
+
+        /// <summary>
+        ///     If the calling result is a success, the given function is executed and its Result is checked. If this Result is a failure, it is returned. Otherwise, the calling result is returned.
+        /// </summary>
+        public static Result<T, E> Check<T, K, E>(this Result<T, E> result, Func<T, Result<K, E>> func)
+        {
+            return result.Bind(func).Map(_ => result.Value);
+        }
+    }
+}

--- a/CSharpFunctionalExtensions/Result/Extensions/CheckAsyncBoth.cs
+++ b/CSharpFunctionalExtensions/Result/Extensions/CheckAsyncBoth.cs
@@ -1,0 +1,35 @@
+using System;
+using System.Threading.Tasks;
+
+namespace CSharpFunctionalExtensions
+{
+    public static partial class AsyncResultExtensionsBothOperands
+    {
+        /// <summary>
+        ///     If the calling result is a success, the given function is executed and its Result is checked. If this Result is a failure, it is returned. Otherwise, the calling result is returned.
+        /// </summary>
+        public static async Task<Result<T>> Check<T>(this Task<Result<T>> resultTask, Func<T, Task<Result>> func)
+        {
+            Result<T> result = await resultTask.DefaultAwait();
+            return await result.Bind(func).Map(() => result.Value).DefaultAwait();
+        }
+
+        /// <summary>
+        ///     If the calling result is a success, the given function is executed and its Result is checked. If this Result is a failure, it is returned. Otherwise, the calling result is returned.
+        /// </summary>
+        public static async Task<Result<T>> Check<T, K>(this Task<Result<T>> resultTask, Func<T, Task<Result<K>>> func)
+        {
+            Result<T> result = await resultTask.DefaultAwait();
+            return await result.Bind(func).Map(_ => result.Value).DefaultAwait();
+        }
+
+        /// <summary>
+        ///     If the calling result is a success, the given function is executed and its Result is checked. If this Result is a failure, it is returned. Otherwise, the calling result is returned.
+        /// </summary>
+        public static async Task<Result<T, E>> Check<T, K, E>(this Task<Result<T, E>> resultTask, Func<T, Task<Result<K, E>>> func)
+        {
+            Result<T, E> result = await resultTask.DefaultAwait();
+            return await result.Bind(func).Map(_ => result.Value).DefaultAwait();
+        }
+    }
+}

--- a/CSharpFunctionalExtensions/Result/Extensions/CheckAsyncLeft.cs
+++ b/CSharpFunctionalExtensions/Result/Extensions/CheckAsyncLeft.cs
@@ -1,0 +1,35 @@
+using System;
+using System.Threading.Tasks;
+
+namespace CSharpFunctionalExtensions
+{
+    public static partial class AsyncResultExtensionsLeftOperand
+    {
+        /// <summary>
+        ///     If the calling result is a success, the given function is executed and its Result is checked. If this Result is a failure, it is returned. Otherwise, the calling result is returned.
+        /// </summary>
+        public static async Task<Result<T>> Check<T>(this Task<Result<T>> resultTask, Func<T, Result> func)
+        {
+            Result<T> result = await resultTask.DefaultAwait();
+            return result.Check(func);
+        }
+
+        /// <summary>
+        ///     If the calling result is a success, the given function is executed and its Result is checked. If this Result is a failure, it is returned. Otherwise, the calling result is returned.
+        /// </summary>
+        public static async Task<Result<T>> Check<T, K>(this Task<Result<T>> resultTask, Func<T, Result<K>> func)
+        {
+            Result<T> result = await resultTask.DefaultAwait();
+            return result.Check(func);
+        }
+
+        /// <summary>
+        ///     If the calling result is a success, the given function is executed and its Result is checked. If this Result is a failure, it is returned. Otherwise, the calling result is returned.
+        /// </summary>
+        public static async Task<Result<T, E>> Check<T, K, E>(this Task<Result<T, E>> resultTask, Func<T, Result<K, E>> func)
+        {
+            Result<T, E> result = await resultTask.DefaultAwait();
+            return result.Check(func);
+        }
+    }
+}

--- a/CSharpFunctionalExtensions/Result/Extensions/CheckAsyncRight.cs
+++ b/CSharpFunctionalExtensions/Result/Extensions/CheckAsyncRight.cs
@@ -1,0 +1,32 @@
+using System;
+using System.Threading.Tasks;
+
+namespace CSharpFunctionalExtensions
+{
+    public static partial class AsyncResultExtensionsRightOperand
+    {
+        /// <summary>
+        ///     If the calling result is a success, the given function is executed and its Result is checked. If this Result is a failure, it is returned. Otherwise, the calling result is returned.
+        /// </summary>
+        public static async Task<Result<T>> Check<T>(this Result<T> result, Func<T, Task<Result>> func)
+        {
+            return await result.Bind(func).Map(() => result.Value).DefaultAwait();
+        }
+
+        /// <summary>
+        ///     If the calling result is a success, the given function is executed and its Result is checked. If this Result is a failure, it is returned. Otherwise, the calling result is returned.
+        /// </summary>
+        public static async Task<Result<T>> Check<T, K>(this Result<T> result, Func<T, Task<Result<K>>> func)
+        {
+            return await result.Bind(func).Map(_ => result.Value).DefaultAwait();
+        }
+
+        /// <summary>
+        ///     If the calling result is a success, the given function is executed and its Result is checked. If this Result is a failure, it is returned. Otherwise, the calling result is returned.
+        /// </summary>
+        public static async Task<Result<T, E>> Check<T, K, E>(this Result<T, E> result, Func<T, Task<Result<K, E>>> func)
+        {
+            return await result.Bind(func).Map(_ => result.Value).DefaultAwait();
+        }
+    }
+}

--- a/CSharpFunctionalExtensions/Result/Extensions/CheckIf.cs
+++ b/CSharpFunctionalExtensions/Result/Extensions/CheckIf.cs
@@ -1,0 +1,55 @@
+using System;
+
+namespace CSharpFunctionalExtensions
+{
+    public static partial class ResultExtensions
+    {
+        public static Result<T> CheckIf<T>(this Result<T> result, bool condition, Func<T, Result> func)
+        {
+            if (condition)
+                return result.Check(func);
+            else
+                return result;
+        }
+
+        public static Result<T> CheckIf<T, K>(this Result<T> result, bool condition, Func<T, Result<K>> func)
+        {
+            if (condition)
+                return result.Check(func);
+            else
+                return result;
+        }
+
+        public static Result<T, E> CheckIf<T, K, E>(this Result<T, E> result, bool condition, Func<T, Result<K, E>> func)
+        {
+            if (condition)
+                return result.Check(func);
+            else
+                return result;
+        }
+
+        public static Result<T> CheckIf<T>(this Result<T> result, Func<T, bool> predicate, Func<T, Result> func)
+        {
+            if (result.IsSuccess && predicate(result.Value))
+                return result.Check(func);
+            else
+                return result;
+        }
+
+        public static Result<T> CheckIf<T, K>(this Result<T> result, Func<T, bool> predicate, Func<T, Result<K>> func)
+        {
+            if (result.IsSuccess && predicate(result.Value))
+                return result.Check(func);
+            else
+                return result;
+        }
+
+        public static Result<T, E> CheckIf<T, K, E>(this Result<T, E> result, Func<T, bool> predicate, Func<T, Result<K, E>> func)
+        {
+            if (result.IsSuccess && predicate(result.Value))
+                return result.Check(func);
+            else
+                return result;
+        }
+    }
+}

--- a/CSharpFunctionalExtensions/Result/Extensions/CheckIfAsyncBoth.cs
+++ b/CSharpFunctionalExtensions/Result/Extensions/CheckIfAsyncBoth.cs
@@ -1,0 +1,63 @@
+using System;
+using System.Threading.Tasks;
+
+namespace CSharpFunctionalExtensions
+{
+    public static partial class AsyncResultExtensionsBothOperands
+    {
+        public static Task<Result<T>> CheckIf<T>(this Task<Result<T>> resultTask, bool condition, Func<T, Task<Result>> func)
+        {
+            if (condition)
+                return resultTask.Check(func);
+            else
+                return resultTask;
+        }
+
+        public static Task<Result<T>> CheckIf<T, K>(this Task<Result<T>> resultTask, bool condition, Func<T, Task<Result<K>>> func)
+        {
+            if (condition)
+                return resultTask.Check(func);
+            else
+                return resultTask;
+        }
+
+        public static Task<Result<T, E>> CheckIf<T, K, E>(this Task<Result<T, E>> resultTask, bool condition, Func<T, Task<Result<K, E>>> func)
+        {
+            if (condition)
+                return resultTask.Check(func);
+            else
+                return resultTask;
+        }
+
+        
+        public static async Task<Result<T>> CheckIf<T>(this Task<Result<T>> resultTask, Func<T, bool> predicate, Func<T, Task<Result>> func)
+        {
+            Result<T> result = await resultTask.DefaultAwait();
+
+            if (result.IsSuccess && predicate(result.Value))
+                return await result.Check(func).DefaultAwait();
+            else
+                return result;
+        }
+
+        public static async Task<Result<T>> CheckIf<T, K>(this Task<Result<T>> resultTask, Func<T, bool> predicate, Func<T, Task<Result<K>>> func)
+        {
+            Result<T> result = await resultTask.DefaultAwait();
+
+            if (result.IsSuccess && predicate(result.Value))
+                return await result.Check(func).DefaultAwait();
+            else
+                return result;
+        }
+
+        public static async Task<Result<T, E>> CheckIf<T, K, E>(this Task<Result<T, E>> resultTask, Func<T, bool> predicate, Func<T, Task<Result<K, E>>> func)
+        {
+            Result<T, E> result = await resultTask.DefaultAwait();
+
+            if (result.IsSuccess && predicate(result.Value))
+                return await result.Check(func).DefaultAwait();
+            else
+                return result;
+        }
+    }
+}

--- a/CSharpFunctionalExtensions/Result/Extensions/CheckIfAsyncLeft.cs
+++ b/CSharpFunctionalExtensions/Result/Extensions/CheckIfAsyncLeft.cs
@@ -1,0 +1,63 @@
+using System;
+using System.Threading.Tasks;
+
+namespace CSharpFunctionalExtensions
+{
+    public static partial class AsyncResultExtensionsLeftOperand
+    {
+        public static Task<Result<T>> CheckIf<T>(this Task<Result<T>> resultTask, bool condition, Func<T, Result> func)
+        {
+            if (condition)
+                return resultTask.Check(func);
+            else
+                return resultTask;
+        }
+
+        public static Task<Result<T>> CheckIf<T, K>(this Task<Result<T>> resultTask, bool condition, Func<T, Result<K>> func)
+        {
+            if (condition)
+                return resultTask.Check(func);
+            else
+                return resultTask;
+        }
+
+        public static Task<Result<T, E>> CheckIf<T, K, E>(this Task<Result<T, E>> resultTask, bool condition, Func<T, Result<K, E>> func)
+        {
+            if (condition)
+                return resultTask.Check(func);
+            else
+                return resultTask;
+        }
+
+
+        public static async Task<Result<T>> CheckIf<T>(this Task<Result<T>> resultTask, Func<T, bool> predicate, Func<T, Result> func)
+        {
+            Result<T> result = await resultTask.DefaultAwait();
+
+            if (result.IsSuccess && predicate(result.Value))
+                return result.Check(func);
+            else
+                return result;
+        }
+
+        public static async Task<Result<T>> CheckIf<T, K>(this Task<Result<T>> resultTask, Func<T, bool> predicate, Func<T, Result<K>> func)
+        {
+            Result<T> result = await resultTask.DefaultAwait();
+
+            if (result.IsSuccess && predicate(result.Value))
+                return result.Check(func);
+            else
+                return result;
+        }
+
+        public static async Task<Result<T, E>> CheckIf<T, K, E>(this Task<Result<T, E>> resultTask, Func<T, bool> predicate, Func<T, Result<K, E>> func)
+        {
+            Result<T, E> result = await resultTask.DefaultAwait();
+
+            if (result.IsSuccess && predicate(result.Value))
+                return result.Check(func);
+            else
+                return result;
+        }
+    }
+}

--- a/CSharpFunctionalExtensions/Result/Extensions/CheckIfAsyncRight.cs
+++ b/CSharpFunctionalExtensions/Result/Extensions/CheckIfAsyncRight.cs
@@ -1,0 +1,56 @@
+using System;
+using System.Threading.Tasks;
+
+namespace CSharpFunctionalExtensions
+{
+    public static partial class AsyncResultExtensionsRightOperand
+    {
+        public static Task<Result<T>> CheckIf<T>(this Result<T> result, bool condition, Func<T, Task<Result>> func)
+        {
+            if (condition)
+                return result.Check(func);
+            else
+                return Task.FromResult(result);
+        }
+
+        public static Task<Result<T>> CheckIf<T, K>(this Result<T> result, bool condition, Func<T, Task<Result<K>>> func)
+        {
+            if (condition)
+                return result.Check(func);
+            else
+                return Task.FromResult(result);
+        }
+
+        public static Task<Result<T, E>> CheckIf<T, K, E>(this Result<T, E> result, bool condition, Func<T, Task<Result<K, E>>> func)
+        {
+            if (condition)
+                return result.Check(func);
+            else
+                return Task.FromResult(result);
+        }
+
+        public static Task<Result<T>> CheckIf<T>(this Result<T> result, Func<T, bool> predicate, Func<T, Task<Result>> func)
+        {
+            if (result.IsSuccess && predicate(result.Value))
+                return result.Check(func);
+            else
+                return Task.FromResult(result);
+        }
+
+        public static Task<Result<T>> CheckIf<T, K>(this Result<T> result, Func<T, bool> predicate, Func<T, Task<Result<K>>> func)
+        {
+            if (result.IsSuccess && predicate(result.Value))
+                return result.Check(func);
+            else
+                return Task.FromResult(result);
+        }
+
+        public static Task<Result<T, E>> CheckIf<T, K, E>(this Result<T, E> result, Func<T, bool> predicate, Func<T, Task<Result<K, E>>> func)
+        {
+            if (result.IsSuccess && predicate(result.Value))
+                return result.Check(func);
+            else
+                return Task.FromResult(result);
+        }
+    }
+}

--- a/CSharpFunctionalExtensions/Result/Extensions/Tap.cs
+++ b/CSharpFunctionalExtensions/Result/Extensions/Tap.cs
@@ -58,29 +58,5 @@ namespace CSharpFunctionalExtensions
 
             return result;
         }
-
-        /// <summary>
-        ///     If the calling result is a success, the given function is executed and its Result is checked. If this Result is a failure, it is returned. Otherwise, the calling result is returned.
-        /// </summary>
-        public static Result<T> Tap<T>(this Result<T> result, Func<T, Result> func)
-        {
-            return result.Bind(func).Map(() => result.Value);
-        }
-
-        /// <summary>
-        ///     If the calling result is a success, the given function is executed and its Result is checked. If this Result is a failure, it is returned. Otherwise, the calling result is returned.
-        /// </summary>
-        public static Result<T> Tap<T, K>(this Result<T> result, Func<T, Result<K>> func)
-        {
-            return result.Bind(func).Map(_ => result.Value);
-        }
-
-        /// <summary>
-        ///     If the calling result is a success, the given function is executed and its Result is checked. If this Result is a failure, it is returned. Otherwise, the calling result is returned.
-        /// </summary>
-        public static Result<T, E> Tap<T, K, E>(this Result<T, E> result, Func<T, Result<K, E>> func)
-        {
-            return result.Bind(func).Map(_ => result.Value);
-        }
     }
 }

--- a/CSharpFunctionalExtensions/Result/Extensions/TapAsyncBoth.cs
+++ b/CSharpFunctionalExtensions/Result/Extensions/TapAsyncBoth.cs
@@ -69,32 +69,5 @@ namespace CSharpFunctionalExtensions
 
             return result;
         }
-
-        /// <summary>
-        ///     If the calling result is a success, the given function is executed and its Result is checked. If this Result is a failure, it is returned. Otherwise, the calling result is returned.
-        /// </summary>
-        public static async Task<Result<T>> Tap<T>(this Task<Result<T>> resultTask, Func<T, Task<Result>> func)
-        {
-            Result<T> result = await resultTask.DefaultAwait();
-            return await result.Bind(func).Map(() => result.Value).DefaultAwait();
-        }
-
-        /// <summary>
-        ///     If the calling result is a success, the given function is executed and its Result is checked. If this Result is a failure, it is returned. Otherwise, the calling result is returned.
-        /// </summary>
-        public static async Task<Result<T>> Tap<T, K>(this Task<Result<T>> resultTask, Func<T, Task<Result<K>>> func)
-        {
-            Result<T> result = await resultTask.DefaultAwait();
-            return await result.Bind(func).Map(_ => result.Value).DefaultAwait();
-        }
-
-        /// <summary>
-        ///     If the calling result is a success, the given function is executed and its Result is checked. If this Result is a failure, it is returned. Otherwise, the calling result is returned.
-        /// </summary>
-        public static async Task<Result<T, E>> Tap<T, K, E>(this Task<Result<T, E>> resultTask, Func<T, Task<Result<K, E>>> func)
-        {
-            Result<T, E> result = await resultTask.DefaultAwait();
-            return await result.Bind(func).Map(_ => result.Value).DefaultAwait();
-        }
     }
 }

--- a/CSharpFunctionalExtensions/Result/Extensions/TapAsyncLeft.cs
+++ b/CSharpFunctionalExtensions/Result/Extensions/TapAsyncLeft.cs
@@ -49,32 +49,5 @@ namespace CSharpFunctionalExtensions
             Result<T, E> result = await resultTask.DefaultAwait();
             return result.Tap(action);
         }
-
-        /// <summary>
-        ///     If the calling result is a success, the given function is executed and its Result is checked. If this Result is a failure, it is returned. Otherwise, the calling result is returned.
-        /// </summary>
-        public static async Task<Result<T>> Tap<T>(this Task<Result<T>> resultTask, Func<T, Result> func)
-        {
-            Result<T> result = await resultTask.DefaultAwait();
-            return result.Tap(func);
-        }
-
-        /// <summary>
-        ///     If the calling result is a success, the given function is executed and its Result is checked. If this Result is a failure, it is returned. Otherwise, the calling result is returned.
-        /// </summary>
-        public static async Task<Result<T>> Tap<T, K>(this Task<Result<T>> resultTask, Func<T, Result<K>> func)
-        {
-            Result<T> result = await resultTask.DefaultAwait();
-            return result.Tap(func);
-        }
-
-        /// <summary>
-        ///     If the calling result is a success, the given function is executed and its Result is checked. If this Result is a failure, it is returned. Otherwise, the calling result is returned.
-        /// </summary>
-        public static async Task<Result<T, E>> Tap<T, K, E>(this Task<Result<T, E>> resultTask, Func<T, Result<K, E>> func)
-        {
-            Result<T, E> result = await resultTask.DefaultAwait();
-            return result.Tap(func);
-        }
     }
 }

--- a/CSharpFunctionalExtensions/Result/Extensions/TapAsyncRight.cs
+++ b/CSharpFunctionalExtensions/Result/Extensions/TapAsyncRight.cs
@@ -59,29 +59,5 @@ namespace CSharpFunctionalExtensions
 
             return result;
         }
-
-        /// <summary>
-        ///     If the calling result is a success, the given function is executed and its Result is checked. If this Result is a failure, it is returned. Otherwise, the calling result is returned.
-        /// </summary>
-        public static async Task<Result<T>> Tap<T>(this Result<T> result, Func<T, Task<Result>> func)
-        {
-            return await result.Bind(func).Map(() => result.Value).DefaultAwait();
-        }
-
-        /// <summary>
-        ///     If the calling result is a success, the given function is executed and its Result is checked. If this Result is a failure, it is returned. Otherwise, the calling result is returned.
-        /// </summary>
-        public static async Task<Result<T>> Tap<T, K>(this Result<T> result, Func<T, Task<Result<K>>> func)
-        {
-            return await result.Bind(func).Map(_ => result.Value).DefaultAwait();
-        }
-
-        /// <summary>
-        ///     If the calling result is a success, the given function is executed and its Result is checked. If this Result is a failure, it is returned. Otherwise, the calling result is returned.
-        /// </summary>
-        public static async Task<Result<T, E>> Tap<T, K, E>(this Result<T, E> result, Func<T, Task<Result<K, E>>> func)
-        {
-            return await result.Bind(func).Map(_ => result.Value).DefaultAwait();
-        }
     }
 }

--- a/CSharpFunctionalExtensions/Result/Extensions/TapIf.cs
+++ b/CSharpFunctionalExtensions/Result/Extensions/TapIf.cs
@@ -59,29 +59,6 @@ namespace CSharpFunctionalExtensions
                 return result;
         }
 
-        public static Result<T> TapIf<T>(this Result<T> result, bool condition, Func<T, Result> func)
-        {
-            if (condition)
-                return result.Tap(func);
-            else
-                return result;
-        }
-
-        public static Result<T> TapIf<T, K>(this Result<T> result, bool condition, Func<T, Result<K>> func)
-        {
-            if (condition)
-                return result.Tap(func);
-            else
-                return result;
-        }
-
-        public static Result<T, E> TapIf<T, K, E>(this Result<T, E> result, bool condition, Func<T, Result<K, E>> func)
-        {
-            if (condition)
-                return result.Tap(func);
-            else
-                return result;
-        }
 
         /// <summary>
         ///     Executes the given action if the calling result is a success and condition is true. Returns the calling result.
@@ -123,30 +100,6 @@ namespace CSharpFunctionalExtensions
         {
             if (result.IsSuccess && predicate(result.Value))
                 return result.Tap(action);
-            else
-                return result;
-        }
-
-        public static Result<T> TapIf<T>(this Result<T> result, Func<T, bool> predicate, Func<T, Result> func)
-        {
-            if (result.IsSuccess && predicate(result.Value))
-                return result.Tap(func);
-            else
-                return result;
-        }
-
-        public static Result<T> TapIf<T, K>(this Result<T> result, Func<T, bool> predicate, Func<T, Result<K>> func)
-        {
-            if (result.IsSuccess && predicate(result.Value))
-                return result.Tap(func);
-            else
-                return result;
-        }
-
-        public static Result<T, E> TapIf<T, K, E>(this Result<T, E> result, Func<T, bool> predicate, Func<T, Result<K, E>> func)
-        {
-            if (result.IsSuccess && predicate(result.Value))
-                return result.Tap(func);
             else
                 return result;
         }

--- a/CSharpFunctionalExtensions/Result/Extensions/TapIfAsyncBoth.cs
+++ b/CSharpFunctionalExtensions/Result/Extensions/TapIfAsyncBoth.cs
@@ -60,30 +60,6 @@ namespace CSharpFunctionalExtensions
                 return resultTask;
         }
 
-        public static Task<Result<T>> TapIf<T>(this Task<Result<T>> resultTask, bool condition, Func<T, Task<Result>> func)
-        {
-            if (condition)
-                return resultTask.Tap(func);
-            else
-                return resultTask;
-        }
-
-        public static Task<Result<T>> TapIf<T, K>(this Task<Result<T>> resultTask, bool condition, Func<T, Task<Result<K>>> func)
-        {
-            if (condition)
-                return resultTask.Tap(func);
-            else
-                return resultTask;
-        }
-
-        public static Task<Result<T, E>> TapIf<T, K, E>(this Task<Result<T, E>> resultTask, bool condition, Func<T, Task<Result<K, E>>> func)
-        {
-            if (condition)
-                return resultTask.Tap(func);
-            else
-                return resultTask;
-        }
-
         /// <summary>
         ///     Executes the given action if the calling result is a success and condition is true. Returns the calling result.
         /// </summary>
@@ -127,36 +103,6 @@ namespace CSharpFunctionalExtensions
         ///     Executes the given action if the calling result is a success and condition is true. Returns the calling result.
         /// </summary>
         public static async Task<Result<T, E>> TapIf<T, E>(this Task<Result<T, E>> resultTask, Func<T, bool> predicate, Func<T, Task> func)
-        {
-            Result<T, E> result = await resultTask.DefaultAwait();
-
-            if (result.IsSuccess && predicate(result.Value))
-                return await result.Tap(func).DefaultAwait();
-            else
-                return result;
-        }
-
-        public static async Task<Result<T>> TapIf<T>(this Task<Result<T>> resultTask, Func<T, bool> predicate, Func<T, Task<Result>> func)
-        {
-            Result<T> result = await resultTask.DefaultAwait();
-
-            if (result.IsSuccess && predicate(result.Value))
-                return await result.Tap(func).DefaultAwait();
-            else
-                return result;
-        }
-
-        public static async Task<Result<T>> TapIf<T, K>(this Task<Result<T>> resultTask, Func<T, bool> predicate, Func<T, Task<Result<K>>> func)
-        {
-            Result<T> result = await resultTask.DefaultAwait();
-
-            if (result.IsSuccess && predicate(result.Value))
-                return await result.Tap(func).DefaultAwait();
-            else
-                return result;
-        }
-
-        public static async Task<Result<T, E>> TapIf<T, K, E>(this Task<Result<T, E>> resultTask, Func<T, bool> predicate, Func<T, Task<Result<K, E>>> func)
         {
             Result<T, E> result = await resultTask.DefaultAwait();
 

--- a/CSharpFunctionalExtensions/Result/Extensions/TapIfAsyncLeft.cs
+++ b/CSharpFunctionalExtensions/Result/Extensions/TapIfAsyncLeft.cs
@@ -60,30 +60,6 @@ namespace CSharpFunctionalExtensions
                 return resultTask;
         }
 
-        public static Task<Result<T>> TapIf<T>(this Task<Result<T>> resultTask, bool condition, Func<T, Result> func)
-        {
-            if (condition)
-                return resultTask.Tap(func);
-            else
-                return resultTask;
-        }
-
-        public static Task<Result<T>> TapIf<T, K>(this Task<Result<T>> resultTask, bool condition, Func<T, Result<K>> func)
-        {
-            if (condition)
-                return resultTask.Tap(func);
-            else
-                return resultTask;
-        }
-
-        public static Task<Result<T, E>> TapIf<T, K, E>(this Task<Result<T, E>> resultTask, bool condition, Func<T, Result<K, E>> func)
-        {
-            if (condition)
-                return resultTask.Tap(func);
-            else
-                return resultTask;
-        }
-
         /// <summary>
         ///     Executes the given action if the calling result is a success and condition is true. Returns the calling result.
         /// </summary>
@@ -132,36 +108,6 @@ namespace CSharpFunctionalExtensions
 
             if (result.IsSuccess && predicate(result.Value))
                 return result.Tap(action);
-            else
-                return result;
-        }
-
-        public static async Task<Result<T>> TapIf<T>(this Task<Result<T>> resultTask, Func<T, bool> predicate, Func<T, Result> func)
-        {
-            Result<T> result = await resultTask.DefaultAwait();
-
-            if (result.IsSuccess && predicate(result.Value))
-                return result.Tap(func);
-            else
-                return result;
-        }
-
-        public static async Task<Result<T>> TapIf<T, K>(this Task<Result<T>> resultTask, Func<T, bool> predicate, Func<T, Result<K>> func)
-        {
-            Result<T> result = await resultTask.DefaultAwait();
-
-            if (result.IsSuccess && predicate(result.Value))
-                return result.Tap(func);
-            else
-                return result;
-        }
-
-        public static async Task<Result<T, E>> TapIf<T, K, E>(this Task<Result<T, E>> resultTask, Func<T, bool> predicate, Func<T, Result<K, E>> func)
-        {
-            Result<T, E> result = await resultTask.DefaultAwait();
-
-            if (result.IsSuccess && predicate(result.Value))
-                return result.Tap(func);
             else
                 return result;
         }

--- a/CSharpFunctionalExtensions/Result/Extensions/TapIfAsyncRight.cs
+++ b/CSharpFunctionalExtensions/Result/Extensions/TapIfAsyncRight.cs
@@ -60,30 +60,6 @@ namespace CSharpFunctionalExtensions
                 return Task.FromResult(result);
         }
 
-        public static Task<Result<T>> TapIf<T>(this Result<T> result, bool condition, Func<T, Task<Result>> func)
-        {
-            if (condition)
-                return result.Tap(func);
-            else
-                return Task.FromResult(result);
-        }
-
-        public static Task<Result<T>> TapIf<T, K>(this Result<T> result, bool condition, Func<T, Task<Result<K>>> func)
-        {
-            if (condition)
-                return result.Tap(func);
-            else
-                return Task.FromResult(result);
-        }
-
-        public static Task<Result<T, E>> TapIf<T, K, E>(this Result<T, E> result, bool condition, Func<T, Task<Result<K, E>>> func)
-        {
-            if (condition)
-                return result.Tap(func);
-            else
-                return Task.FromResult(result);
-        }
-
         /// <summary>
         ///     Executes the given action if the calling result is a success and condition is true. Returns the calling result.
         /// </summary>
@@ -121,30 +97,6 @@ namespace CSharpFunctionalExtensions
         ///     Executes the given action if the calling result is a success and condition is true. Returns the calling result.
         /// </summary>
         public static Task<Result<T, E>> TapIf<T, E>(this Result<T, E> result, Func<T, bool> predicate, Func<T, Task> func)
-        {
-            if (result.IsSuccess && predicate(result.Value))
-                return result.Tap(func);
-            else
-                return Task.FromResult(result);
-        }
-
-        public static Task<Result<T>> TapIf<T>(this Result<T> result, Func<T, bool> predicate, Func<T, Task<Result>> func)
-        {
-            if (result.IsSuccess && predicate(result.Value))
-                return result.Tap(func);
-            else
-                return Task.FromResult(result);
-        }
-
-        public static Task<Result<T>> TapIf<T, K>(this Result<T> result, Func<T, bool> predicate, Func<T, Task<Result<K>>> func)
-        {
-            if (result.IsSuccess && predicate(result.Value))
-                return result.Tap(func);
-            else
-                return Task.FromResult(result);
-        }
-
-        public static Task<Result<T, E>> TapIf<T, K, E>(this Result<T, E> result, Func<T, bool> predicate, Func<T, Task<Result<K, E>>> func)
         {
             if (result.IsSuccess && predicate(result.Value))
                 return result.Tap(func);

--- a/CSharpFunctionalExtensions/Result/Obsolete/Tap.cs
+++ b/CSharpFunctionalExtensions/Result/Obsolete/Tap.cs
@@ -1,0 +1,19 @@
+using System;
+
+namespace CSharpFunctionalExtensions
+{
+    public static partial class ResultExtensions
+    {
+        [Obsolete("Use Check() instead.")]
+        public static Result<T> Tap<T>(this Result<T> result, Func<T, Result> func) 
+            => Check(result, func);
+
+        [Obsolete("Use Check() instead.")]
+        public static Result<T> Tap<T, K>(this Result<T> result, Func<T, Result<K>> func) 
+            => Check(result, func);
+
+        [Obsolete("Use Check() instead.")]
+        public static Result<T, E> Tap<T, K, E>(this Result<T, E> result, Func<T, Result<K, E>> func) 
+            => Check(result, func);
+    }
+}

--- a/CSharpFunctionalExtensions/Result/Obsolete/TapAsyncBoth.cs
+++ b/CSharpFunctionalExtensions/Result/Obsolete/TapAsyncBoth.cs
@@ -1,0 +1,20 @@
+using System;
+using System.Threading.Tasks;
+
+namespace CSharpFunctionalExtensions
+{
+    public static partial class AsyncResultExtensionsBothOperands
+    {
+        [Obsolete("Use Check() instead.")]
+        public static Task<Result<T>> Tap<T>(this Task<Result<T>> resultTask, Func<T, Task<Result>> func) =>
+            Check(resultTask, func);
+
+        [Obsolete("Use Check() instead.")]
+        public static Task<Result<T>> Tap<T, K>(this Task<Result<T>> resultTask, Func<T, Task<Result<K>>> func) =>
+            Check(resultTask, func);
+
+        [Obsolete("Use Check() instead.")]
+        public static Task<Result<T, E>> Tap<T, K, E>(this Task<Result<T, E>> resultTask, Func<T, Task<Result<K, E>>> func) => 
+            Check(resultTask, func);
+    }
+}

--- a/CSharpFunctionalExtensions/Result/Obsolete/TapAsyncLeft.cs
+++ b/CSharpFunctionalExtensions/Result/Obsolete/TapAsyncLeft.cs
@@ -1,0 +1,20 @@
+using System;
+using System.Threading.Tasks;
+
+namespace CSharpFunctionalExtensions
+{
+    public static partial class AsyncResultExtensionsLeftOperand
+    {
+        [Obsolete("Use Check() instead.")]
+        public static Task<Result<T>> Tap<T>(this Task<Result<T>> resultTask, Func<T, Result> func) =>
+            Check(resultTask, func);
+
+        [Obsolete("Use Check() instead.")]
+        public static Task<Result<T>> Tap<T, K>(this Task<Result<T>> resultTask, Func<T, Result<K>> func) =>
+            Check(resultTask, func);
+
+        [Obsolete("Use Check() instead.")]
+        public static Task<Result<T, E>> Tap<T, K, E>(this Task<Result<T, E>> resultTask, Func<T, Result<K, E>> func) =>
+            Check(resultTask, func);
+    }
+}

--- a/CSharpFunctionalExtensions/Result/Obsolete/TapAsyncRight.cs
+++ b/CSharpFunctionalExtensions/Result/Obsolete/TapAsyncRight.cs
@@ -1,0 +1,19 @@
+using System;
+using System.Threading.Tasks;
+
+namespace CSharpFunctionalExtensions
+{
+    public static partial class AsyncResultExtensionsRightOperand
+    {
+        [Obsolete("Use Check() instead.")]
+        public static Task<Result<T>> Tap<T>(this Result<T> result, Func<T, Task<Result>> func) => Check(result, func);
+
+        [Obsolete("Use Check() instead.")]
+        public static Task<Result<T>> Tap<T, K>(this Result<T> result, Func<T, Task<Result<K>>> func) =>
+            Check(result, func);
+
+        [Obsolete("Use Check() instead.")]
+        public static Task<Result<T, E>> Tap<T, K, E>(this Result<T, E> result, Func<T, Task<Result<K, E>>> func) =>
+            Check(result, func);
+    }
+}

--- a/CSharpFunctionalExtensions/Result/Obsolete/TapIf.cs
+++ b/CSharpFunctionalExtensions/Result/Obsolete/TapIf.cs
@@ -1,0 +1,31 @@
+using System;
+
+namespace CSharpFunctionalExtensions
+{
+    public static partial class ResultExtensions
+    {
+        [Obsolete("Use CheckIf() instead.")]
+        public static Result<T> TapIf<T>(this Result<T> result, bool condition, Func<T, Result> func) =>
+            CheckIf(result, condition, func);
+
+        [Obsolete("Use CheckIf() instead.")]
+        public static Result<T> TapIf<T, K>(this Result<T> result, bool condition, Func<T, Result<K>> func) =>
+            CheckIf(result, condition, func);
+
+        [Obsolete("Use CheckIf() instead.")]
+        public static Result<T, E> TapIf<T, K, E>(this Result<T, E> result, bool condition, Func<T, Result<K, E>> func) =>
+            CheckIf(result, condition, func);
+
+        [Obsolete("Use CheckIf() instead.")]
+        public static Result<T> TapIf<T>(this Result<T> result, Func<T, bool> predicate, Func<T, Result> func) =>
+            CheckIf(result, predicate, func);
+
+        [Obsolete("Use CheckIf() instead.")]
+        public static Result<T> TapIf<T, K>(this Result<T> result, Func<T, bool> predicate, Func<T, Result<K>> func) =>
+            CheckIf(result, predicate, func);
+
+        [Obsolete("Use CheckIf() instead.")]
+        public static Result<T, E> TapIf<T, K, E>(this Result<T, E> result, Func<T, bool> predicate, Func<T, Result<K, E>> func) =>
+            CheckIf(result, predicate, func);
+    }
+}

--- a/CSharpFunctionalExtensions/Result/Obsolete/TapIfAsyncBoth.cs
+++ b/CSharpFunctionalExtensions/Result/Obsolete/TapIfAsyncBoth.cs
@@ -1,0 +1,32 @@
+using System;
+using System.Threading.Tasks;
+
+namespace CSharpFunctionalExtensions
+{
+    public static partial class AsyncResultExtensionsBothOperands
+    {
+        [Obsolete("Use CheckIf() instead.")]
+        public static Task<Result<T>> TapIf<T>(this Task<Result<T>> resultTask, bool condition, Func<T, Task<Result>> func) =>
+            CheckIf(resultTask, condition, func);
+
+        [Obsolete("Use CheckIf() instead.")]
+        public static Task<Result<T>> TapIf<T, K>(this Task<Result<T>> resultTask, bool condition, Func<T, Task<Result<K>>> func) =>
+            CheckIf(resultTask, condition, func);
+
+        [Obsolete("Use CheckIf() instead.")]
+        public static Task<Result<T, E>> TapIf<T, K, E>(this Task<Result<T, E>> resultTask, bool condition, Func<T, Task<Result<K, E>>> func) =>
+            CheckIf(resultTask, condition, func);
+
+        [Obsolete("Use CheckIf() instead.")]
+        public static Task<Result<T>> TapIf<T>(this Task<Result<T>> resultTask, Func<T, bool> predicate, Func<T, Task<Result>> func) =>
+            CheckIf(resultTask, predicate, func);
+
+        [Obsolete("Use CheckIf() instead.")]
+        public static Task<Result<T>> TapIf<T, K>(this Task<Result<T>> resultTask, Func<T, bool> predicate, Func<T, Task<Result<K>>> func) =>
+            CheckIf(resultTask, predicate, func);
+
+        [Obsolete("Use CheckIf() instead.")]
+        public static Task<Result<T, E>> TapIf<T, K, E>(this Task<Result<T, E>> resultTask, Func<T, bool> predicate, Func<T, Task<Result<K, E>>> func) =>
+            CheckIf(resultTask, predicate, func);
+    }
+}

--- a/CSharpFunctionalExtensions/Result/Obsolete/TapIfAsyncLeft.cs
+++ b/CSharpFunctionalExtensions/Result/Obsolete/TapIfAsyncLeft.cs
@@ -1,0 +1,26 @@
+using System;
+using System.Threading.Tasks;
+
+namespace CSharpFunctionalExtensions
+{
+    public static partial class AsyncResultExtensionsLeftOperand
+    {
+        public static Task<Result<T>> TapIf<T>(this Task<Result<T>> resultTask, bool condition, Func<T, Result> func) =>
+            CheckIf(resultTask, condition, func);
+
+        public static Task<Result<T>> TapIf<T, K>(this Task<Result<T>> resultTask, bool condition, Func<T, Result<K>> func) =>
+            CheckIf(resultTask, condition, func);
+
+        public static Task<Result<T, E>> TapIf<T, K, E>(this Task<Result<T, E>> resultTask, bool condition, Func<T, Result<K, E>> func) =>
+            CheckIf(resultTask, condition, func);
+
+        public static Task<Result<T>> TapIf<T>(this Task<Result<T>> resultTask, Func<T, bool> predicate, Func<T, Result> func) =>
+            CheckIf(resultTask, predicate, func);
+
+        public static Task<Result<T>> TapIf<T, K>(this Task<Result<T>> resultTask, Func<T, bool> predicate, Func<T, Result<K>> func) =>
+            CheckIf(resultTask, predicate, func);
+
+        public static Task<Result<T, E>> TapIf<T, K, E>(this Task<Result<T, E>> resultTask, Func<T, bool> predicate, Func<T, Result<K, E>> func) =>
+            CheckIf(resultTask, predicate, func);
+    }
+}

--- a/CSharpFunctionalExtensions/Result/Obsolete/TapIfAsyncLeft.cs
+++ b/CSharpFunctionalExtensions/Result/Obsolete/TapIfAsyncLeft.cs
@@ -5,21 +5,27 @@ namespace CSharpFunctionalExtensions
 {
     public static partial class AsyncResultExtensionsLeftOperand
     {
+        [Obsolete("Use CheckIf() instead.")]
         public static Task<Result<T>> TapIf<T>(this Task<Result<T>> resultTask, bool condition, Func<T, Result> func) =>
             CheckIf(resultTask, condition, func);
 
+        [Obsolete("Use CheckIf() instead.")]
         public static Task<Result<T>> TapIf<T, K>(this Task<Result<T>> resultTask, bool condition, Func<T, Result<K>> func) =>
             CheckIf(resultTask, condition, func);
 
+        [Obsolete("Use CheckIf() instead.")]
         public static Task<Result<T, E>> TapIf<T, K, E>(this Task<Result<T, E>> resultTask, bool condition, Func<T, Result<K, E>> func) =>
             CheckIf(resultTask, condition, func);
 
+        [Obsolete("Use CheckIf() instead.")]
         public static Task<Result<T>> TapIf<T>(this Task<Result<T>> resultTask, Func<T, bool> predicate, Func<T, Result> func) =>
             CheckIf(resultTask, predicate, func);
 
+        [Obsolete("Use CheckIf() instead.")]
         public static Task<Result<T>> TapIf<T, K>(this Task<Result<T>> resultTask, Func<T, bool> predicate, Func<T, Result<K>> func) =>
             CheckIf(resultTask, predicate, func);
 
+        [Obsolete("Use CheckIf() instead.")]
         public static Task<Result<T, E>> TapIf<T, K, E>(this Task<Result<T, E>> resultTask, Func<T, bool> predicate, Func<T, Result<K, E>> func) =>
             CheckIf(resultTask, predicate, func);
     }

--- a/CSharpFunctionalExtensions/Result/Obsolete/TapIfAsyncRight.cs
+++ b/CSharpFunctionalExtensions/Result/Obsolete/TapIfAsyncRight.cs
@@ -1,0 +1,26 @@
+using System;
+using System.Threading.Tasks;
+
+namespace CSharpFunctionalExtensions
+{
+    public static partial class AsyncResultExtensionsRightOperand
+    {
+        public static Task<Result<T>> TapIf<T>(this Result<T> result, bool condition, Func<T, Task<Result>> func) =>
+            CheckIf(result, condition, func);
+
+        public static Task<Result<T>> TapIf<T, K>(this Result<T> result, bool condition, Func<T, Task<Result<K>>> func) =>
+            CheckIf(result, condition, func);
+
+        public static Task<Result<T, E>> TapIf<T, K, E>(this Result<T, E> result, bool condition, Func<T, Task<Result<K, E>>> func) =>
+            CheckIf(result, condition, func);
+
+        public static Task<Result<T>> TapIf<T>(this Result<T> result, Func<T, bool> predicate, Func<T, Task<Result>> func) =>
+            CheckIf(result, predicate, func);
+
+        public static Task<Result<T>> TapIf<T, K>(this Result<T> result, Func<T, bool> predicate, Func<T, Task<Result<K>>> func) =>
+            CheckIf(result, predicate, func);
+
+        public static Task<Result<T, E>> TapIf<T, K, E>(this Result<T, E> result, Func<T, bool> predicate, Func<T, Task<Result<K, E>>> func) =>
+            CheckIf(result, predicate, func);
+    }
+}

--- a/CSharpFunctionalExtensions/Result/Obsolete/TapIfAsyncRight.cs
+++ b/CSharpFunctionalExtensions/Result/Obsolete/TapIfAsyncRight.cs
@@ -5,21 +5,27 @@ namespace CSharpFunctionalExtensions
 {
     public static partial class AsyncResultExtensionsRightOperand
     {
+        [Obsolete("Use CheckIf() instead.")]
         public static Task<Result<T>> TapIf<T>(this Result<T> result, bool condition, Func<T, Task<Result>> func) =>
             CheckIf(result, condition, func);
 
+        [Obsolete("Use CheckIf() instead.")]
         public static Task<Result<T>> TapIf<T, K>(this Result<T> result, bool condition, Func<T, Task<Result<K>>> func) =>
             CheckIf(result, condition, func);
 
+        [Obsolete("Use CheckIf() instead.")]
         public static Task<Result<T, E>> TapIf<T, K, E>(this Result<T, E> result, bool condition, Func<T, Task<Result<K, E>>> func) =>
             CheckIf(result, condition, func);
 
+        [Obsolete("Use CheckIf() instead.")]
         public static Task<Result<T>> TapIf<T>(this Result<T> result, Func<T, bool> predicate, Func<T, Task<Result>> func) =>
             CheckIf(result, predicate, func);
 
+        [Obsolete("Use CheckIf() instead.")]
         public static Task<Result<T>> TapIf<T, K>(this Result<T> result, Func<T, bool> predicate, Func<T, Task<Result<K>>> func) =>
             CheckIf(result, predicate, func);
 
+        [Obsolete("Use CheckIf() instead.")]
         public static Task<Result<T, E>> TapIf<T, K, E>(this Result<T, E> result, Func<T, bool> predicate, Func<T, Task<Result<K, E>>> func) =>
             CheckIf(result, predicate, func);
     }


### PR DESCRIPTION
This is a PR after the issue discussion https://github.com/vkhorikov/CSharpFunctionalExtensions/issues/242.

What was changed:
1. Added Check and CheckIf methods for all Tap and TapIf overloads that could affect output results.
2. Old methods were marked as obsolete and moved to separate files in "Obsolete" folder.
3. Tests were splitted accordingly.

