### PR TITLE
Fix Result.Ensure

### DIFF
--- a/CSharpFunctionalExtensions.Tests/ResultTests/EnsureMethodTests.cs
+++ b/CSharpFunctionalExtensions.Tests/ResultTests/EnsureMethodTests.cs
@@ -72,6 +72,16 @@ namespace CSharpFunctionalExtensions.Tests.ResultTests
         }
 
         [Fact]
+        public async Task Ensure_task_source_result_is_success_predicate_is_passed_error_predicate_is_not_invoked()
+        {
+            Task<Result<int?>> sut = Task.FromResult(Result.Success<int?>(null));
+
+            Result<int?> result = await sut.Ensure(value => !value.HasValue, value => Task.FromResult($"should be null but found {value.Value}"));
+
+            result.Should().Be(sut.Result);
+        }
+
+        [Fact]
         public async Task Ensure_task_source_result_is_failure_predicate_do_not_invoked_expect_is_result_failure()
         {
             Task<Result> sut = Task.FromResult(Result.Failure("some error"));

--- a/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/EnsureAsyncLeftTests.cs
+++ b/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/EnsureAsyncLeftTests.cs
@@ -43,6 +43,16 @@ namespace CSharpFunctionalExtensions.Tests.ResultTests.Extensions
         }
 
         [Fact]
+        public async Task Ensure_with_errorPredicate_does_not_execute_error_predicate_when_predicate_passes()
+        {
+            var tResult = Task.FromResult(Result.Success<int?>(null));
+
+            Result<int?> result = await tResult.Ensure(value => !value.HasValue, value => $"should be null but found {value.Value}");
+
+            result.Should().Be(tResult.Result);
+        }
+
+        [Fact]
         public async Task Ensure_with_errorPredicate_using_errorPredicate()
         {
             var tResult = Task.FromResult(Result.Success(""));

--- a/CSharpFunctionalExtensions/Result/Extensions/EnsureAsyncLeft.cs
+++ b/CSharpFunctionalExtensions/Result/Extensions/EnsureAsyncLeft.cs
@@ -44,7 +44,7 @@ namespace CSharpFunctionalExtensions
             if (result.IsFailure)
                 return result;
 
-            return result.Ensure(predicate, errorPredicate(result.Value));
+            return result.Ensure(predicate, errorPredicate);
         }
 
         /// <summary>
@@ -57,7 +57,10 @@ namespace CSharpFunctionalExtensions
             if (result.IsFailure)
                 return result;
 
-            return result.Ensure(predicate, await errorPredicate(result.Value));
+            if (predicate(result.Value))
+                return result;
+
+            return Result.Failure<T>(await errorPredicate(result.Value));
         }
 
         /// <summary>


### PR DESCRIPTION
There are 2 overloads of `Result.Ensure` that execute the error predicate even when the 'ensure' predicate passes.

This can lead to unexpected behavior and exceptions because the error predicate might access the `T` value in a way that the failing predicate would imply is valid.

For example, if `Result<User>.Ensure(user => user is null, user => $"User {user.Email} is not null");` passes and the error predicate is still evaluated, it will lead to a `NullReferenceException`.

The error predicate should only be evaluated when the predicate fails.

I added 2 tests to verify the changes.