### PR TITLE
Feature: Maybe.ExecuteNoValue, Maybe.Execute async action, update README examples

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,10 +1,13 @@
 {
     "line-length": {
-        "line_length": 120
+        "line_length": 140
     },
     "code-block-style": {
         "style": "fenced"
     },
     "code": true,
-    "code-fence-style": true
+    "code-fence-style": true,
+    "no-duplicate-header": {
+        "siblings_only": true
+    }
 }

--- a/CSharpFunctionalExtensions.Tests/MaybeTests/AsyncExtensionsTests.cs
+++ b/CSharpFunctionalExtensions.Tests/MaybeTests/AsyncExtensionsTests.cs
@@ -554,6 +554,62 @@ namespace CSharpFunctionalExtensions.Tests.MaybeTests
             maybe2.Should().Be(result);
         }
 
+        [Fact]
+        public async Task Async_Execute_executes_action_when_value()
+        {
+            string property = null;
+            var instance = new MyClass { Property = "Some value" };
+            Task<Maybe<MyClass>> maybeTask = GetMaybeTask(instance);
+
+            await maybeTask.Execute(x => property = x.Property);
+
+            property.Should().Be("Some value");
+        }
+
+        [Fact]
+        public async Task Async_ExecuteNoValue_executes_action_when_no_value()
+        {
+            string property = null;
+            
+            Task<Maybe<MyClass>> maybeTask = GetMaybeTask(Maybe<MyClass>.None);
+
+            await maybeTask.ExecuteNoValue(() => property = "Some value");
+
+            property.Should().Be("Some value");
+        }
+
+        [Fact]
+        public async Task Async_Execute_executes_async_action_when_value()
+        {
+            string property = null;
+            var instance = new MyClass { Property = "Some value" };
+            Task<Maybe<MyClass>> maybeTask = GetMaybeTask(instance);
+
+            await maybeTask.Execute(x => 
+            {
+                property = x.Property;
+                return Task.CompletedTask;
+            });
+
+            property.Should().Be("Some value");
+        }
+
+        [Fact]
+        public async Task Async_ExecuteNoValue_executes_async_action_when_no_value()
+        {
+            string property = null;
+            
+            Task<Maybe<MyClass>> maybeTask = GetMaybeTask(Maybe<MyClass>.None);
+
+            await maybeTask.ExecuteNoValue(() => 
+            {
+                property = "Some value";
+                return Task.CompletedTask;
+            });
+
+            property.Should().Be("Some value");
+        }
+
         private static Task<Maybe<MyClass>> GetMaybeTask(Maybe<MyClass> maybe) => maybe.AsTask();
 
         private static Func<MyClass, T> ExpectAndReturn<T>(MyClass expected, T result) => actual =>

--- a/CSharpFunctionalExtensions.Tests/MaybeTests/ExtensionsTests.cs
+++ b/CSharpFunctionalExtensions.Tests/MaybeTests/ExtensionsTests.cs
@@ -1,6 +1,7 @@
 ﻿using FluentAssertions;
 using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using Xunit;
 
 
@@ -207,12 +208,74 @@ namespace CSharpFunctionalExtensions.Tests.MaybeTests
         }
 
         [Fact]
