### PR TITLE
Added test for comparing two value objects with different type

### DIFF
--- a/CSharpFunctionalExtensions.Tests/ValueObjectTests/IComparableTests.cs
+++ b/CSharpFunctionalExtensions.Tests/ValueObjectTests/IComparableTests.cs
@@ -106,6 +106,20 @@ namespace CSharpFunctionalExtensions.Tests.ValueObjectTests
             result2.Should().NotBe(0);
         }
 
+        [Fact]
+        public void Can_compare_value_objects_with_different_types()
+        {
+            var intValueObject = new VOIntType(1);
+            var stringValueObject = new VOStringType("2");
+
+            int result1 = intValueObject.CompareTo(stringValueObject);
+            int result2 = stringValueObject.CompareTo(intValueObject);
+
+            result1.Should().BeLessOrEqualTo(-1);
+            result2.Should().BeGreaterOrEqualTo(-1);
+            result1.Should().Be(-result2);
+        }
+
         private class VOWithCollection : ValueObject
         {
             readonly string[] _components;
@@ -166,6 +180,20 @@ namespace CSharpFunctionalExtensions.Tests.ValueObjectTests
         {
             public NameSuffix(int value)
                 : base(value)
+            {
+            }
+        }
+
+        private class VOIntType: SimpleValueObject<int>
+        {
+            public VOIntType(int value) : base(value)
+            {
+            }
+        }
+
+        private class VOStringType : SimpleValueObject<string>
+        {
+            public VOStringType(string value) : base(value)
             {
             }
         }


### PR DESCRIPTION
Hi
Thank you for your great repository, your contribution and valuable book in Unit Testing
There is not any unit test when comparing two different value objects which have a different type. In this situation, `CompareTo`  try to comparing string representation of value object type together.
It seems this new test is a trivial test that I added to the Test Project but it might be helpful for those that want to change this comparison implementation(using value comparison instead of string representation of value object type).
