### PR TITLE
Align EnumValueObject implementations

### DIFF
--- a/CSharpFunctionalExtensions.Tests/ValueObjectTests/EnumValueObjectTests.cs
+++ b/CSharpFunctionalExtensions.Tests/ValueObjectTests/EnumValueObjectTests.cs
@@ -82,10 +82,10 @@ namespace CSharpFunctionalExtensions.Tests.ValueObjectTests
         [InlineData("Four", false)]
         [InlineData(nameof(TestEnumValueObject.Two), true)]
         [InlineData(nameof(TestEnumValueObject.One), true)]
-        public void GivenPossibleKey_WhenCheckingIfKeyIsEnumValueObject_ThenShouldReturnTrueIfKeyRecognized(string possibleKey, bool isIn)
+        public void GivenPossibleKey_WhenCheckingIfKeyIsEnumValueObject_ThenShouldReturnTrueIfKeyRecognized(string possibleId, bool isIn)
         {
             // Act
-            var isEnumValueObject = TestEnumValueObject.Is(possibleKey);
+            var isEnumValueObject = TestEnumValueObject.Is(possibleId);
 
             // Assert
             isEnumValueObject.Should().Be(isIn);

--- a/CSharpFunctionalExtensions/ValueObject/EnumValueObject.cs
+++ b/CSharpFunctionalExtensions/ValueObject/EnumValueObject.cs
@@ -66,7 +66,12 @@ namespace CSharpFunctionalExtensions
                 : null;
         }
 
+
+#if NET40
+        public static ICollection<TEnumeration> All = EnumerationsById.Values.OfType<TEnumeration>().ToList();
+#else
         public static IReadOnlyCollection<TEnumeration> All = EnumerationsById.Values.OfType<TEnumeration>().ToList();
+#endif
 
         public static bool Is(string possibleName) => All.Select(e => e.Name).Contains(possibleName);
 
@@ -106,7 +111,11 @@ namespace CSharpFunctionalExtensions
             Id = id;
         }
 
+#if NET40
+        public static ICollection<TEnumeration> All = Enumerations.Values.OfType<TEnumeration>().ToList();
+#else
         public static IReadOnlyCollection<TEnumeration> All = Enumerations.Values.OfType<TEnumeration>().ToList();
+#endif
 
         public virtual string Id { get; protected set; }
         

--- a/CSharpFunctionalExtensions/ValueObject/EnumValueObject.cs
+++ b/CSharpFunctionalExtensions/ValueObject/EnumValueObject.cs
@@ -65,7 +65,15 @@ namespace CSharpFunctionalExtensions
                 ? EnumerationsByName[name]
                 : null;
         }
-        
+
+        public static IReadOnlyCollection<TEnumeration> All = EnumerationsById.Values;
+
+        public static bool Is(string possibleName) => All.Select(e => e.Name).Contains(possibleName);
+
+        public static bool Is(TId possibleId) => All.Select(e => e.Id).Contains(possibleId);
+
+        public override string ToString() => Name;
+
         protected override IEnumerable<object> GetEqualityComponents()
         {
             yield return Id;
@@ -98,7 +106,7 @@ namespace CSharpFunctionalExtensions
             Id = id;
         }
 
-        public static IEnumerable<TEnumeration> All = Enumerations.Values;
+        public static IReadOnlyCollection<TEnumeration> All = Enumerations.Values;
 
         public virtual string Id { get; protected set; }
         
@@ -139,7 +147,7 @@ namespace CSharpFunctionalExtensions
                 : null;
         }
 
-        public static bool Is(string possibleKey) => All.Select(e => e.Id).Contains(possibleKey);
+        public static bool Is(string possibleId) => All.Select(e => e.Id).Contains(possibleId);
 
         public override string ToString() => Id;
 

--- a/CSharpFunctionalExtensions/ValueObject/EnumValueObject.cs
+++ b/CSharpFunctionalExtensions/ValueObject/EnumValueObject.cs
@@ -66,7 +66,7 @@ namespace CSharpFunctionalExtensions
                 : null;
         }
 
-        public static IReadOnlyCollection<TEnumeration> All = EnumerationsById.Values;
+        public static IReadOnlyCollection<TEnumeration> All = EnumerationsById.Values.OfType<TEnumeration>().ToList();
 
         public static bool Is(string possibleName) => All.Select(e => e.Name).Contains(possibleName);
 
@@ -106,7 +106,7 @@ namespace CSharpFunctionalExtensions
             Id = id;
         }
 
-        public static IReadOnlyCollection<TEnumeration> All = Enumerations.Values;
+        public static IReadOnlyCollection<TEnumeration> All = Enumerations.Values.OfType<TEnumeration>().ToList();
 
         public virtual string Id { get; protected set; }
         


### PR DESCRIPTION
This PR closes #286.

@vkhorikov do you like they way the problem with missing `IReadOnlyCollection<>` is solved for .NET4.0 or do you prefer a different solution? This follows your suggestion from the issue (though I thought collection might be more appropriate than list).