### PR TITLE
Add Maybe.GetValueOrThrow() and Maybe.GetValueOrDefault()

### DIFF
--- a/CSharpFunctionalExtensions.Tests/MaybeTests/ExtensionsTests.cs
+++ b/CSharpFunctionalExtensions.Tests/MaybeTests/ExtensionsTests.cs
@@ -10,42 +10,42 @@ namespace CSharpFunctionalExtensions.Tests.MaybeTests
     public class ExtensionsTests
     {
         [Fact]
-        public void Unwrap_extracts_value_if_not_null()
+        public void GetValueOrDefault_extracts_value_if_not_null()
         {
             var instance = new MyClass();
             Maybe<MyClass> maybe = instance;
 
-            MyClass myClass = maybe.Unwrap();
+            MyClass myClass = maybe.GetValueOrDefault();
 
             myClass.Should().Be(instance);
         }
 
         [Fact]
-        public void Unwrap_extracts_null_if_no_value()
+        public void GetValueOrDefault_extracts_null_if_no_value()
         {
             Maybe<MyClass> maybe = null;
 
-            MyClass myClass = maybe.Unwrap();
+            MyClass myClass = maybe.GetValueOrDefault();
 
             myClass.Should().BeNull();
         }
 
         [Fact]
-        public void Can_use_selector_in_Unwrap()
+        public void Can_use_selector_in_GetValueOrDefault()
         {
             Maybe<MyClass> maybe = new MyClass { Property = "Some value" };
 
-            string value = maybe.Unwrap(x => x.Property);
+            string value = maybe.GetValueOrDefault(x => x.Property);
 
             value.Should().Be("Some value");
         }
 
         [Fact]
-        public void Can_use_default_value_in_Unwrap()
+        public void Can_use_default_value_in_GetValueOrDefault()
         {
             Maybe<string> maybe = null;
 
-            string value = maybe.Unwrap("");
+            string value = maybe.GetValueOrDefault("");
 
             value.Should().Be("");
         }
@@ -281,21 +281,21 @@ namespace CSharpFunctionalExtensions.Tests.MaybeTests
         }
 
         [Fact]
-        public void Unwrap_supports_NET_value_types()
+        public void GetValueOrDefault_supports_NET_value_types()
         {
             Maybe<MyClass> maybe = new MyClass { IntProperty = 42 };
 
-            int integer = maybe.Select(x => x.IntProperty).Unwrap();
+            int integer = maybe.Select(x => x.IntProperty).GetValueOrDefault();
 
             integer.Should().Be(42);
         }
 
         [Fact]
-        public void Unwrap_returns_default_for_NET_value_types()
+        public void GetValueOrDefault_returns_default_for_NET_value_types()
         {
             Maybe<MyClass> maybe = null;
 
-            int integer = maybe.Select(x => x.IntProperty).Unwrap();
+            int integer = maybe.Select(x => x.IntProperty).GetValueOrDefault();
 
             integer.Should().Be(0);
         }

--- a/CSharpFunctionalExtensions/Maybe/AsyncMaybeExtensions.cs
+++ b/CSharpFunctionalExtensions/Maybe/AsyncMaybeExtensions.cs
@@ -17,6 +17,68 @@ namespace CSharpFunctionalExtensions
             return maybe.ToResult(error);
         }
 
