### PR TITLE
add an overload to avoid nesting

### DIFF
--- a/CSharpFunctionalExtensions/Result/Extensions/MapAsyncRight.cs
+++ b/CSharpFunctionalExtensions/Result/Extensions/MapAsyncRight.cs
@@ -34,6 +34,18 @@ namespace CSharpFunctionalExtensions
         /// <summary>
         ///     Creates a new result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.
         /// </summary>
+        public static async Task<Result<K>> Map<T, K>(this Result<T> result, Func<T, Task<Result<K>>> func)
+        {
+            if (result.IsFailure)
+                return Result.Failure<K>(result.Error);
+
+            Result<K> value = await func(result.Value).DefaultAwait();
+            return value;
+        }
+
+        /// <summary>
+        ///     Creates a new result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.
+        /// </summary>
         public static async Task<Result<K>> Map<K>(this Result result, Func<Task<K>> func)
         {
             if (result.IsFailure)


### PR DESCRIPTION
Just ran into a situation where `.Map` returned a `Task<Result<T>>` and the return type was `Result<Result<T>>`. This will allow the return type to be `Result<T>`.

Example Code
``` csharp
Result<Y> result = await Maybe<X>.From(something)
    .ToResult("My Message")
    .Map(async x => 
    {
        Result<Y> y = await GetYAsync();
        y.OnFailure(log);
        // something else
        return y; // formerly this would result in Result<Result<Y>>
    });
```