-        public void Execute_executes_action()
+        public void Execute_executes_action_when_value()
         {
             string property = null;
             Maybe<MyClass> maybe = new MyClass { Property = "Some value" };
 
             maybe.Execute(x => property = x.Property);
+
+            property.Should().Be("Some value");
+        }
+
+        [Fact]
+        public void Execute_does_not_execute_action_when_no_value()
+        {
+            string property = null;
+            Maybe<MyClass> maybe = Maybe<MyClass>.None;
+
+            maybe.Execute(x => property = "Some value");
+
+            property.Should().NotBe("Some value");
+        }
+
+        [Fact]
+        public void ExecuteNoValue_executes_action_when_no_value()
+        {
+            string property = null;
+            Maybe<MyClass> maybe = Maybe<MyClass>.None;
+
+            maybe.ExecuteNoValue(() => property = "Some value");
+
+            property.Should().Be("Some value");
+        }
+
+        [Fact]
+        public void ExecuteNoValue_does_not_execute_action_when_value()
+        {
+            Maybe<MyClass> maybe = new MyClass{ Property = "test" };
+
+            maybe.ExecuteNoValue(() => maybe.Value.Property = "new value");
+
+            maybe.Value.Property.Should().NotBe("new value");
+        }
+
+        [Fact]
+        public async Task Execute_executes_async_action_when_value()
+        {
+            string property = null;
+            Maybe<MyClass> maybe = new MyClass { Property = "Some value" };
+
+            await maybe.Execute(x => 
+            {
+                property = x.Property;
+                return Task.CompletedTask;
+            });
+
+            property.Should().Be("Some value");
+        }
+
+        [Fact]
+        public async Task ExecuteNoValue_executes_async_action_when_no_value()
+        {
+            string property = null;
+            Maybe<MyClass> maybe = Maybe<MyClass>.None;
+
+            await maybe.ExecuteNoValue(() => 
+            {
+                property = "Some value";
+                return Task.CompletedTask;
+            });
 
             property.Should().Be("Some value");
         }

--- a/CSharpFunctionalExtensions/Maybe/AsyncMaybeExtensions.cs
+++ b/CSharpFunctionalExtensions/Maybe/AsyncMaybeExtensions.cs
@@ -205,5 +205,69 @@ namespace CSharpFunctionalExtensions
 
             return maybe;
         }
+
+        /// <summary>
+        /// Executes the given <paramref name="action" /> if the <paramref name="maybeTask" /> produces a value
+        /// </summary>
+        /// <param name="maybeTask"></param>
+        /// <param name="action"></param>
+        /// <typeparam name="T"></typeparam>
+        public static async Task Execute<T>(this Task<Maybe<T>> maybeTask, Action<T> action)
+        {
+            var maybe = await maybeTask.DefaultAwait();
+
+            if (maybe.HasNoValue)
+                return;
+
+            action(maybe.Value);
+        }
+
+        /// <summary>
+        /// Executes the given <paramref name="action" /> if the <paramref name="maybeTask" /> produces no value
+        /// </summary>
+        /// <param name="maybeTask"></param>
+        /// <param name="action"></param>
+        /// <typeparam name="T"></typeparam>
+        public static async Task ExecuteNoValue<T>(this Task<Maybe<T>> maybeTask, Action action)
+        {
+            var maybe = await maybeTask.DefaultAwait();
+
+            if (maybe.HasValue)
+                return;
+
+            action();
+        }
+
+        /// <summary>
+        /// Executes the given async <paramref name="action" /> if the <paramref name="maybeTask" /> produces a value
+        /// </summary>
+        /// <param name="maybeTask"></param>
+        /// <param name="action"></param>
+        /// <typeparam name="T"></typeparam>
+        public static async Task Execute<T>(this Task<Maybe<T>> maybeTask, Func<T, Task> action)
+        {
+            var maybe = await maybeTask.DefaultAwait();
+
+            if (maybe.HasNoValue)
+                return;
+
+            await action(maybe.Value).DefaultAwait();
+        }
+
+        /// <summary>
+        /// Executes the given async <paramref name="action" /> if the <paramref name="maybeTask" /> produces no value
+        /// </summary>
+        /// <param name="maybeTask"></param>
+        /// <param name="action"></param>
+        /// <typeparam name="T"></typeparam>
+        public static async Task ExecuteNoValue<T>(this Task<Maybe<T>> maybeTask, Func<Task> action)
+        {
+            var maybe = await maybeTask.DefaultAwait();
+
+            if (maybe.HasValue)
+                return;
+
+            await action().DefaultAwait();
+        }
     }
 }

--- a/CSharpFunctionalExtensions/Maybe/MaybeExtensions.cs
+++ b/CSharpFunctionalExtensions/Maybe/MaybeExtensions.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 
 namespace CSharpFunctionalExtensions
 {
@@ -92,12 +93,60 @@ namespace CSharpFunctionalExtensions
             return selector(maybe.Value);
         }
 
