### PR TITLE
Accept custom exceptions for GetValueOrThrow on Maybes

### DIFF
--- a/CSharpFunctionalExtensions.Tests/MaybeTests/AsyncExtensionsTests.cs
+++ b/CSharpFunctionalExtensions.Tests/MaybeTests/AsyncExtensionsTests.cs
@@ -645,6 +645,23 @@ namespace CSharpFunctionalExtensions.Tests.MaybeTests
             instance.Value.Property.Should().Be("Some Value");
         }
 
+        [Fact]
+        public async Task Async_GetValueOrThrow_throws_requested_exception_if_none()
+        {
+            const string exceptionMessage = "Maybe is none";
+            var exception = new MyException(exceptionMessage);
+
+            Func<Task<int>> getMaybeValue = () =>
+            {
+                var maybe = Maybe<int>.None;
+                var maybeTask = Task.FromResult(maybe);
+                
+                return maybeTask.GetValueOrThrow(exception);
+            };
+
+            await getMaybeValue.Should().ThrowExactlyAsync<MyException>().WithMessage(exceptionMessage);
+        }
+
         private static Task<Maybe<MyClass>> GetMaybeTask(Maybe<MyClass> maybe) => maybe.AsTask();
 
         private static Func<MyClass, T> ExpectAndReturn<T>(MyClass expected, T result) => actual =>
@@ -679,6 +696,13 @@ namespace CSharpFunctionalExtensions.Tests.MaybeTests
 
         private class MyErrorClass
         {
+        }
+
+        private class MyException : Exception
+        {
+            public MyException(string message) : base(message)
+            {
+            }
         }
     }
 }

--- a/CSharpFunctionalExtensions.Tests/MaybeTests/ExtensionsTests.cs
+++ b/CSharpFunctionalExtensions.Tests/MaybeTests/ExtensionsTests.cs
@@ -683,6 +683,21 @@ namespace CSharpFunctionalExtensions.Tests.MaybeTests
             orMaybe.Should().NotBe(maybe);
         }
 
+        [Fact]
+        public void GetValueOrThrow_throws_requested_exception_if_none()
+        {
+            const string exceptionMessage = "Maybe is none";
+            var exception = new MyException(exceptionMessage);
+
+            Action assignMaybeValue = () =>
+            {
+                var maybe = Maybe<int>.None;
+                int _ = maybe.GetValueOrThrow(exception);
+            };
+
+            assignMaybeValue.Should().ThrowExactly<MyException>().WithMessage(exceptionMessage);
+        }
+
         private static Maybe<string> GetPropertyIfExists(MyClass myClass)
         {
             return myClass.Property;
@@ -697,6 +712,13 @@ namespace CSharpFunctionalExtensions.Tests.MaybeTests
 
         private class MyErrorClass
         {
+        }
+
+        private class MyException : Exception
+        {
+            public MyException(string message) : base(message)
+            {
+            }
         }
     }
 }

--- a/CSharpFunctionalExtensions/Maybe/AsyncMaybeExtensions.cs
+++ b/CSharpFunctionalExtensions/Maybe/AsyncMaybeExtensions.cs
@@ -79,6 +79,13 @@ namespace CSharpFunctionalExtensions
             return await maybe.GetValueOrDefault(selector, defaultValue).DefaultAwait();
         }
 
+        public static async Task<T> GetValueOrThrow<T>(this Task<Maybe<T>> maybeTask, Exception exception)
+        {
+            var maybe = await maybeTask.DefaultAwait();
+
+            return maybe.GetValueOrThrow(exception);
+        }
+
         public static async Task<Maybe<T>> Where<T>(this Task<Maybe<T>> maybeTask, Func<T, bool> predicate)
         {
             Maybe<T> maybe = await maybeTask.DefaultAwait();

--- a/CSharpFunctionalExtensions/Maybe/MaybeExtensions.cs
+++ b/CSharpFunctionalExtensions/Maybe/MaybeExtensions.cs
@@ -59,6 +59,13 @@ namespace CSharpFunctionalExtensions
             return maybe.GetValueOrDefault(selector, defaultValue);
         }
 
+        public static T GetValueOrThrow<T>(this Maybe<T> maybe, Exception exception)
+        {
+            return maybe.HasValue
+                ? maybe.GetValueOrThrow()
+                : throw exception;
+        }
+
         public static List<T> ToList<T>(this Maybe<T> maybe)
         {
             return maybe.GetValueOrDefault(value => new List<T> {value}, new List<T>());


### PR DESCRIPTION
Currently, ``GetValueOrThrow`` throws a generic ``InvalidOperationException`` when the maybe is none. These new extensions allow users to specify a custom exception that is more relevant to their application.