### PR TITLE
Extend Match with deconstruct KeyValuePair

### DIFF
--- a/CSharpFunctionalExtensions.Tests/MaybeTests/ExtensionsTests.cs
+++ b/CSharpFunctionalExtensions.Tests/MaybeTests/ExtensionsTests.cs
@@ -260,6 +260,61 @@ namespace CSharpFunctionalExtensions.Tests.MaybeTests
         }
 
         [Fact]
+        public void Match_for_deconstruct_kv_follows_some_branch_where_is_no_value()
+        {
+            Maybe<KeyValuePair<int, string>> maybe = Maybe<KeyValuePair<int, string>>.From(new KeyValuePair<int, string>(42, "Matrix"));
+
+            maybe.Match(
+                Some: (intValue, stringValue) =>
+                {
+                    intValue.Should().Be(42);
+                    stringValue.Should().Be("Matrix");
+                },
+                None: () => throw new FieldAccessException("Accessed None path while maybe has value")
+            );
+        }
+
+        [Fact]
+        public void Match_for_deconstruct_kv_follows_none_branch_where_is_no_value()
+        {
+            Maybe<KeyValuePair<int, string>> maybe = Maybe<KeyValuePair<int, string>>.None;
+
+            maybe.Match(
+                Some: (intValue, stringValue) => throw new FieldAccessException("Accessed Some path while maybe has no value"),
+                None: () => Assert.True(true) 
+            );
+        }
+        
+        [Fact]
+        public void Match_for_deconstruct_kv_follows_some_branch_where_is_a_return_value()
+        {
+            Maybe<KeyValuePair<int, string>> maybe = Maybe<KeyValuePair<int, string>>.From(new KeyValuePair<int, string>(42, "Matrix"));
+
+            var returnValue = maybe.Match(
+                Some: (intValue, stringValue) => intValue,
+                None: () => throw new FieldAccessException("Accessed None path while maybe has value")
+            );
+
+            42.Should().Be(returnValue);
+        }
+        
+        [Fact]
+        public void Match_for_deconstruct_kv_follows_none_branch_where_is_a_return_value()
+        {
+            Maybe<KeyValuePair<int, string>> maybe = Maybe<KeyValuePair<int, string>>.None;
+
+            var returnValue = maybe.Match(
+                Some: (intValue, stringValue) => throw new FieldAccessException("Accessed Some path while maybe has no value"),
+                None: () => -1 
+            );
+
+            (-1).Should().Be(returnValue);
+
+        }
+        
+        
+
+        [Fact]
         public void Choose_double_values()
         {
             var source = new[]

--- a/CSharpFunctionalExtensions/Maybe/MaybeExtensions.cs
+++ b/CSharpFunctionalExtensions/Maybe/MaybeExtensions.cs
@@ -37,7 +37,7 @@ namespace CSharpFunctionalExtensions
 
         public static List<T> ToList<T>(this Maybe<T> maybe)
         {
-            return maybe.Unwrap(value => new List<T> { value }, new List<T>());
+            return maybe.Unwrap(value => new List<T> {value}, new List<T>());
         }
 
         public static Maybe<T> Where<T>(this Maybe<T> maybe, Func<T, bool> predicate)
@@ -164,6 +164,22 @@ namespace CSharpFunctionalExtensions
             }
         }
 
+        public static TE Match<TE, TKey, TValue>(this Maybe<KeyValuePair<TKey, TValue>> maybe, Func<TKey, TValue, TE> Some, Func<TE> None) =>
+            maybe.HasValue ? Some.Invoke(maybe.Value.Key, maybe.Value.Value) : None.Invoke();
+
+        public static void Match<TKey, TValue>(this Maybe<KeyValuePair<TKey, TValue>> maybe, Action<TKey, TValue> Some, Action None)
+        {
+            if (maybe.HasValue)
+            {
+                Some.Invoke(maybe.Value.Key, maybe.Value.Value);
+            }
+            else
+            {
+                None.Invoke();
+            }
+        }
+
+
         public static IEnumerable<U> Choose<T, U>(this IEnumerable<Maybe<T>> source, Func<T, U> selector)
         {
             using (var enumerator = source.GetEnumerator())
@@ -185,6 +201,7 @@ namespace CSharpFunctionalExtensions
             {
                 return Maybe<T>.From(source.First());
             }
+
             return Maybe<T>.None;
         }
 
@@ -195,6 +212,7 @@ namespace CSharpFunctionalExtensions
             {
                 return Maybe<T>.From(firstOrEmpty[0]);
             }
+
             return Maybe<T>.None;
         }
 
@@ -204,6 +222,7 @@ namespace CSharpFunctionalExtensions
             {
                 return Maybe<T>.From(source.Last());
             }
+
             return Maybe<T>.None;
         }
 
@@ -214,6 +233,7 @@ namespace CSharpFunctionalExtensions
             {
                 return Maybe<T>.From(last);
             }
+
             return Maybe<T>.None;
         }
 
@@ -224,6 +244,7 @@ namespace CSharpFunctionalExtensions
             {
                 return dict[key];
             }
+
             return Maybe<V>.None;
         }
 #else


### PR DESCRIPTION
This update extends the Match-function to deconstruct a given KeyValuePair and give the key- and value-parameter to the Some-Method.
Create functions for return- and void-Match.