### PR TITLE
fix: Ensure with errorPredicate checks initial result state

### DIFF
--- a/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/EnsureAsyncLeftTests.cs
+++ b/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/EnsureAsyncLeftTests.cs
@@ -1,0 +1,57 @@
+using System;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Xunit;
+
+namespace CSharpFunctionalExtensions.Tests.ResultTests.Extensions
+{
+    public class EnsureAsyncLeftTests
+    {
+        [Fact]
+        public async Task Ensure_with_errorPredicate_does_not_throw_when_given_result_failure()
+        {
+            var result = Task.FromResult(Result.Failure<string>("initial error message"));
+            Func<Task> ensure = () => result.Ensure(
+                x => x != "", 
+                x =>"new error message: string should not be empty");
+            
+            await ensure.Should().NotThrowAsync<Exception>("passing in a Result.Failure is a valid use case");
+        }
+        
+        [Fact]
+        public async Task Ensure_with_errorPredicate_initial_result_has_failure_state()
+        {
+            var tResult = Task.FromResult(Result.Failure<string>("initial error message"));
+
+            var result = await tResult.Ensure(x => x != "", 
+                x => "new error message: string should not be empty");
+            
+            result.IsSuccess.Should().BeFalse("Input Result.Failure should be returned");
+            result.Error.Should().Be("initial error message");
+        }
+
+        [Fact]
+        public async Task Ensure_with_errorPredicate_predicate_passes()
+        {
+            var tResult = Task.FromResult(Result.Success("initial ok"));
+
+            var result = await tResult.Ensure(x => x != "", 
+                x => "new error message: string should not be empty");
+            
+            result.IsSuccess.Should().BeTrue("Input Result passes predicate condition");
+            result.Value.Should().Be("initial ok");
+        }
+
+        [Fact]
+        public async Task Ensure_with_errorPredicate_using_errorPredicate()
+        {
+            var tResult = Task.FromResult(Result.Success(""));
+
+            var result = await tResult.Ensure(x => x != "", 
+                x => "new error message: string should not be empty");
+            
+            result.IsSuccess.Should().BeFalse("Input Result fails predicate condition");
+            result.Error.Should().Be("new error message: string should not be empty");
+        }
+    }
+}

--- a/CSharpFunctionalExtensions/Result/Extensions/EnsureAsyncLeft.cs
+++ b/CSharpFunctionalExtensions/Result/Extensions/EnsureAsyncLeft.cs
@@ -30,6 +30,10 @@ namespace CSharpFunctionalExtensions
         public static async Task<Result<T>> Ensure<T>(this Task<Result<T>> resultTask, Func<T, bool> predicate, Func<T, string> errorPredicate)
         {
             Result<T> result = await resultTask.DefaultAwait();
+            
+            if (result.IsFailure)
+                return result;
+
             return result.Ensure(predicate, errorPredicate(result.Value));
         }
 
@@ -39,6 +43,10 @@ namespace CSharpFunctionalExtensions
         public static async Task<Result<T>> Ensure<T>(this Task<Result<T>> resultTask, Func<T, bool> predicate, Func<T, Task<string>> errorPredicate)
         {
             Result<T> result = await resultTask.DefaultAwait();
+            
+            if (result.IsFailure)
+                return result;
+
             return result.Ensure(predicate, await errorPredicate(result.Value));
         }
 


### PR DESCRIPTION
This patch to the Ensure methods adds a missing check to see if the input result is in failure state.
Also added some tests to confirm the behavior.