### PR TITLE
Add Maybe.Or sync/async extensions and tests

### DIFF
--- a/CSharpFunctionalExtensions.Tests/MaybeTests/AsyncExtensionsTests.cs
+++ b/CSharpFunctionalExtensions.Tests/MaybeTests/AsyncExtensionsTests.cs
@@ -372,6 +372,32 @@ namespace CSharpFunctionalExtensions.Tests.MaybeTests
             maybe2.Value.Should().Be(result);
         }
 
+        [Fact]
+        public async Task Async_Or_returns_source_if_source_has_value()
+        {
+            var instance = new MyClass { Property = "Some value" };
+            Task<Maybe<MyClass>> maybeTask = GetMaybeTask(instance);
+            var result = new MyClass { Property = "Different value" };
+
+            Maybe<MyClass> maybe2 = await maybeTask.Or(result);
+
+            maybe2.HasValue.Should().BeTrue();
+            maybe2.Should().Be(instance);
+        }
+
+        [Fact]
+        public async Task Async_Or_returns_a_new_instance_with_value_when_source_is_empty()
+        {
+            var instance = Maybe<MyClass>.None;
+            Task<Maybe<MyClass>> maybeTask = GetMaybeTask(instance);
+            var result = new MyClass { Property = "Different value" };
+
+            Maybe<MyClass> maybe2 = await maybeTask.Or(result);
+
+            maybe2.HasValue.Should().BeTrue();
+            maybe2.Should().Be(result);
+        }
+
         private static Task<Maybe<MyClass>> GetMaybeTask(Maybe<MyClass> maybe) => maybe.AsTask();
 
         private static Func<MyClass, T> ExpectAndReturn<T>(MyClass expected, T result) => actual =>

--- a/CSharpFunctionalExtensions.Tests/MaybeTests/AsyncExtensionsTests.cs
+++ b/CSharpFunctionalExtensions.Tests/MaybeTests/AsyncExtensionsTests.cs
@@ -373,7 +373,7 @@ namespace CSharpFunctionalExtensions.Tests.MaybeTests
         }
 
         [Fact]
-        public async Task Async_Or_returns_source_if_source_has_value()
+        public async Task Async_Or_fallback_value_returns_source_if_source_has_value()
         {
             var instance = new MyClass { Property = "Some value" };
             Task<Maybe<MyClass>> maybeTask = GetMaybeTask(instance);
@@ -386,13 +386,169 @@ namespace CSharpFunctionalExtensions.Tests.MaybeTests
         }
 
         [Fact]
