### PR TITLE
Add overload to Result<T,E>.Ensure() for an error predicate

### DIFF
--- a/CSharpFunctionalExtensions/Result/Extensions/Ensure.cs
+++ b/CSharpFunctionalExtensions/Result/Extensions/Ensure.cs
@@ -7,6 +7,20 @@ namespace CSharpFunctionalExtensions
         /// <summary>
         ///     Returns a new failure result if the predicate is false. Otherwise returns the starting result.
         /// </summary>
+        public static Result<T, E> Ensure<T, E>(this Result<T, E> result, Func<T, bool> predicate, Func<T, E> errorPredicate)
+        {
+            if (result.IsFailure)
+                return result;
+
+            if (!predicate(result.Value))
+                return Result.Failure<T, E>(errorPredicate(result.Value));
+
+            return result;
+        }
+
+        /// <summary>
+        ///     Returns a new failure result if the predicate is false. Otherwise returns the starting result.
+        /// </summary>
         public static Result<T, E> Ensure<T, E>(this Result<T, E> result, Func<T, bool> predicate, E error)
         {
             if (result.IsFailure)
@@ -47,7 +61,7 @@ namespace CSharpFunctionalExtensions
         }
 
         /// <summary>
-        ///     Returns a new failure result if the predicate is false. Otherwise returns the starting result.
+        ///     Returns a new failure result if the predicate is false. Otherwise returns the starting result.  
         /// </summary>
         public static Result Ensure(this Result result, Func<bool> predicate, string errorMessage)
         {

--- a/CSharpFunctionalExtensions/Result/Extensions/Ensure.cs
+++ b/CSharpFunctionalExtensions/Result/Extensions/Ensure.cs
@@ -61,7 +61,7 @@ namespace CSharpFunctionalExtensions
         }
 
         /// <summary>
