### PR TITLE
Remove redundant Maybe.Or extension, add Maybe.Or null test

### DIFF
--- a/CSharpFunctionalExtensions.Tests/MaybeTests/ExtensionsTests.cs
+++ b/CSharpFunctionalExtensions.Tests/MaybeTests/ExtensionsTests.cs
@@ -448,6 +448,18 @@ namespace CSharpFunctionalExtensions.Tests.MaybeTests
         }
 
         [Fact]
+        public void Or_fallback_value_returns_none_if_source_and_fallback_are_none()
+        {
+            string value = null;
+
+            Maybe<string> maybe = Maybe<string>.None;
+
+            var orMaybe = maybe.Or(value);
+            
+            orMaybe.HasValue.Should().BeFalse();
+        }
+
+        [Fact]
         public void Or_fallback_value_returns_source_if_source_has_value()
         {
             Maybe<string> maybe = "value";

--- a/CSharpFunctionalExtensions/Maybe/MaybeExtensions.cs
+++ b/CSharpFunctionalExtensions/Maybe/MaybeExtensions.cs
@@ -101,21 +101,6 @@ namespace CSharpFunctionalExtensions
         }
 
         /// <summary>
-        /// Creates a new <see cref="Maybe{T}" /> if <paramref name="maybe" /> is empty, using the supplied <paramref name="fallback" />, otherwise it returns <paramref name="maybe" />
-        /// </summary>
-        /// <param name="maybe"></param>
-        /// <param name="fallback"></param>
-        /// <typeparam name="T"></typeparam>
-        /// <returns></returns>
-        public static Maybe<T> Or<T>(this Maybe<T> maybe, T fallback)
-        {
-            if (maybe.HasNoValue)
-                return Maybe<T>.From(fallback);
-
-            return maybe;
-        }
-
-        /// <summary>
         /// Creates a new <see cref="Maybe{T}" /> if <paramref name="maybe" /> is empty, using the result of the supplied <paramref name="fallbackOperation" />, otherwise it returns <paramref name="maybe" />
         /// </summary>
         /// <param name="maybe"></param>


### PR DESCRIPTION
Follow up for #296

Added a `null` test for `Or()`.