+        public static async Task<T> GetValueOrThrow<T>(this Task<Maybe<T>> maybeTask)
+        {
+            var maybe = await maybeTask.DefaultAwait();
+            return maybe.GetValueOrThrow();
+        }
+
+        public static async Task<T> GetValueOrDefault<T>(this Maybe<T> maybe, Func<Task<T>> defaultValue)
+        {
+            if (maybe.HasNoValue)
+                return await defaultValue().DefaultAwait();
+
+            return maybe.GetValueOrThrow();
+        }
+
+        public static async Task<K> GetValueOrDefault<T, K>(this Maybe<T> maybe, Func<T, K> selector, Func<Task<K>> defaultValue)
+        {
+            if (maybe.HasNoValue)
+                return await defaultValue().DefaultAwait();
+
+            return selector(maybe.GetValueOrThrow());
+        }
+
+        public static async Task<K> GetValueOrDefault<T, K>(this Maybe<T> maybe, Func<T, Task<K>> selector, K defaultValue = default)
+        {
+            if (maybe.HasNoValue)
+                return defaultValue;
+
+            return await selector(maybe.GetValueOrThrow()).DefaultAwait();
+        }
+
+        public static async Task<K> GetValueOrDefault<T, K>(this Maybe<T> maybe, Func<T, Task<K>> selector, Func<Task<K>> defaultValue)
+        {
+            if (maybe.HasNoValue)
+                return await defaultValue().DefaultAwait();
+
+            return await selector(maybe.GetValueOrThrow()).DefaultAwait();
+        }
+
+        public static async Task<T> GetValueOrDefault<T>(this Task<Maybe<T>> maybeTask, Func<Task<T>> defaultValue)
+        {
+            var maybe = await maybeTask.DefaultAwait();
+            return await maybe.GetValueOrDefault(defaultValue).DefaultAwait();
+        }
+
+        public static async Task<K> GetValueOrDefault<T, K>(this Task<Maybe<T>> maybeTask, Func<T, K> selector, Func<Task<K>> defaultValue)
+        {
+            var maybe = await maybeTask.DefaultAwait();
+            return await maybe.GetValueOrDefault(selector, defaultValue).DefaultAwait();
+        }
+
+        public static async Task<K> GetValueOrDefault<T, K>(this Task<Maybe<T>> maybeTask, Func<T, Task<K>> selector, K defaultValue = default)
+        {
+            var maybe = await maybeTask.DefaultAwait();
+            return await maybe.GetValueOrDefault(selector, defaultValue).DefaultAwait();
+        }
+
+        public static async Task<K> GetValueOrDefault<T, K>(this Task<Maybe<T>> maybeTask, Func<T, Task<K>> selector, Func<Task<K>> defaultValue)
+        {
+            var maybe = await maybeTask.DefaultAwait();
+            return await maybe.GetValueOrDefault(selector, defaultValue).DefaultAwait();
+        }
+
         public static async Task<Maybe<T>> Where<T>(this Task<Maybe<T>> maybeTask, Func<T, bool> predicate)
         {
             Maybe<T> maybe = await maybeTask.DefaultAwait();
@@ -28,7 +90,7 @@ namespace CSharpFunctionalExtensions
             if (maybe.HasNoValue)
                 return Maybe<T>.None;
 
-            if (await predicate(maybe.Value).DefaultAwait())
+            if (await predicate(maybe.GetValueOrThrow()).DefaultAwait())
                 return maybe;
 
             return Maybe<T>.None;
@@ -51,7 +113,7 @@ namespace CSharpFunctionalExtensions
             if (maybe.HasNoValue)
                 return Maybe<K>.None;
 
-            return await selector(maybe.Value).DefaultAwait();
+            return await selector(maybe.GetValueOrThrow()).DefaultAwait();
         }
 
         public static async Task<Maybe<K>> Map<T, K>(this Task<Maybe<T>> maybeTask, Func<T, Task<K>> selector)
@@ -71,7 +133,7 @@ namespace CSharpFunctionalExtensions
             if (maybe.HasNoValue)
                 return Maybe<K>.None.AsCompletedTask();
 
-            return selector(maybe.Value);
+            return selector(maybe.GetValueOrThrow());
         }
 
         public static async Task<Maybe<K>> Bind<T, K>(this Task<Maybe<T>> maybeTask, Func<T, Task<Maybe<K>>> selector)
@@ -220,7 +282,7 @@ namespace CSharpFunctionalExtensions
             if (maybe.HasNoValue)
                 return;
 
-            action(maybe.Value);
+            action(maybe.GetValueOrThrow());
         }
 
         /// <summary>
@@ -253,7 +315,7 @@ namespace CSharpFunctionalExtensions
             if (maybe.HasNoValue)
                 return;
 
-            await asyncAction(maybe.Value).DefaultAwait();
+            await asyncAction(maybe.GetValueOrThrow()).DefaultAwait();
         }
 
         /// <summary>

--- a/CSharpFunctionalExtensions/Maybe/Maybe.cs
+++ b/CSharpFunctionalExtensions/Maybe/Maybe.cs
@@ -8,16 +8,25 @@ namespace CSharpFunctionalExtensions
         private readonly bool _isValueSet;
 
         private readonly T _value;
-        public T Value
-        {
-            get
-            {
-                if (HasNoValue)
-                    throw new InvalidOperationException();
 
-                return _value;
-            }
+        public T GetValueOrThrow()
+        {
+            if (HasNoValue)
+                throw new InvalidOperationException();
+
+            return _value;
         }
+
+        public T GetValueOrDefault(T defaultValue = default)
+        {
+            if (HasNoValue)
+                return defaultValue;
+
+            return _value;
+        }
+
+        [Obsolete("Use GetValueOrThrow() instead.")]
+        public T Value => GetValueOrThrow();
 
         public static Maybe<T> None => new Maybe<T>();
 
@@ -62,7 +71,7 @@ namespace CSharpFunctionalExtensions
             if (maybe.HasNoValue)
                 return value is null;
 
-            return maybe.Value.Equals(value);
+            return maybe._value.Equals(value);
         }
 
         public static bool operator !=(Maybe<T> maybe, T value)
@@ -124,7 +133,7 @@ namespace CSharpFunctionalExtensions
             if (HasNoValue)
                 return "No value";
 
-            return Value.ToString();
+            return _value.ToString();
         }
     }
 


### PR DESCRIPTION
This is a draft of `Maybe.GetValueOrThrow()` and `Maybe.GetValueOrDefault()` replacement for `.Value` and `.Unwrap()`

If it looks good, I will also add `Result.GetValueOrThrow()`, `Result.GetValueOrDefault()`, `Result.GetErrorOrThrow()` and `Result.GetErrorOrDefault()`

Closes #312
Closes #330 