-        public async Task Async_Or_returns_a_new_instance_with_value_when_source_is_empty()
+        public async Task Async_Or_fallback_value_returns_a_new_instance_with_value_when_source_is_empty()
         {
             var instance = Maybe<MyClass>.None;
             Task<Maybe<MyClass>> maybeTask = GetMaybeTask(instance);
             var result = new MyClass { Property = "Different value" };
 
             Maybe<MyClass> maybe2 = await maybeTask.Or(result);
+
+            maybe2.HasValue.Should().BeTrue();
+            maybe2.Should().Be(result);
+        }
+
+        [Fact]
+        public async Task Async_Or_fallback_task_returns_source_if_source_has_value()
+        {
+            var instance = new MyClass { Property = "Some value" };
+            Task<Maybe<MyClass>> maybeTask = GetMaybeTask(instance);
+            var result = new MyClass { Property = "Different value" };
+
+            Maybe<MyClass> maybe2 = await maybeTask.Or(Task.FromResult(result));
+
+            maybe2.HasValue.Should().BeTrue();
+            maybe2.Should().Be(instance);
+        }
+
+        [Fact]
+        public async Task Async_Or_fallback_task_returns_a_new_instance_with_value_when_source_is_empty()
+        {
+            var instance = Maybe<MyClass>.None;
+            Task<Maybe<MyClass>> maybeTask = GetMaybeTask(instance);
+            var result = new MyClass { Property = "Different value" };
+
+            Maybe<MyClass> maybe2 = await maybeTask.Or(Task.FromResult(result));
+
+            maybe2.HasValue.Should().BeTrue();
+            maybe2.Should().Be(result);
+        }
+
+        [Fact]
+        public async Task Async_Or_fallback_operation_returns_source_if_source_has_value()
+        {
+            var instance = new MyClass { Property = "Some value" };
+            Task<Maybe<MyClass>> maybeTask = GetMaybeTask(instance);
+            var result = new MyClass { Property = "Different value" };
+
+            Maybe<MyClass> maybe2 = await maybeTask.Or(() => result);
+
+            maybe2.HasValue.Should().BeTrue();
+            maybe2.Should().Be(instance);
+        }
+
+        [Fact]
+        public async Task Async_Or_fallback_operation_returns_a_new_instance_with_value_when_source_is_empty()
+        {
+            var instance = Maybe<MyClass>.None;
+            Task<Maybe<MyClass>> maybeTask = GetMaybeTask(instance);
+            var result = new MyClass { Property = "Different value" };
+
+            Maybe<MyClass> maybe2 = await maybeTask.Or(() => result);
+
+            maybe2.HasValue.Should().BeTrue();
+            maybe2.Should().Be(result);
+        }
+
+        [Fact]
+        public async Task Async_Or_fallback_operation_async_returns_source_if_source_has_value()
+        {
+            var instance = new MyClass { Property = "Some value" };
+            Task<Maybe<MyClass>> maybeTask = GetMaybeTask(instance);
+            var result = new MyClass { Property = "Different value" };
+
+            Maybe<MyClass> maybe2 = await maybeTask.Or(() => Task.FromResult(result));
+
+            maybe2.HasValue.Should().BeTrue();
+            maybe2.Should().Be(instance);
+        }
+
+        [Fact]
+        public async Task Async_Or_fallback_operation_async_returns_a_new_instance_with_value_when_source_is_empty()
+        {
+            var instance = Maybe<MyClass>.None;
+            Task<Maybe<MyClass>> maybeTask = GetMaybeTask(instance);
+            var result = new MyClass { Property = "Different value" };
+
+            Maybe<MyClass> maybe2 = await maybeTask.Or(() => Task.FromResult(result));
+
+            maybe2.HasValue.Should().BeTrue();
+            maybe2.Should().Be(result);
+        }
+
+        [Fact]
+        public async Task Async_Or_fallback_maybe_returns_source_if_source_has_value()
+        {
+            var instance = new MyClass { Property = "Some value" };
+            Task<Maybe<MyClass>> maybeTask = GetMaybeTask(instance);
+            var result = new MyClass { Property = "Different value" };
+
+            Maybe<MyClass> maybe2 = await maybeTask.Or(Maybe.From(result));
+
+            maybe2.HasValue.Should().BeTrue();
+            maybe2.Should().Be(instance);
+        }
+
+        [Fact]
+        public async Task Async_Or_fallback_maybe_returns_a_new_instance_with_value_when_source_is_empty()
+        {
+            var instance = Maybe<MyClass>.None;
+            Task<Maybe<MyClass>> maybeTask = GetMaybeTask(instance);
+            var result = new MyClass { Property = "Different value" };
+
+            Maybe<MyClass> maybe2 = await maybeTask.Or(Maybe.From(result));
+
+            maybe2.HasValue.Should().BeTrue();
+            maybe2.Should().Be(result);
+        }
+
+        [Fact]
+        public async Task Async_Or_fallback_operation_maybe_returns_source_if_source_has_value()
+        {
+            var instance = new MyClass { Property = "Some value" };
+            Task<Maybe<MyClass>> maybeTask = GetMaybeTask(instance);
+            var result = new MyClass { Property = "Different value" };
+
+            Maybe<MyClass> maybe2 = await maybeTask.Or(() => Maybe.From(result));
+
+            maybe2.HasValue.Should().BeTrue();
+            maybe2.Should().Be(instance);
+        }
+
+        [Fact]
+        public async Task Async_Or_fallback_operation_maybe_returns_a_new_instance_with_value_when_source_is_empty()
+        {
+            var instance = Maybe<MyClass>.None;
+            Task<Maybe<MyClass>> maybeTask = GetMaybeTask(instance);
+            var result = new MyClass { Property = "Different value" };
+
+            Maybe<MyClass> maybe2 = await maybeTask.Or(() => Maybe.From(result));
+
+            maybe2.HasValue.Should().BeTrue();
+            maybe2.Should().Be(result);
+        }
+
+        [Fact]
+        public async Task Async_Or_fallback_operation_maybe_async_returns_source_if_source_has_value()
+        {
+            var instance = new MyClass { Property = "Some value" };
+            Task<Maybe<MyClass>> maybeTask = GetMaybeTask(instance);
+            var result = new MyClass { Property = "Different value" };
+
+            Maybe<MyClass> maybe2 = await maybeTask.Or(() => Task.FromResult(Maybe.From(result)));
+
+            maybe2.HasValue.Should().BeTrue();
+            maybe2.Should().Be(instance);
+        }
+
+        [Fact]
+        public async Task Async_Or_fallback_operation_maybe_async_returns_a_new_instance_with_value_when_source_is_empty()
+        {
+            var instance = Maybe<MyClass>.None;
+            Task<Maybe<MyClass>> maybeTask = GetMaybeTask(instance);
+            var result = new MyClass { Property = "Different value" };
+
+            Maybe<MyClass> maybe2 = await maybeTask.Or(() => Task.FromResult(Maybe.From(result)));
 
             maybe2.HasValue.Should().BeTrue();
             maybe2.Should().Be(result);

--- a/CSharpFunctionalExtensions.Tests/MaybeTests/ExtensionsTests.cs
+++ b/CSharpFunctionalExtensions.Tests/MaybeTests/ExtensionsTests.cs
@@ -448,26 +448,90 @@ namespace CSharpFunctionalExtensions.Tests.MaybeTests
         }
 
         [Fact]