+        /// <summary>
+        /// Executes the given <paramref name="action" /> if the <paramref name="maybe" /> has a value
+        /// </summary>
+        /// <param name="maybe"></param>
+        /// <param name="action"></param>
+        /// <typeparam name="T"></typeparam>
         public static void Execute<T>(this Maybe<T> maybe, Action<T> action)
         {
             if (maybe.HasNoValue)
                 return;
 
             action(maybe.Value);
+        }
+
+        /// <summary>
+        /// Executes the given <paramref name="action" /> if the <paramref name="maybe" /> has no value
+        /// </summary>
+        /// <param name="maybe"></param>
+        /// <param name="action"></param>
+        /// <typeparam name="T"></typeparam>
+        public static void ExecuteNoValue<T>(this Maybe<T> maybe, Action action)
+        {
+            if (maybe.HasValue)
+                return;
+
+            action();
+        }
+        
+        /// <summary>
+        /// Executes the given async <paramref name="action" /> if the <paramref name="maybe" /> has a value
+        /// </summary>
+        /// <param name="maybe"></param>
+        /// <param name="action"></param>
+        /// <typeparam name="T"></typeparam>
+        public static async Task Execute<T>(this Maybe<T> maybe, Func<T, Task> action)
+        {
+            if (maybe.HasNoValue)
+                return;
+
+            await action(maybe.Value).DefaultAwait();
+        }
+
+        /// <summary>
+        /// Executes the given async <paramref name="action" /> if the <paramref name="maybe" /> has no value
+        /// </summary>
+        /// <param name="maybe"></param>
+        /// <param name="action"></param>
+        /// <typeparam name="T"></typeparam>
+        public static async Task ExecuteNoValue<T>(this Maybe<T> maybe, Func<Task> action)
+        {
+            if (maybe.HasValue)
+                return;
+
+            await action().DefaultAwait();
         }
 
         /// <summary>

--- a/README.md
+++ b/README.md
@@ -352,7 +352,7 @@ apple.Match(
     () => Console.WriteLine("There's no fruit"));
 
 // Mapping Match
-Maybe<string> fruitMessage = noFruit.Match(
+string fruitMessage = noFruit.Match(
     fruit => $"It's a {fruit}",
     () => "There's no fruit"));
 
@@ -421,7 +421,104 @@ Console.WriteLine(failedToGetAFruit.Error); // "There was no fruit to give"
 
 ### Result
 
