### PR TITLE
CombineInOrder IEnumerable<Task<Result<T>>> extension

### DIFF
--- a/CSharpFunctionalExtensions.Tests/ResultTests/CombineInOrderMethodTests.cs
+++ b/CSharpFunctionalExtensions.Tests/ResultTests/CombineInOrderMethodTests.cs
@@ -1,0 +1,250 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Xunit;
+using static CSharpFunctionalExtensions.Tests.ResultTests.CombineWithErrorMethodTests;
+
+namespace CSharpFunctionalExtensions.Tests.ResultTests
+{
+    public class CombineInOrderMethodTests
+    {
+        [Fact]
+        public async Task CombineInOrder_works_with_collection_of_Tasks_results_success()
+        {
+            StringBuilder builder = new StringBuilder();
+            IEnumerable<Task<Result>> tasks = 
+                new [] { "a", "b", "c" }
+                .Select( s => TaskOfResult(builder, s));
+
+            Result result = await tasks.CombineInOrder(";");
+
+            result.IsSuccess.Should().BeTrue();
+            builder.ToString().Should().Be("abc");
+        }
+
+        [Fact]
+        public async Task CombineInOrder_works_with_collection_of_Tasks_combines_all_collection_errors_together()
+        {
+            StringBuilder builder = new StringBuilder();
+            IEnumerable<Task<Result>> tasks =
+                new[] { ("a", true), ("e", false), ("b", true), ("r", false) }
+                .Select(s => TaskOfResult(builder, s.Item1, s.Item2));
+
+            Result result = await tasks.CombineInOrder(";");
+
+            result.IsFailure.Should().BeTrue();
+            result.Error.Should().Be("e;r");
+        }
+
+        [Fact]
+        public async Task CombineInOrder_works_with_collection_of_Tasks_aggregates_all_identical_collection_errors_together_with_count()
+        {
+            StringBuilder builder = new StringBuilder();
+            IEnumerable<Task<Result>> tasks =
+                new[] { ("a", true), ("e", false), ("r", false), ("b", true), ("r", false) }
+                .Select(s => TaskOfResult(builder, s.Item1, s.Item2));
+
+            Result result = await tasks.CombineInOrder(";");
+
+            result.IsFailure.Should().BeTrue();
+            result.Error.Should().Be("e;r (2×)");
+        }
+
+        [Fact]
+        public async Task CombineInOrder_combines_all_tasks_of_Generic_results_collection_errors_together()
+        {
+            StringBuilder builder = new StringBuilder();
+            IEnumerable<Task<Result<string>>> tasks =
+                new[] { ("a", true), ("e", false), ("b", true), ("r", false) }
+                .Select(s => TaskOfResultOfT(builder, s.Item1, s.Item2));
+
+            Result<IEnumerable<string>> result = await tasks.CombineInOrder(";");
+
+            result.IsSuccess.Should().BeFalse();
+            result.Error.Should().Be("e;r");
+        }
+
+        [Fact]
+        public async Task CombineInOrder_returns_Ok_if_no_failures_in_Generic_results_collection_of_tasks()
+        {
+            string[] stringArr = new[] { "a", "b", "c" };
+            StringBuilder builder = new StringBuilder();
+            IEnumerable<Task<Result<string>>> tasks =
+                stringArr
+                .Select(s => TaskOfResultOfT(builder, s));
+
+            Result<IEnumerable<string>> result = await tasks.CombineInOrder(";");
+
+            result.IsSuccess.Should().BeTrue();
+            result.Value.Should().BeEquivalentTo(stringArr);
+            builder.ToString().Should().Be("abc");
+        }
+
+        [Fact]
+        public async Task CombineInOrder_works_with_task_with_collection_of_tasks_of_results_success()
+        {
+            StringBuilder builder = new StringBuilder();
+            IEnumerable<Task<Result>> tasks =
+                new[] { "a", "b", "c" }
+                .Select(s => TaskOfResult(builder, s));
+            Task<IEnumerable<Task<Result>>> task = Task.FromResult(tasks);
+
+            Result result = await task.CombineInOrder(";");
+
+            result.IsSuccess.Should().BeTrue();
+            builder.ToString().Should().Be("abc");
+        }
+
+        [Fact]
+        public async Task CombineInOrder_works_with_task_with_collection_of_tasks_of_results_failure()
+        {
+            StringBuilder builder = new StringBuilder();
+            IEnumerable<Task<Result>> tasks =
+                new[] { ("a", true), ("e", false), ("b", true), ("r", false) }
+                .Select(s => TaskOfResult(builder, s.Item1, s.Item2));
+            Task<IEnumerable<Task<Result>>> task = Task.FromResult(tasks);
+
+            Result result = await task.Combine(";");
+
+            result.IsSuccess.Should().BeFalse();
+            result.Error.Should().Be("e;r");
+        }
+
+        [Fact]
+        public async Task CombineInOrder_works_with_task_with_collection_of_tasks_of_Generic_results_success()
+        {
+            string[] stringArr = new[] { "a", "b", "c" };
+            StringBuilder builder = new StringBuilder();
+            IEnumerable<Task<Result<string>>> tasks =
+                stringArr
+                .Select(s => TaskOfResultOfT(builder, s));
+
+            Task<IEnumerable<Task<Result<string>>>> task = Task.FromResult(tasks);
+
+            Result<IEnumerable<string>> result = await task.CombineInOrder(";");
+
+            result.IsSuccess.Should().BeTrue();
+            result.Value.Should().BeEquivalentTo(stringArr);
+            builder.ToString().Should().Be("abc");
+        }
+
+        [Fact]
+        public async Task CombineInOrder_works_with_task_with_collection_of_tasks_of_Generic_results_failure()
+        {
+            StringBuilder builder = new StringBuilder();
+            IEnumerable<Task<Result<string>>> tasks =
+                new[] { ("a", true), ("e", false), ("b", true), ("r", false) }
+                .Select(s => TaskOfResultOfT(builder, s.Item1, s.Item2));
+
+            Task<IEnumerable<Task<Result<string>>>> task = Task.FromResult(tasks);
+
+            Result<IEnumerable<string>> result = await task.CombineInOrder(";");
+
+            result.IsSuccess.Should().BeFalse();
+            result.Error.Should().Be("e;r");
+        }
+
+        [Fact]
+        public async Task CombineInOrder_works_with_task_with_collection_of_tasks_of_Generic_results_failure_with_identical_errors_aggregated_with_count()
+        {
+            StringBuilder builder = new StringBuilder();
+            IEnumerable<Task<Result<string>>> tasks =
+                new[] { ("a", true), ("e", false), ("b", true), ("e", false), ("r", false) }
+                .Select(s => TaskOfResultOfT(builder, s.Item1, s.Item2));
+            Task<IEnumerable<Task<Result<string>>>> task = Task.FromResult(tasks);
+
+            Result<IEnumerable<string>> result = await task.CombineInOrder(";");
+
+            result.IsSuccess.Should().BeFalse();
+            result.Error.Should().Be("e (2×);r");
+        }
+
+        [Fact]
+        public async Task CombineInOrder_works_with_collection_of_tasks_of_results_and_compose_to_new_result_success()
+        {
+            string[] stringArr = new[] { "a", "b", "c" };
+            StringBuilder builder = new StringBuilder();
+            IEnumerable<Task<Result<string>>> tasks =
+                stringArr
+                .Select(s => TaskOfResultOfT(builder, s));
+
+            Result<string> result = await tasks.CombineInOrder(values => string.Join(';', values));
+
+            result.IsSuccess.Should().BeTrue();
+            result.Value.Should().Be("a;b;c");
+            builder.ToString().Should().Be("abc");
+        }
+
+        [Fact]
+        public async Task CombineInOrder_works_with_collection_of_tasks_of_results_and_compose_to_new_result_failure()
+        {
+            StringBuilder builder = new StringBuilder();
+            IEnumerable<Task<Result<string>>> tasks =
+                new[] { ("a", true), ("e", false), ("b", true), ("e", false), ("r", false) }
+                .Select(s => TaskOfResultOfT(builder, s.Item1, s.Item2));
+            Task<IEnumerable<Task<Result<string>>>> task = Task.FromResult(tasks);
+
+            Result<string> result = await tasks.CombineInOrder(values => string.Join(';', values), ";");
+
+            result.IsFailure.Should().BeTrue();
+            result.Error.Should().Be("e (2×);r");
+        }
+
+        [Fact]
+        public async Task Combine_works_with_task_of_collection_of_tasks_of_results_and_compose_to_new_result_success()
+        {
+            IEnumerable<Task<Result<int>>> tasks = new Task<Result<int>>[]
+            {
+                Task.FromResult(Result.Success(90)),
+                Task.FromResult(Result.Success(95)),
+                Task.FromResult(Result.Success(99)),
+            };
+            Task<IEnumerable<Task<Result<int>>>> task = Task.FromResult(tasks);
+
+            Result<double> result = await task.Combine(values => (double)values.Max() / 100, ";");
+
+            result.IsSuccess.Should().BeTrue();
+            result.Value.Should().Be(.99);
+        }
+
+        [Fact]
+        public async Task CombineInOrder_works_with_task_of_collection_of_tasks_of_results_and_compose_to_new_result_failure()
+        {
+            string[] stringArr = new[] { "a", "b", "c" };
+            StringBuilder builder = new StringBuilder();
+            IEnumerable<Task<Result<string>>> tasks =
+                stringArr
+                .Select(s => TaskOfResultOfT(builder, s));
+
+            Task<IEnumerable<Task<Result<string>>>> task = Task.FromResult(tasks);
+            Result<string> result = await task.CombineInOrder(values => string.Join(';', values));
+
+            result.IsSuccess.Should().BeTrue();
+            result.Value.Should().Be("a;b;c");
+            builder.ToString().Should().Be("abc");
+        }
+
+        private async Task<Result> TaskOfResult(StringBuilder stringBuilder, string s, bool success = true)
+        {
+            await Task.Yield();
+            if (success)
+            {
+                stringBuilder.Append(s);
+            }
+            return success ? Result.Success() : Result.Failure(s);
+        }
+
+        private async Task<Result<string>> TaskOfResultOfT(StringBuilder stringBuilder, string s, bool success = true)
+        {
+            await Task.Yield();
+            if (success)
+            {
+                stringBuilder.Append(s);
+            }
+            return success ? Result.Success(s) : Result.Failure<string>(s);
+        }
+    }
+}