-        public void Or_returns_source_if_source_has_value()
+        public void Or_fallback_value_returns_source_if_source_has_value()
         {
             Maybe<string> maybe = "value";
 
             var orMaybe = maybe.Or("other");
             
             orMaybe.HasValue.Should().BeTrue();
-            orMaybe.Value.Should().Be("value");
             orMaybe.Should().Be(maybe);
         }
 
         [Fact]
-        public void Or_creates_a_new_instance_with_value_when_source_is_empty()
+        public void Or_fallback_value_creates_a_new_instance_with_fallback_when_source_is_empty()
         {
             Maybe<string> maybe = Maybe<string>.None;
 
             var orMaybe = maybe.Or("other");
             
             orMaybe.HasValue.Should().BeTrue();
-            orMaybe.Value.Should().Be("other");
+            orMaybe.Should().NotBe(maybe);
+        }
+
+        [Fact]
+        public void Or_fallback_operation_returns_source_if_source_has_value()
+        {
+            Maybe<string> maybe = "value";
+
+            var orMaybe = maybe.Or(() => "other");
+            
+            orMaybe.HasValue.Should().BeTrue();
+            orMaybe.Should().Be(maybe);
+        }
+
+        [Fact]
+        public void Or_fallback_operation_creates_a_new_instance_with_fallback_operation_when_source_is_empty()
+        {
+            Maybe<string> maybe = Maybe<string>.None;
+
+            var orMaybe = maybe.Or(() => "other");
+            
+            orMaybe.HasValue.Should().BeTrue();
+            orMaybe.Should().NotBe(maybe);
+        }
+
+        [Fact]
+        public void Or_fallback_maybe_returns_source_if_source_has_value()
+        {
+            Maybe<string> maybe = "value";
+
+            var orMaybe = maybe.Or(Maybe.From("other"));
+            
+            orMaybe.HasValue.Should().BeTrue();
+            orMaybe.Should().Be(maybe);
+        }
+
+        [Fact]
+        public void Or_fallback_maybe_returns_fallback_when_source_is_empty()
+        {
+            Maybe<string> maybe = Maybe<string>.None;
+
+            var orMaybe = maybe.Or(Maybe.From("other"));
+            
+            orMaybe.HasValue.Should().BeTrue();
+            orMaybe.Should().NotBe(maybe);
+        }
+
+        [Fact]
+        public void Or_fallback_maybe_operation_returns_source_if_source_has_value()
+        {
+            Maybe<string> maybe = "value";
+
+            var orMaybe = maybe.Or(() => Maybe.From("other"));
+            
+            orMaybe.HasValue.Should().BeTrue();
+            orMaybe.Should().Be(maybe);
+        }
+
+        [Fact]
+        public void Or_fallback_maybe_operation_returns_fallback_when_source_is_empty()
+        {
+            Maybe<string> maybe = Maybe<string>.None;
+
+            var orMaybe = maybe.Or(() => Maybe.From("other"));
+            
+            orMaybe.HasValue.Should().BeTrue();
             orMaybe.Should().NotBe(maybe);
         }
 

--- a/CSharpFunctionalExtensions.Tests/MaybeTests/ExtensionsTests.cs
+++ b/CSharpFunctionalExtensions.Tests/MaybeTests/ExtensionsTests.cs
@@ -447,6 +447,30 @@ namespace CSharpFunctionalExtensions.Tests.MaybeTests
             myClasses[0].Should().Be(instance);
         }
 
