### PR TITLE
Bind-/Map-/WithTransactionScope() fixed for net5.0 (symbol is NET5_0,…

### DIFF
--- a/CSharpFunctionalExtensions/Result/Extensions/BindWithTransactionScope.cs
+++ b/CSharpFunctionalExtensions/Result/Extensions/BindWithTransactionScope.cs
@@ -1,4 +1,4 @@
-#if NETSTANDARD2_0 || NET50
+#if NETSTANDARD2_0 || NET5_0
 using System;
 
 namespace CSharpFunctionalExtensions

--- a/CSharpFunctionalExtensions/Result/Extensions/BindWithTransactionScopeAsyncBoth.cs
+++ b/CSharpFunctionalExtensions/Result/Extensions/BindWithTransactionScopeAsyncBoth.cs
@@ -1,4 +1,4 @@
-#if NETSTANDARD2_0
+#if NETSTANDARD2_0 || NET5_0
 using System;
 using System.Threading.Tasks;
 

--- a/CSharpFunctionalExtensions/Result/Extensions/BindWithTransactionScopeAsyncLeft.cs
+++ b/CSharpFunctionalExtensions/Result/Extensions/BindWithTransactionScopeAsyncLeft.cs
@@ -1,4 +1,4 @@
-#if NETSTANDARD2_0
+#if NETSTANDARD2_0 || NET5_0
 using System;
 using System.Threading.Tasks;
 

--- a/CSharpFunctionalExtensions/Result/Extensions/BindWithTransactionScopeAsyncRight.cs
+++ b/CSharpFunctionalExtensions/Result/Extensions/BindWithTransactionScopeAsyncRight.cs
@@ -1,4 +1,4 @@
-#if NETSTANDARD2_0
+#if NETSTANDARD2_0 || NET5_0
 using System;
 using System.Threading.Tasks;
 

--- a/CSharpFunctionalExtensions/Result/Extensions/MapWithTransactionScope.cs
+++ b/CSharpFunctionalExtensions/Result/Extensions/MapWithTransactionScope.cs
@@ -1,4 +1,4 @@
-#if NETSTANDARD2_0
+#if NETSTANDARD2_0 || NET5_0
 using System;
 
 namespace CSharpFunctionalExtensions

--- a/CSharpFunctionalExtensions/Result/Extensions/MapWithTransactionScopeAsyncBoth.cs
+++ b/CSharpFunctionalExtensions/Result/Extensions/MapWithTransactionScopeAsyncBoth.cs
@@ -1,4 +1,4 @@
-#if NETSTANDARD2_0
+#if NETSTANDARD2_0 || NET5_0
 using System;
 using System.Threading.Tasks;
 

--- a/CSharpFunctionalExtensions/Result/Extensions/MapWithTransactionScopeAsyncLeft.cs
+++ b/CSharpFunctionalExtensions/Result/Extensions/MapWithTransactionScopeAsyncLeft.cs
@@ -1,4 +1,4 @@
-#if NETSTANDARD2_0
+#if NETSTANDARD2_0 || NET5_0
 using System;
 using System.Threading.Tasks;
 

--- a/CSharpFunctionalExtensions/Result/Extensions/MapWithTransactionScopeAsyncRight.cs
+++ b/CSharpFunctionalExtensions/Result/Extensions/MapWithTransactionScopeAsyncRight.cs
@@ -1,4 +1,4 @@
-#if NETSTANDARD2_0
+#if NETSTANDARD2_0 || NET5_0
 using System;
 using System.Threading.Tasks;
 

--- a/CSharpFunctionalExtensions/Result/Extensions/WithTransactionScope.cs
+++ b/CSharpFunctionalExtensions/Result/Extensions/WithTransactionScope.cs
@@ -1,4 +1,4 @@
-#if NETSTANDARD2_0 || NET50
+#if NETSTANDARD2_0 || NET5_0
 using System;
 using System.Threading.Tasks;
 using System.Transactions;


### PR DESCRIPTION
… not NET50)