--- a/CSharpFunctionalExtensions/Result/Extensions/CombineInOrderAsyncLeft.cs
+++ b/CSharpFunctionalExtensions/Result/Extensions/CombineInOrderAsyncLeft.cs
@@ -1,0 +1,113 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+#if NET40
+using Task = System.Threading.Tasks.TaskEx;
+#else
+using Task = System.Threading.Tasks.Task;
+#endif
+
+namespace CSharpFunctionalExtensions
+{
+    public static partial class AsyncResultExtensionsLeftOperand
+    {
+        public static async Task<Result> CombineInOrder(this IEnumerable<Task<Result>> tasks, string errorMessageSeparator = null)
+        {
+            Result[] results = await CompleteInOrder(tasks).DefaultAwait();
+            return results.Combine(errorMessageSeparator);
+        }
+
+        public static async Task<Result<IEnumerable<T>, E>> CombineInOrder<T, E>(this IEnumerable<Task<Result<T, E>>> tasks, Func<IEnumerable<E>, E> composerError)
+        {
+            Result<T, E>[] results = await CompleteInOrder(tasks).DefaultAwait();
+            return results.Combine(composerError);
+        }
+
+        public static async Task<Result<IEnumerable<T>, E>> CombineInOrder<T, E>(this IEnumerable<Task<Result<T, E>>> tasks)
+            where E : ICombine
+        {
+            Result<T, E>[] results = await CompleteInOrder(tasks).DefaultAwait();
+            return results.Combine();
+        }
+
+        public static async Task<Result<IEnumerable<T>>> CombineInOrder<T>(this IEnumerable<Task<Result<T>>> tasks, string errorMessageSeparator = null)
+        {
+            Result<T>[] results = await CompleteInOrder(tasks).DefaultAwait();
+            return results.Combine(errorMessageSeparator);
+        }
+
+        public static async Task<Result> CombineInOrder(this Task<IEnumerable<Task<Result>>> task, string errorMessageSeparator = null)
+        {
+            IEnumerable<Task<Result>> tasks = await task.DefaultAwait();
+            return await tasks.CombineInOrder(errorMessageSeparator).DefaultAwait();
+        }
+
+        public static async Task<Result<IEnumerable<T>, E>> CombineInOrder<T, E>(this Task<IEnumerable<Task<Result<T, E>>>> task, Func<IEnumerable<E>, E> composerError)
+        {
+            IEnumerable<Task<Result<T, E>>> tasks = await task.DefaultAwait();
+            return await tasks.CombineInOrder(composerError).DefaultAwait();
+        }
+
+        public static async Task<Result<IEnumerable<T>, E>> CombineInOrder<T, E>(this Task<IEnumerable<Task<Result<T, E>>>> task)
+            where E : ICombine
+        {
+            IEnumerable<Task<Result<T, E>>> tasks = await task.DefaultAwait();
+            return await tasks.CombineInOrder().DefaultAwait();
+        }
+
+        public static async Task<Result<IEnumerable<T>>> CombineInOrder<T>(this Task<IEnumerable<Task<Result<T>>>> task, string errorMessageSeparator = null)
+        {
+            IEnumerable<Task<Result<T>>> tasks = await task.DefaultAwait();
+            return await tasks.CombineInOrder(errorMessageSeparator).DefaultAwait();
+        }
+
+        public static async Task<Result<K, E>> CombineInOrder<T, K, E>(this IEnumerable<Task<Result<T, E>>> tasks, Func<IEnumerable<T>, K> composer, Func<IEnumerable<E>, E> composerError)
+        {
+            IEnumerable<Result<T, E>> results = await CompleteInOrder(tasks).DefaultAwait();
+            return results.Combine(composer, composerError);
+        }
+
+        public static async Task<Result<K, E>> CombineInOrder<T, K, E>(this IEnumerable<Task<Result<T, E>>> tasks, Func<IEnumerable<T>, K> composer)
+            where E : ICombine
+        {
+            IEnumerable<Result<T, E>> results = await CompleteInOrder(tasks).DefaultAwait();
+            return results.Combine(composer);
+        }
+
+        public static async Task<Result<K>> CombineInOrder<T, K>(this IEnumerable<Task<Result<T>>> tasks, Func<IEnumerable<T>, K> composer, string errorMessageSeparator = null)
+        {
+            IEnumerable<Result<T>> results = await CompleteInOrder(tasks).DefaultAwait();
+            return results.Combine(composer, errorMessageSeparator);
+        }
+
+        public static async Task<Result<K, E>> CombineInOrder<T, K, E>(this Task<IEnumerable<Task<Result<T, E>>>> task, Func<IEnumerable<T>, K> composer, Func<IEnumerable<E>, E> composerError)
+        {
+            IEnumerable<Task<Result<T, E>>> tasks = await task.DefaultAwait();
+            return await tasks.CombineInOrder(composer, composerError).DefaultAwait();
+        }
+
+        public static async Task<Result<K, E>> CombineInOrder<T, K, E>(this Task<IEnumerable<Task<Result<T, E>>>> task, Func<IEnumerable<T>, K> composer)
+            where E : ICombine
+        {
+            IEnumerable<Task<Result<T, E>>> tasks = await task.DefaultAwait();
+            return await tasks.CombineInOrder(composer).DefaultAwait();
+        }
+
+        public static async Task<Result<K>> CombineInOrder<T, K>(this Task<IEnumerable<Task<Result<T>>>> task, Func<IEnumerable<T>, K> composer, string errorMessageSeparator = null)
+        {
+            IEnumerable<Task<Result<T>>> tasks = await task.DefaultAwait();
+            return await tasks.CombineInOrder(composer, errorMessageSeparator).DefaultAwait();
+        }
+
+        public static async Task<T[]> CompleteInOrder<T>(IEnumerable<Task<T>> tasks)
+        {
+            List<T> results = new List<T>();
+            foreach (var task in tasks)
+            {
+                results.Add(await task.DefaultAwait());
+            }
+            return results.ToArray();
+        }
+    }
+}


### PR DESCRIPTION
#307 Create and test CombineInOrder extension method that keep tasks execution order and avoid EF.Core aysnc issues: https://go.microsoft.com/fwlink/?linkid=2097913.