+        [Fact]
+        public void Or_returns_source_if_source_has_value()
+        {
+            Maybe<string> maybe = "value";
+
+            var orMaybe = maybe.Or("other");
+            
+            orMaybe.HasValue.Should().BeTrue();
+            orMaybe.Value.Should().Be("value");
+            orMaybe.Should().Be(maybe);
+        }
+
+        [Fact]
+        public void Or_creates_a_new_instance_with_value_when_source_is_empty()
+        {
+            Maybe<string> maybe = Maybe<string>.None;
+
+            var orMaybe = maybe.Or("other");
+            
+            orMaybe.HasValue.Should().BeTrue();
+            orMaybe.Value.Should().Be("other");
+            orMaybe.Should().NotBe(maybe);
+        }
+
         private static Maybe<string> GetPropertyIfExists(MyClass myClass)
         {
             return myClass.Property;

--- a/CSharpFunctionalExtensions/Maybe/AsyncMaybeExtensions.cs
+++ b/CSharpFunctionalExtensions/Maybe/AsyncMaybeExtensions.cs
@@ -81,18 +81,127 @@ namespace CSharpFunctionalExtensions
         }
 
         /// <summary>
-        /// Creates a new <see cref="Maybe{T}" /> if <paramref name="maybeTask" /> is empty, using the supplied <paramref name="value" />, otherwise it returns <paramref name="maybeTask" />
+        /// Creates a new <see cref="Maybe{T}" /> if <paramref name="maybeTask" /> is empty, using the supplied <paramref name="fallback" />, otherwise it returns <paramref name="maybeTask" />
         /// </summary>
         /// <param name="maybeTask"></param>
-        /// <param name="value"></param>
+        /// <param name="fallback"></param>
         /// <typeparam name="T"></typeparam>
         /// <returns></returns>
-        public static async Task<Maybe<T>> Or<T>(this Task<Maybe<T>> maybeTask, T value)
+        public static async Task<Maybe<T>> Or<T>(this Task<Maybe<T>> maybeTask, T fallback)
         {
             Maybe<T> maybe = await maybeTask.DefaultAwait();
 
             if (maybe.HasNoValue)
+                return Maybe<T>.From(fallback);
+
+            return maybe;
+        }
+
+        /// <summary>
+        /// Creates a new <see cref="Maybe{T}" /> if <paramref name="maybeTask" /> is empty, using the supplied <paramref name="fallback" />, otherwise it returns <paramref name="maybeTask" />
+        /// </summary>
+        /// <param name="maybeTask"></param>
+        /// <param name="fallback"></param>
+        /// <typeparam name="T"></typeparam>
+        /// <returns></returns>
+        public static async Task<Maybe<T>> Or<T>(this Task<Maybe<T>> maybeTask, Task<T> fallback)
+        {
+            Maybe<T> maybe = await maybeTask.DefaultAwait();
+
+            if (maybe.HasNoValue)
+            {
+                var value = await fallback.DefaultAwait();
                 return Maybe<T>.From(value);
+            }
+
+            return maybe;
+        }
+
+        /// <summary>
+        /// Creates a new <see cref="Maybe{T}" /> if <paramref name="maybeTask" /> is empty, using the result of the supplied <paramref name="fallbackOperation" />, otherwise it returns <paramref name="maybeTask" />
+        /// </summary>
+        /// <param name="maybeTask"></param>
+        /// <param name="fallbackOperation"></param>
+        /// <typeparam name="T"></typeparam>
+        /// <returns></returns>
+        public static async Task<Maybe<T>> Or<T>(this Task<Maybe<T>> maybeTask, Func<T> fallbackOperation)
+        {
+            Maybe<T> maybe = await maybeTask.DefaultAwait();
+
+            if (maybe.HasNoValue)
+                return Maybe<T>.From(fallbackOperation());
+
+            return maybe;
+        }
+
+        /// <summary>
+        /// Creates a new <see cref="Maybe{T}" /> if <paramref name="maybeTask" /> is empty, using the result of the supplied <paramref name="fallbackOperation" />, otherwise it returns <paramref name="maybeTask" />
+        /// </summary>
+        /// <param name="maybeTask"></param>
+        /// <param name="fallbackOperation"></param>
+        /// <typeparam name="T"></typeparam>
+        /// <returns></returns>
+        public static async Task<Maybe<T>> Or<T>(this Task<Maybe<T>> maybeTask, Func<Task<T>> fallbackOperation)
+        {
+            Maybe<T> maybe = await maybeTask.DefaultAwait();
+
+            if (maybe.HasNoValue)
+            {
+                var value = await fallbackOperation().DefaultAwait();
+
+                return Maybe<T>.From(value);
+            }
+
+            return maybe;
+        }
+
+        /// <summary>
+        /// Returns <paramref name="fallback" /> if <paramref name="maybeTask" /> is empty, otherwise it returns <paramref name="maybeTask" />
+        /// </summary>
+        /// <param name="maybeTask"></param>
+        /// <param name="fallback"></param>
+        /// <typeparam name="T"></typeparam>
+        /// <returns></returns>
+        public static async Task<Maybe<T>> Or<T>(this Task<Maybe<T>> maybeTask, Maybe<T> fallback)
+        {
+            Maybe<T> maybe = await maybeTask.DefaultAwait();
+
+            if (maybe.HasNoValue)
+                return fallback;
+
+            return maybe;
+        }
+
+        /// <summary>
+        /// Returns <paramref name="fallbackOperation" /> if <paramref name="maybeTask" /> is empty, otherwise it returns <paramref name="maybeTask" />
+        /// </summary>
+        /// <param name="maybeTask"></param>
+        /// <param name="fallbackOperation"></param>
+        /// <typeparam name="T"></typeparam>
+        /// <returns></returns>
+        public static async Task<Maybe<T>> Or<T>(this Task<Maybe<T>> maybeTask, Func<Maybe<T>> fallbackOperation)
+        {
+            Maybe<T> maybe = await maybeTask.DefaultAwait();
+
+            if (maybe.HasNoValue)
+                return fallbackOperation();
+
+            return maybe;
+        }
+
+        /// <summary>
+        /// Returns <paramref name="fallbackOperation" /> if <paramref name="maybeTask" /> is empty, otherwise it returns <paramref name="maybeTask" />
+        /// </summary>
+        /// <param name="maybeTask"></param>
+        /// <param name="fallbackOperation"></param>
+        /// <typeparam name="T"></typeparam>
+        /// <returns></returns>
+        public static async Task<Maybe<T>> Or<T>(this Task<Maybe<T>> maybeTask, Func<Task<Maybe<T>>> fallbackOperation)
+        {
+            Maybe<T> maybe = await maybeTask.DefaultAwait();
+
+            if (maybe.HasNoValue)
+                return await fallbackOperation().DefaultAwait();
 
             return maybe;
         }