-        ///     Returns a new failure result if the predicate is false. Otherwise returns the starting result.  
+        ///     Returns a new failure result if the predicate is false. Otherwise returns the starting result.
         /// </summary>
         public static Result Ensure(this Result result, Func<bool> predicate, string errorMessage)
         {

--- a/CSharpFunctionalExtensions/Result/Extensions/EnsureAsyncBoth.cs
+++ b/CSharpFunctionalExtensions/Result/Extensions/EnsureAsyncBoth.cs
@@ -1,14 +1,14 @@
 using System;
 using System.Threading.Tasks;
 
-namespace CSharpFunctionalExtensions 
+namespace CSharpFunctionalExtensions
 {
-    public static partial class AsyncResultExtensionsBothOperands 
+    public static partial class AsyncResultExtensionsBothOperands
     {
         /// <summary>
         ///     Returns a new failure result if the predicate is false. Otherwise returns the starting result.
         /// </summary>
-        public static async Task<Result<T>> Ensure<T>(this Task<Result<T>> resultTask, Func<T, Task<bool>> predicate, string errorMessage) 
+        public static async Task<Result<T>> Ensure<T>(this Task<Result<T>> resultTask, Func<T, Task<bool>> predicate, string errorMessage)
         {
             Result<T> result = await resultTask.DefaultAwait();
 
@@ -24,7 +24,7 @@ namespace CSharpFunctionalExtensions
         /// <summary>
         ///     Returns a new failure result if the predicate is false. Otherwise returns the starting result.
         /// </summary>
-        public static async Task<Result<T, E>> Ensure<T, E>(this Task<Result<T, E>> resultTask, Func<T, Task<bool>> predicate, E error) 
+        public static async Task<Result<T, E>> Ensure<T, E>(this Task<Result<T, E>> resultTask, Func<T, Task<bool>> predicate, E error)
         {
             Result<T, E> result = await resultTask.DefaultAwait();
 
@@ -40,7 +40,7 @@ namespace CSharpFunctionalExtensions
         /// <summary>
         ///     Returns a new failure result if the predicate is false. Otherwise returns the starting result.
         /// </summary>
-        public static async Task<Result<T, E>> Ensure<T, E>(this Task<Result<T, E>> resultTask, Func<T, Task<bool>> predicate, Func<T, E> errorPredicate) 
+        public static async Task<Result<T, E>> Ensure<T, E>(this Task<Result<T, E>> resultTask, Func<T, Task<bool>> predicate, Func<T, E> errorPredicate)
         {
             Result<T, E> result = await resultTask.DefaultAwait();
 
@@ -56,7 +56,7 @@ namespace CSharpFunctionalExtensions
         /// <summary>
         ///     Returns a new failure result if the predicate is false. Otherwise returns the starting result.
         /// </summary>
-        public static async Task<Result<T, E>> Ensure<T, E>(this Task<Result<T, E>> resultTask, Func<T, Task<bool>> predicate, Func<T, Task<E>> errorPredicate) 
+        public static async Task<Result<T, E>> Ensure<T, E>(this Task<Result<T, E>> resultTask, Func<T, Task<bool>> predicate, Func<T, Task<E>> errorPredicate)
         {
             Result<T, E> result = await resultTask.DefaultAwait();
 
@@ -72,7 +72,8 @@ namespace CSharpFunctionalExtensions
         /// <summary>
         ///     Returns a new failure result if the predicate is false. Otherwise returns the starting result.
         /// </summary>
-        public static async Task<Result<T>> Ensure<T>(this Task<Result<T>> resultTask, Func<T, Task<bool>> predicate, Func<T, string> errorPredicate) {
+        public static async Task<Result<T>> Ensure<T>(this Task<Result<T>> resultTask, Func<T, Task<bool>> predicate, Func<T, string> errorPredicate) 
+        {
             Result<T> result = await resultTask.DefaultAwait();
 
             if (result.IsFailure)
@@ -87,7 +88,7 @@ namespace CSharpFunctionalExtensions
         /// <summary>
         ///     Returns a new failure result if the predicate is false. Otherwise returns the starting result.
         /// </summary>
-        public static async Task<Result<T>> Ensure<T>(this Task<Result<T>> resultTask, Func<T, Task<bool>> predicate, Func<T, Task<string>> errorPredicate) 
+        public static async Task<Result<T>> Ensure<T>(this Task<Result<T>> resultTask, Func<T, Task<bool>> predicate, Func<T, Task<string>> errorPredicate)
         {
             Result<T> result = await resultTask.DefaultAwait();
 
@@ -103,7 +104,7 @@ namespace CSharpFunctionalExtensions
         /// <summary>
         ///     Returns a new failure result if the predicate is false. Otherwise returns the starting result.
         /// </summary>
-        public static async Task<Result> Ensure(this Task<Result> resultTask, Func<Task<bool>> predicate, string errorMessage) 
+        public static async Task<Result> Ensure(this Task<Result> resultTask, Func<Task<bool>> predicate, string errorMessage)
         {
             Result result = await resultTask.DefaultAwait();
 

--- a/CSharpFunctionalExtensions/Result/Extensions/EnsureAsyncBoth.cs
+++ b/CSharpFunctionalExtensions/Result/Extensions/EnsureAsyncBoth.cs
@@ -1,14 +1,14 @@
 using System;
 using System.Threading.Tasks;
 
-namespace CSharpFunctionalExtensions
+namespace CSharpFunctionalExtensions 
 {
-    public static partial class AsyncResultExtensionsBothOperands
+    public static partial class AsyncResultExtensionsBothOperands 
     {
         /// <summary>
         ///     Returns a new failure result if the predicate is false. Otherwise returns the starting result.
         /// </summary>
-        public static async Task<Result<T>> Ensure<T>(this Task<Result<T>> resultTask, Func<T, Task<bool>> predicate, string errorMessage)
+        public static async Task<Result<T>> Ensure<T>(this Task<Result<T>> resultTask, Func<T, Task<bool>> predicate, string errorMessage) 
         {
             Result<T> result = await resultTask.DefaultAwait();
 
@@ -24,7 +24,7 @@ namespace CSharpFunctionalExtensions
         /// <summary>
         ///     Returns a new failure result if the predicate is false. Otherwise returns the starting result.
         /// </summary>
-        public static async Task<Result<T, E>> Ensure<T, E>(this Task<Result<T, E>> resultTask, Func<T, Task<bool>> predicate, E error)
+        public static async Task<Result<T, E>> Ensure<T, E>(this Task<Result<T, E>> resultTask, Func<T, Task<bool>> predicate, E error) 
         {
             Result<T, E> result = await resultTask.DefaultAwait();
 
@@ -40,8 +40,39 @@ namespace CSharpFunctionalExtensions
         /// <summary>
         ///     Returns a new failure result if the predicate is false. Otherwise returns the starting result.
         /// </summary>
-        public static async Task<Result<T>> Ensure<T>(this Task<Result<T>> resultTask, Func<T, Task<bool>> predicate, Func<T, string> errorPredicate)
+        public static async Task<Result<T, E>> Ensure<T, E>(this Task<Result<T, E>> resultTask, Func<T, Task<bool>> predicate, Func<T, E> errorPredicate) 
         {
+            Result<T, E> result = await resultTask.DefaultAwait();
+
+            if (result.IsFailure)
+                return result;
+
+            if (!await predicate(result.Value).DefaultAwait())
+                return Result.Failure<T, E>(errorPredicate(result.Value));
+
+            return result;
+        }
+
+        /// <summary>
+        ///     Returns a new failure result if the predicate is false. Otherwise returns the starting result.
+        /// </summary>
+        public static async Task<Result<T, E>> Ensure<T, E>(this Task<Result<T, E>> resultTask, Func<T, Task<bool>> predicate, Func<T, Task<E>> errorPredicate) 
+        {
+            Result<T, E> result = await resultTask.DefaultAwait();
+
+            if (result.IsFailure)
+                return result;
+
+            if (!await predicate(result.Value).DefaultAwait())
+                return Result.Failure<T, E>(await errorPredicate(result.Value));
+
+            return result;
+        }
+
+        /// <summary>
+        ///     Returns a new failure result if the predicate is false. Otherwise returns the starting result.
+        /// </summary>
+        public static async Task<Result<T>> Ensure<T>(this Task<Result<T>> resultTask, Func<T, Task<bool>> predicate, Func<T, string> errorPredicate) {
             Result<T> result = await resultTask.DefaultAwait();
 
             if (result.IsFailure)
@@ -56,7 +87,7 @@ namespace CSharpFunctionalExtensions
         /// <summary>
         ///     Returns a new failure result if the predicate is false. Otherwise returns the starting result.
         /// </summary>
-        public static async Task<Result<T>> Ensure<T>(this Task<Result<T>> resultTask, Func<T, Task<bool>> predicate, Func<T, Task<string>> errorPredicate)
+        public static async Task<Result<T>> Ensure<T>(this Task<Result<T>> resultTask, Func<T, Task<bool>> predicate, Func<T, Task<string>> errorPredicate) 
         {
             Result<T> result = await resultTask.DefaultAwait();
 
@@ -72,7 +103,7 @@ namespace CSharpFunctionalExtensions
         /// <summary>
         ///     Returns a new failure result if the predicate is false. Otherwise returns the starting result.
         /// </summary>
-        public static async Task<Result> Ensure(this Task<Result> resultTask, Func<Task<bool>> predicate, string errorMessage)
+        public static async Task<Result> Ensure(this Task<Result> resultTask, Func<Task<bool>> predicate, string errorMessage) 
         {
             Result result = await resultTask.DefaultAwait();
 

--- a/CSharpFunctionalExtensions/Result/Extensions/EnsureAsyncLeft.cs
+++ b/CSharpFunctionalExtensions/Result/Extensions/EnsureAsyncLeft.cs
@@ -1,14 +1,14 @@
 using System;
 using System.Threading.Tasks;
 
-namespace CSharpFunctionalExtensions
+namespace CSharpFunctionalExtensions 
 {
-    public static partial class AsyncResultExtensionsLeftOperand
+    public static partial class AsyncResultExtensionsLeftOperand 
     {
         /// <summary>
         ///     Returns a new failure result if the predicate is false. Otherwise returns the starting result.
         /// </summary>
-        public static async Task<Result<T>> Ensure<T>(this Task<Result<T>> resultTask, Func<T, bool> predicate, string errorMessage)
+        public static async Task<Result<T>> Ensure<T>(this Task<Result<T>> resultTask, Func<T, bool> predicate, string errorMessage) 
         {
             Result<T> result = await resultTask.DefaultAwait();
             return result.Ensure(predicate, errorMessage);
@@ -18,7 +18,7 @@ namespace CSharpFunctionalExtensions
         ///     Returns a new failure result if the predicate is false. Otherwise returns the starting result.
         /// </summary>
         public static async Task<Result<T, E>> Ensure<T, E>(this Task<Result<T, E>> resultTask,
-            Func<T, bool> predicate, E error)
+            Func<T, bool> predicate, E error) 
         {
             Result<T, E> result = await resultTask.DefaultAwait();
             return result.Ensure(predicate, error);
@@ -27,10 +27,20 @@ namespace CSharpFunctionalExtensions
         /// <summary>
         ///     Returns a new failure result if the predicate is false. Otherwise returns the starting result.
         /// </summary>
-        public static async Task<Result<T>> Ensure<T>(this Task<Result<T>> resultTask, Func<T, bool> predicate, Func<T, string> errorPredicate)
+        public static async Task<Result<T, E>> Ensure<T, E>(this Task<Result<T, E>> resultTask,
+            Func<T, bool> predicate, Func<T, E> errorPredicate) 
+        {
+            Result<T, E> result = await resultTask.DefaultAwait();
+            return result.Ensure(predicate, errorPredicate);
+        }
+
+        /// <summary>
+        ///     Returns a new failure result if the predicate is false. Otherwise returns the starting result.
+        /// </summary>
+        public static async Task<Result<T>> Ensure<T>(this Task<Result<T>> resultTask, Func<T, bool> predicate, Func<T, string> errorPredicate) 
         {
             Result<T> result = await resultTask.DefaultAwait();
-            
+
             if (result.IsFailure)
                 return result;
 
@@ -40,10 +50,10 @@ namespace CSharpFunctionalExtensions
         /// <summary>
         ///     Returns a new failure result if the predicate is false. Otherwise returns the starting result.
         /// </summary>
-        public static async Task<Result<T>> Ensure<T>(this Task<Result<T>> resultTask, Func<T, bool> predicate, Func<T, Task<string>> errorPredicate)
+        public static async Task<Result<T>> Ensure<T>(this Task<Result<T>> resultTask, Func<T, bool> predicate, Func<T, Task<string>> errorPredicate) 
         {
             Result<T> result = await resultTask.DefaultAwait();
-            
+
             if (result.IsFailure)
                 return result;
 
@@ -53,7 +63,7 @@ namespace CSharpFunctionalExtensions
         /// <summary>
         ///     Returns a new failure result if the predicate is false. Otherwise returns the starting result.
         /// </summary>
-        public static async Task<Result> Ensure(this Task<Result> resultTask, Func<bool> predicate, string errorMessage)
+        public static async Task<Result> Ensure(this Task<Result> resultTask, Func<bool> predicate, string errorMessage) 
         {
             Result result = await resultTask.DefaultAwait();
             return result.Ensure(predicate, errorMessage);

--- a/CSharpFunctionalExtensions/Result/Extensions/EnsureAsyncLeft.cs
+++ b/CSharpFunctionalExtensions/Result/Extensions/EnsureAsyncLeft.cs
@@ -8,7 +8,7 @@ namespace CSharpFunctionalExtensions
         /// <summary>
         ///     Returns a new failure result if the predicate is false. Otherwise returns the starting result.
         /// </summary>
-        public static async Task<Result<T>> Ensure<T>(this Task<Result<T>> resultTask, Func<T, bool> predicate, string errorMessage) 
+        public static async Task<Result<T>> Ensure<T>(this Task<Result<T>> resultTask, Func<T, bool> predicate, string errorMessage)
         {
             Result<T> result = await resultTask.DefaultAwait();
             return result.Ensure(predicate, errorMessage);
@@ -28,7 +28,7 @@ namespace CSharpFunctionalExtensions
         ///     Returns a new failure result if the predicate is false. Otherwise returns the starting result.
         /// </summary>
         public static async Task<Result<T, E>> Ensure<T, E>(this Task<Result<T, E>> resultTask,
-            Func<T, bool> predicate, Func<T, E> errorPredicate) 
+            Func<T, bool> predicate, Func<T, E> errorPredicate)
         {
             Result<T, E> result = await resultTask.DefaultAwait();
             return result.Ensure(predicate, errorPredicate);
@@ -37,7 +37,7 @@ namespace CSharpFunctionalExtensions
         /// <summary>
         ///     Returns a new failure result if the predicate is false. Otherwise returns the starting result.
         /// </summary>
-        public static async Task<Result<T>> Ensure<T>(this Task<Result<T>> resultTask, Func<T, bool> predicate, Func<T, string> errorPredicate) 
+        public static async Task<Result<T>> Ensure<T>(this Task<Result<T>> resultTask, Func<T, bool> predicate, Func<T, string> errorPredicate)
         {
             Result<T> result = await resultTask.DefaultAwait();
 
@@ -50,7 +50,7 @@ namespace CSharpFunctionalExtensions
         /// <summary>
         ///     Returns a new failure result if the predicate is false. Otherwise returns the starting result.
         /// </summary>
-        public static async Task<Result<T>> Ensure<T>(this Task<Result<T>> resultTask, Func<T, bool> predicate, Func<T, Task<string>> errorPredicate) 
+        public static async Task<Result<T>> Ensure<T>(this Task<Result<T>> resultTask, Func<T, bool> predicate, Func<T, Task<string>> errorPredicate)
         {
             Result<T> result = await resultTask.DefaultAwait();
 
@@ -63,7 +63,7 @@ namespace CSharpFunctionalExtensions
         /// <summary>
         ///     Returns a new failure result if the predicate is false. Otherwise returns the starting result.
         /// </summary>
-        public static async Task<Result> Ensure(this Task<Result> resultTask, Func<bool> predicate, string errorMessage) 
+        public static async Task<Result> Ensure(this Task<Result> resultTask, Func<bool> predicate, string errorMessage)
         {
             Result result = await resultTask.DefaultAwait();
             return result.Ensure(predicate, errorMessage);

--- a/CSharpFunctionalExtensions/Result/Extensions/EnsureAsyncRight.cs
+++ b/CSharpFunctionalExtensions/Result/Extensions/EnsureAsyncRight.cs
@@ -8,7 +8,7 @@ namespace CSharpFunctionalExtensions
         /// <summary>
         ///     Returns a new failure result if the predicate is false. Otherwise returns the starting result.
         /// </summary>
-        public static async Task<Result<T>> Ensure<T>(this Result<T> result, Func<T, Task<bool>> predicate, string errorMessage) 
+        public static async Task<Result<T>> Ensure<T>(this Result<T> result, Func<T, Task<bool>> predicate, string errorMessage)
         {
             if (result.IsFailure)
                 return result;
@@ -23,7 +23,7 @@ namespace CSharpFunctionalExtensions
         ///     Returns a new failure result if the predicate is false. Otherwise returns the starting result.
         /// </summary>
         public static async Task<Result<T, E>> Ensure<T, E>(this Result<T, E> result,
-            Func<T, Task<bool>> predicate, E error) 
+            Func<T, Task<bool>> predicate, E error)
         {
             if (result.IsFailure)
                 return result;
@@ -38,7 +38,7 @@ namespace CSharpFunctionalExtensions
         ///     Returns a new failure result if the predicate is false. Otherwise returns the starting result.
         /// </summary>
         public static async Task<Result<T, E>> Ensure<T, E>(this Result<T, E> result,
-            Func<T, Task<bool>> predicate, Func<T, E> errorPredicate) 
+            Func<T, Task<bool>> predicate, Func<T, E> errorPredicate)
         {
             if (result.IsFailure)
                 return result;
@@ -53,7 +53,7 @@ namespace CSharpFunctionalExtensions
         ///     Returns a new failure result if the predicate is false. Otherwise returns the starting result.
         /// </summary>
         public static async Task<Result<T, E>> Ensure<T, E>(this Result<T, E> result,
-            Func<T, Task<bool>> predicate, Func<T, Task<E>> errorPredicate) 
+            Func<T, Task<bool>> predicate, Func<T, Task<E>> errorPredicate)
         {
             if (result.IsFailure)
                 return result;
@@ -67,7 +67,8 @@ namespace CSharpFunctionalExtensions
         /// <summary>
         ///     Returns a new failure result if the predicate is false. Otherwise returns the starting result.
         /// </summary>
-        public static async Task<Result<T>> Ensure<T>(this Result<T> result, Func<T, Task<bool>> predicate, Func<T, string> errorPredicate) {
+        public static async Task<Result<T>> Ensure<T>(this Result<T> result, Func<T, Task<bool>> predicate, Func<T, string> errorPredicate)
+        {
             if (result.IsFailure)
                 return result;
 
@@ -80,7 +81,7 @@ namespace CSharpFunctionalExtensions
         /// <summary>
         ///     Returns a new failure result if the predicate is false. Otherwise returns the starting result.
         /// </summary>
-        public static async Task<Result<T>> Ensure<T>(this Result<T> result, Func<T, Task<bool>> predicate, Func<T, Task<string>> errorPredicate) 
+        public static async Task<Result<T>> Ensure<T>(this Result<T> result, Func<T, Task<bool>> predicate, Func<T, Task<string>> errorPredicate)
         {
             if (result.IsFailure)
                 return result;
@@ -94,7 +95,7 @@ namespace CSharpFunctionalExtensions
         /// <summary>
         ///     Returns a new failure result if the predicate is false. Otherwise returns the starting result.
         /// </summary>
-        public static async Task<Result> Ensure(this Result result, Func<Task<bool>> predicate, string errorMessage) 
+        public static async Task<Result> Ensure(this Result result, Func<Task<bool>> predicate, string errorMessage)
         {
             if (result.IsFailure)
                 return result;

--- a/CSharpFunctionalExtensions/Result/Extensions/EnsureAsyncRight.cs
+++ b/CSharpFunctionalExtensions/Result/Extensions/EnsureAsyncRight.cs
@@ -3,12 +3,12 @@ using System.Threading.Tasks;
 
 namespace CSharpFunctionalExtensions
 {
-    public static partial class AsyncResultExtensionsRightOperand
+    public static partial class AsyncResultExtensionsRightOperand 
     {
         /// <summary>
         ///     Returns a new failure result if the predicate is false. Otherwise returns the starting result.
         /// </summary>
-        public static async Task<Result<T>> Ensure<T>(this Result<T> result, Func<T, Task<bool>> predicate, string errorMessage)
+        public static async Task<Result<T>> Ensure<T>(this Result<T> result, Func<T, Task<bool>> predicate, string errorMessage) 
         {
             if (result.IsFailure)
                 return result;
@@ -23,7 +23,7 @@ namespace CSharpFunctionalExtensions
         ///     Returns a new failure result if the predicate is false. Otherwise returns the starting result.
         /// </summary>
         public static async Task<Result<T, E>> Ensure<T, E>(this Result<T, E> result,
-            Func<T, Task<bool>> predicate, E error)
+            Func<T, Task<bool>> predicate, E error) 
         {
             if (result.IsFailure)
                 return result;
@@ -37,8 +37,37 @@ namespace CSharpFunctionalExtensions
         /// <summary>
         ///     Returns a new failure result if the predicate is false. Otherwise returns the starting result.
         /// </summary>
-        public static async Task<Result<T>> Ensure<T>(this Result<T> result, Func<T, Task<bool>> predicate, Func<T, string> errorPredicate)
+        public static async Task<Result<T, E>> Ensure<T, E>(this Result<T, E> result,
+            Func<T, Task<bool>> predicate, Func<T, E> errorPredicate) 
         {
+            if (result.IsFailure)
+                return result;
+
+            if (!await predicate(result.Value).DefaultAwait())
+                return Result.Failure<T, E>(errorPredicate(result.Value));
+
+            return result;
+        }
+
+        /// <summary>
+        ///     Returns a new failure result if the predicate is false. Otherwise returns the starting result.
+        /// </summary>
+        public static async Task<Result<T, E>> Ensure<T, E>(this Result<T, E> result,
+            Func<T, Task<bool>> predicate, Func<T, Task<E>> errorPredicate) 
+        {
+            if (result.IsFailure)
+                return result;
+
+            if (!await predicate(result.Value).DefaultAwait())
+                return Result.Failure<T, E>(await errorPredicate(result.Value));
+
+            return result;
+        }
+
+        /// <summary>
+        ///     Returns a new failure result if the predicate is false. Otherwise returns the starting result.
+        /// </summary>
+        public static async Task<Result<T>> Ensure<T>(this Result<T> result, Func<T, Task<bool>> predicate, Func<T, string> errorPredicate) {
             if (result.IsFailure)
                 return result;
 
@@ -51,7 +80,7 @@ namespace CSharpFunctionalExtensions
         /// <summary>
         ///     Returns a new failure result if the predicate is false. Otherwise returns the starting result.
         /// </summary>
-        public static async Task<Result<T>> Ensure<T>(this Result<T> result, Func<T, Task<bool>> predicate, Func<T, Task<string>> errorPredicate)
+        public static async Task<Result<T>> Ensure<T>(this Result<T> result, Func<T, Task<bool>> predicate, Func<T, Task<string>> errorPredicate) 
         {
             if (result.IsFailure)
                 return result;
@@ -65,7 +94,7 @@ namespace CSharpFunctionalExtensions
         /// <summary>
         ///     Returns a new failure result if the predicate is false. Otherwise returns the starting result.
         /// </summary>
-        public static async Task<Result> Ensure(this Result result, Func<Task<bool>> predicate, string errorMessage)
+        public static async Task<Result> Ensure(this Result result, Func<Task<bool>> predicate, string errorMessage) 
         {
             if (result.IsFailure)
                 return result;


### PR DESCRIPTION
Example use case:

```
var result = GetCustomerWithId(id)
    .Ensure(c => c.isActive, c => new BadRequest($"Customer {c.name} is not active"));
```