-// TODO
+#### Explicit Construction: Success and Failure
+
+Use case: Creating a new Result in a Success or Failure state
+
+```csharp
+record FruitInventory(string Name, int Count);
+
+Result<FruitInventory> appleInventory = Result.Success(new FruitInventory("apple", 4));
+Result<FruitInventory> failedOperation = Result.Failure<FruitInventory>("Could not find inventory");
+Result successInventoryUpdate = Result.Success();
+```
+
+#### Conditional Construction: SuccessIf and FailureIf
+
+Use case: Creating successful or failed Results based on expressions or delegates instead of if/else statements or ternary expressions
+
+```csharp
+bool onTropicalIsland = true;
+
+Result foundCoconut = Result.SuccessIf(onTropicalIsland, "These trees seem bare 🥥");
+Result foundGrapes = Result.FailureIf(() => onTropicalIsland, "No grapes 🍇 here");
+
+// or
+
+bool isNewShipmentDay = true;
+
+Result<FruitInventory> appleInventory = Result.SuccessIf(isNewShipmentDay, new FruitInventory("apple", 4), "No 🍎 today");
+Result<FruitInventory> bananaInventory = Result.SuccessIf(() => isNewShipmentDay, new FruitInventory("banana", 2), "All out of 🍌");
+
+// or
+
+bool afterBreakfast = true;
+
+Result<FruitInventory> orangeInventory = Result.FailureIf(afterBreakfast, new FruitInventory("orange", 10), "No 🍊 today");
+Result<FruitInventory> grapefruitInventory = Result.FailureIf(() => afterBreakfast, new FruitInventory("grapefruit", 5), "No grapefruit 😢");
+```
+
+#### Implicit Conversion
+
+Use case: Easily creating a successful result from a value
+
+```csharp
+Result<FruitInventory> appleInventory = new FruitInventory("apple", 4);
+Result failedInventoryUpdate = "Could not update inventory";
+```
+
+#### ToString
+
+Use case: Printing out the state of a Result and its inner value or error
+
+```csharp
+Result<FruitInventory> appleInventory = new FruitInventory("apple", 4);
+Result<FruitInventory> bananaInventory = Result.Failure<FruitInventory>("Could not find any bananas");
+Result failedInventoryUpdate = "Could not update inventory";
+Result successfulInventoryUpdate = Result.Success();
+
+Console.WriteLine(appleInventory.ToString()); // "Success(FruitInventory { Name = apple, Count = 4 })"
+Console.WriteLine(bananaInventory.ToString()); // "Failure(Could not find any bananas)"
+Console.WriteLine(failedInventoryUpdate.ToString()); // "Failure(Could not update inventory)"
+Console.WriteLine(successfulInventoryUpdate.ToString()); // "Success"
+```
+
+#### Map
+
+Use case: Transforming the inner value of a successful Result, without needing to check on
+the success/failure state of the Result
+
+**Note**: the delegate (ex `CreateMessage`) passed to `Result.Map()` is only executed if the Result was successful
+
+```csharp
+string CreateMessage(FruitInventory inventory)
+{
+    return $"There are {inventory.Count} {inventory.Name}(s)";
+}
+
+Result<FruitInventory> appleInventory = new FruitInventory("apple", 4);
+Result<FruitInventory> bananaInventory = Result.Failure<FruitInventory>("Could not find any bananas");
+
+Console.WriteLine(appleInventory.Map(CreateMessage)); // "Success(There are 4 apple(s))"
+Console.WriteLine(bananaInventory.Map(CreateMessage)); // "Failure(Could not find any bananas)"
+```
+
+#### MapError
+
+Use case: Transforming the inner error of a failed Result, without needing to check on
+the success/failure state of the Result
+
+**Note**: the delegate (ex `ErrorEnhancer`) passed to `Result.MapError()` is only executed if the Result failed
+
+```csharp
+string ErrorEnhancer(string errorMessage)
+{
+    return $"Failed operation: {errorMessage}";
+}
+
+Console.WriteLine(appleInventory.MapError(ErrorEnhancer)); // "Success(FruitInventory { Name = apple, Count = 4 })"
+Console.WriteLine(bananaInventory.MapError(ErrorEnhancer)); // "Failed operation: Could not find any bananas"
+```
 
 ## Testing
 

--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ if (noFruit.HasNoValue)
 }
 ```
 
-#### UnWrap
+#### Unwrap
 
 Use case: Safely accessing the inner value, without checking if there is one, by providing a fallback
 if no value exists
@@ -201,8 +201,8 @@ void Response(string fruit)
 Maybe<string> apple = "apple";
 Maybe<string> unknownFruit = Maybe<string>.None;
 
-string appleValue = apple.UnWrap("banana");
-string unknownFruitValue = unknownFruit.UnWrap("banana");
+string appleValue = apple.Unwrap("banana");
+string unknownFruitValue = unknownFruit.Unwrap("banana");
 
 Response(appleValue); // It's a apple
 Response(unknownFruitValue); // It's a banana
@@ -243,8 +243,8 @@ string CreateMessage(string fruit)
 Maybe<string> apple = "apple";
 Maybe<string> noFruit = Maybe<string>.None;
 
-Console.WriteLine(apple.Map(CreateMessage).UnWrap("No fruit")); // "The fruit is a apple"
-Console.WriteLine(noFruit.Map(CreateMessage).UnWrap("No fruit")); // "No fruit"
+Console.WriteLine(apple.Map(CreateMessage).Unwrap("No fruit")); // "The fruit is a apple"
+Console.WriteLine(noFruit.Map(CreateMessage).Unwrap("No fruit")); // "No fruit"
 ```
 
 #### Select

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Maybe<string> apple = Maybe.From("apple"); // type inference
 var apple = Maybe.From("apple");
 ```
 
-#### No Value
+#### None/No Value
 
 Use case: Replacing `null` or the
 [Null Object Pattern](https://www.c-sharpcorner.com/article/null-object-design-pattern/) for representing 'missing' data.
@@ -99,6 +99,14 @@ int storeInventory = ...
 Maybe<string> fruit = storeInventory > 0
     ? Maybe<string>.From("apple")
     : Maybe<string>.None;
+
+// or where the generic type is a reference type
+
+Maybe<string> fruit = null;
+
+// or where the generic type is a value type
+
+Maybe<int> fruit = default;
 ```
 
 #### Implicit Conversion