--- a/CSharpFunctionalExtensions/Maybe/AsyncMaybeExtensions.cs
+++ b/CSharpFunctionalExtensions/Maybe/AsyncMaybeExtensions.cs
@@ -79,5 +79,22 @@ namespace CSharpFunctionalExtensions
             Maybe<T> maybe = await maybeTask.DefaultAwait();
             return await maybe.Bind(selector).DefaultAwait();
         }
+
+        /// <summary>
+        /// Creates a new <see cref="Maybe{T}" /> if <paramref name="maybeTask" /> is empty, using the supplied <paramref name="value" />, otherwise it returns <paramref name="maybeTask" />
+        /// </summary>
+        /// <param name="maybeTask"></param>
+        /// <param name="value"></param>
+        /// <typeparam name="T"></typeparam>
+        /// <returns></returns>
+        public static async Task<Maybe<T>> Or<T>(this Task<Maybe<T>> maybeTask, T value)
+        {
+            Maybe<T> maybe = await maybeTask.DefaultAwait();
+
+            if (maybe.HasNoValue)
+                return Maybe<T>.From(value);
+
+            return maybe;
+        }
     }
 }

--- a/CSharpFunctionalExtensions/Maybe/MaybeExtensions.cs
+++ b/CSharpFunctionalExtensions/Maybe/MaybeExtensions.cs
@@ -101,16 +101,61 @@ namespace CSharpFunctionalExtensions
         }
 
         /// <summary>
-        /// Creates a new <see cref="Maybe{T}" /> if <paramref name="maybe" /> is empty, using the supplied <paramref name="value" />, otherwise it returns <paramref name="maybe" />
+        /// Creates a new <see cref="Maybe{T}" /> if <paramref name="maybe" /> is empty, using the supplied <paramref name="fallback" />, otherwise it returns <paramref name="maybe" />
         /// </summary>
         /// <param name="maybe"></param>
-        /// <param name="value"></param>
+        /// <param name="fallback"></param>
         /// <typeparam name="T"></typeparam>
         /// <returns></returns>
-        public static Maybe<T> Or<T>(this Maybe<T> maybe, T value)
+        public static Maybe<T> Or<T>(this Maybe<T> maybe, T fallback)
         {
             if (maybe.HasNoValue)
-                return Maybe<T>.From(value);
+                return Maybe<T>.From(fallback);
+
+            return maybe;
+        }
+
+        /// <summary>
+        /// Creates a new <see cref="Maybe{T}" /> if <paramref name="maybe" /> is empty, using the result of the supplied <paramref name="fallbackOperation" />, otherwise it returns <paramref name="maybe" />
+        /// </summary>
+        /// <param name="maybe"></param>
+        /// <param name="fallbackOperation"></param>
+        /// <typeparam name="T"></typeparam>
+        /// <returns></returns>
+        public static Maybe<T> Or<T>(this Maybe<T> maybe, Func<T> fallbackOperation)
+        {
+            if (maybe.HasNoValue)
+                return Maybe<T>.From(fallbackOperation());
+
+            return maybe;
+        }
+
+        /// <summary>
+        /// Returns <paramref name="fallback" /> if <paramref name="maybe" /> is empty, otherwise it returns <paramref name="maybe" />
+        /// </summary>
+        /// <param name="maybe"></param>
+        /// <param name="fallback"></param>
+        /// <typeparam name="T"></typeparam>
+        /// <returns></returns>
+        public static Maybe<T> Or<T>(this Maybe<T> maybe, Maybe<T> fallback)
+        {
+            if (maybe.HasNoValue)
+                return fallback;
+
+            return maybe;
+        }
+
+        /// <summary>
+        /// Returns the result of <paramref name="fallbackOperation" /> if <paramref name="maybe" /> is empty, otherwise it returns <paramref name="maybe" />
+        /// </summary>
+        /// <param name="maybe"></param>
+        /// <param name="fallbackOperation"></param>
+        /// <typeparam name="T"></typeparam>
+        /// <returns></returns>
+        public static Maybe<T> Or<T>(this Maybe<T> maybe, Func<Maybe<T>> fallbackOperation)
+        {
+            if (maybe.HasNoValue)
+                return fallbackOperation();
 
             return maybe;
         }

--- a/CSharpFunctionalExtensions/Maybe/MaybeExtensions.cs
+++ b/CSharpFunctionalExtensions/Maybe/MaybeExtensions.cs
@@ -37,7 +37,7 @@ namespace CSharpFunctionalExtensions
 
         public static List<T> ToList<T>(this Maybe<T> maybe)
         {
-            return maybe.Unwrap(value => new List<T> {value}, new List<T>());
+            return maybe.Unwrap(value => new List<T> { value }, new List<T>());
         }
 
         public static Maybe<T> Where<T>(this Maybe<T> maybe, Func<T, bool> predicate)
@@ -98,6 +98,21 @@ namespace CSharpFunctionalExtensions
                 return;
 
             action(maybe.Value);
+        }
+
+        /// <summary>
+        /// Creates a new <see cref="Maybe{T}" /> if <paramref name="maybe" /> is empty, using the supplied <paramref name="value" />, otherwise it returns <paramref name="maybe" />
+        /// </summary>
+        /// <param name="maybe"></param>
+        /// <param name="value"></param>
+        /// <typeparam name="T"></typeparam>
+        /// <returns></returns>
+        public static Maybe<T> Or<T>(this Maybe<T> maybe, T value)
+        {
+            if (maybe.HasNoValue)
+                return Maybe<T>.From(value);
+
+            return maybe;
         }
 
         public static TE Match<TE, T>(this Maybe<T> maybe, Func<T, TE> Some, Func<TE> None)


### PR DESCRIPTION
Implementation for https://github.com/vkhorikov/CSharpFunctionalExtensions/issues/294

I added these:

```csharp
public static Maybe<T> Or<T>(this Maybe<T> maybe, T value)
public static async Task<Maybe<T>> Or<T>(this Task<Maybe<T>> maybeTask, T value)
```

Do we want any additional overloads here?

Ex (including async equivalents):

```csharp
public static Maybe<T> Or<T>(this Maybe<T> maybe, Maybe<T> fallback)
public static Maybe<T> Or<T>(this Maybe<T> maybe, Func<T> fallbackOperation)
public static Maybe<T> Or<T>(this Maybe<T> maybe, Func<Maybe<T>> fallbackOperation)
```