@@ -224,7 +232,7 @@ Maybe<string> apple = "apple";
 
 Maybe<string> favoriteFruit = apple.Where(IsMyFavorite);
 
-Console.WriteLine(favoriteFruit); // "No value"
+Console.WriteLine(favoriteFruit.ToString()); // "No value"
 ```
 
 #### Map
@@ -273,9 +281,9 @@ Maybe<string> apple = "apple";
 Maybe<string> banana = "banana";
 Maybe<string> noFruit = Maybe<string>.None;
 
-Console.WriteLine(apple.Bind(MakeAppleSauce)); // "applesauce"
-Console.WriteLine(banana.Bind(MakeAppleSauce)); // "No value"
-Console.WriteLine(noFruit.Bind(MakeAppleSauce)); // "No value"
+Console.WriteLine(apple.Bind(MakeAppleSauce).ToString()); // "applesauce"
+Console.WriteLine(banana.Bind(MakeAppleSauce).ToString()); // "No value"
+Console.WriteLine(noFruit.Bind(MakeAppleSauce).ToString()); // "No value"
 ```
 
 #### SelectMany
@@ -301,7 +309,7 @@ Console.WriteLine(string.Join(", ", fruitResponses)) // "Delicious apple, Delici
 
 #### Execute
 
-Use case: Safely executing a void returning operation on the Maybe inner value
+Use case: Safely executing a `void` (or `Task`) returning operation on the Maybe inner value
 without checking if there is one
 
 **Note**: the `Action` (ex `PrintFruit`) passed to `Maybe.Execute()` is only executed if the Maybe has an inner value
@@ -315,8 +323,25 @@ void PrintFruit(string fruit)
 Maybe<string> apple = "apple";
 Maybe<string> noFruit = Maybe<string>.None;
 
-apple.Execute(PrintFruit); // "This is a apple"
-noFruit.Execute(PrintFruit); // no output to the console
+apple.Execute(PrintFruit.ToString()); // "This is a apple"
+noFruit.Execute(PrintFruit.ToString()); // no output to the console
+```
+
+#### ExecuteNoValue
+
+Use case: Executing a `void` (or `Task`) returning operation when the Maybe has no value
+
+```csharp
+void LogNoFruit(string fruit)
+{
+    Console.WriteLine($"There are no {fruit}");
+}
+
+Maybe<string> apple = "apple";
+Maybe<string> banana = Maybe<string>.None;
+
+apple.ExecuteNoValue(() => LogNoFruit("apple")); // no output to console
+banana.ExecuteNoValue(() => LogNoFruit("banana")); // "There are no banana"
 ```
 
 #### Or
@@ -331,10 +356,10 @@ Maybe<string> apple = "apple";
 Maybe<string> banana = "banana";
 Maybe<string> noFruit = Maybe<string>.None;
 
-Console.WriteLine(apple.Or(banana)); // "apple"
-Console.WriteLine(noFruit.Or(() => banana))); // "banana"
-Console.WriteLine(noFruit.Or("banana")); // "banana"
-Console.WriteLine(noFruit.Or(() => "banana")); // "banana"
+Console.WriteLine(apple.Or(banana).ToString()); // "apple"
+Console.WriteLine(noFruit.Or(() => banana)).ToString()); // "banana"
+Console.WriteLine(noFruit.Or("banana").ToString()); // "banana"
+Console.WriteLine(noFruit.Or(() => "banana").ToString()); // "banana"
 ```
 
 #### Match
@@ -371,15 +396,15 @@ Maybe<string> firstFruit = fruits.TryFirst();
 Maybe<string> probablyABanana = fruits.TryFirst(fruit => fruit.StartsWith("ba"));
 Maybe<string> aPeachOrAPear = fruits.TryFirst(fruit => fruit.StartsWith("p"));
 
-Console.WriteLine(firstFruit); // "apple"
-Console.WriteLine(probablyABanana); // "banana"
-Console.WriteLine(aPeachOrAPear); // "No value"
+Console.WriteLine(firstFruit.ToString()); // "apple"
+Console.WriteLine(probablyABanana.ToString()); // "banana"
+Console.WriteLine(aPeachOrAPear.ToString()); // "No value"
 
 Maybe<string> lastFruit = fruits.TryLast();
 Maybe<string> anAppleOrApricot = fruits.TryLast(fruit => fruit.StartsWith("a"));
 
-Console.WriteLine(lastFruit); // "banana"
-Console.WriteLine(anAppleOrApricot); // "apple"
+Console.WriteLine(lastFruit.ToString()); // "banana"
+Console.WriteLine(anAppleOrApricot.ToString()); // "apple"
 ```
 
 #### TryFind
@@ -396,8 +421,8 @@ Dictionary<string, int> fruitInventory = new()
 Maybe<int> appleCount = fruitInventory.TryFind("apple");
 Maybe<int> kiwiCount = fruitInventory.TryFind("kiwi");
 
-Console.WriteLine(appleCount); // "10"
-Console.WriteLine(kiwiCount); // "No value"
+Console.WriteLine(appleCount.ToString()); // "10"
+Console.WriteLine(kiwiCount.ToString()); // "No value"
 ```
 
 #### ToResult
@@ -499,8 +524,8 @@ string CreateMessage(FruitInventory inventory)
 Result<FruitInventory> appleInventory = new FruitInventory("apple", 4);
 Result<FruitInventory> bananaInventory = Result.Failure<FruitInventory>("Could not find any bananas");
 
-Console.WriteLine(appleInventory.Map(CreateMessage)); // "Success(There are 4 apple(s))"
-Console.WriteLine(bananaInventory.Map(CreateMessage)); // "Failure(Could not find any bananas)"
+Console.WriteLine(appleInventory.Map(CreateMessage).ToString()); // "Success(There are 4 apple(s))"
+Console.WriteLine(bananaInventory.Map(CreateMessage).ToString()); // "Failure(Could not find any bananas)"
 ```
 
 #### MapError
@@ -516,8 +541,8 @@ string ErrorEnhancer(string errorMessage)
     return $"Failed operation: {errorMessage}";
 }
 
-Console.WriteLine(appleInventory.MapError(ErrorEnhancer)); // "Success(FruitInventory { Name = apple, Count = 4 })"
-Console.WriteLine(bananaInventory.MapError(ErrorEnhancer)); // "Failed operation: Could not find any bananas"
+Console.WriteLine(appleInventory.MapError(ErrorEnhancer).ToString()); // "Success(FruitInventory { Name = apple, Count = 4 })"
+Console.WriteLine(bananaInventory.MapError(ErrorEnhancer).ToString()); // "Failed operation: Could not find any bananas"
 ```
 
 ## Testing


### PR DESCRIPTION
This PR:
- Handles #328 for `Maybe.ExecuteNoValue`.
- Adds the ability to pass `Task` returning 'actions' to `Execute` (and `ExecuteNoValue`)
- Updates the README where I noticed some of the examples weren't correct
- Adds the beginning of the `Result` examples