### PR TITLE
With Extensions (Combine)

### DIFF
--- a/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/With/AsyncResultOfTETests.cs
+++ b/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/With/AsyncResultOfTETests.cs
@@ -1,0 +1,32 @@
+﻿using System.Threading.Tasks;
+using FluentAssertions;
+using Xunit;
+
+namespace CSharpFunctionalExtensions.Tests.ResultTests.Extensions.With
+{
+    public class AsyncResultOfTETests
+    {
+        [Fact]
+        public async Task Combining_successful()
+        {
+            var r1 = Result.Success<int, string>(1);
+            var r2 = Result.Success<int, string>(2);
+            var actual = await r1.WithMap(r2, (a, b) => Task.FromResult(a + b), (e1, e2) => "failure");
+
+            actual.IsSuccess.Should().BeTrue();
+        }
+
+        [Fact]
+        public async Task Successful_results_are_combined_with_binding()
+        {
+            var r1 = Result.Success<int, string>(1);
+            var r2 = Result.Success<int, string>(2);
+
+            var actual = await r1
+                .WithBind(r2, (a, b) => Task.FromResult(Result.Success<int, string>(a + b)), (e1, e2) => "error");
+
+            actual.IsSuccess.Should().BeTrue();
+            actual.Value.Should().Be(3);
+        }
+    }
+}

--- a/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/With/AsyncResultOfTTests.cs
+++ b/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/With/AsyncResultOfTTests.cs
@@ -1,0 +1,59 @@
+﻿using System.Threading.Tasks;
+using FluentAssertions;
+using Xunit;
+
+namespace CSharpFunctionalExtensions.Tests.ResultTests.Extensions.With
+{
+    public class AsyncResultOfTTests
+    {
+        [Fact]
+        public async Task Successful_results_are_combined_with_mapping()
+        {
+            var r1 = Result.Success(1);
+            var r2 = Result.Success("hola");
+
+            var actual = await r1
+                .WithMap(r2, (a, b) => Task.FromResult(a + b));
+
+            actual.IsSuccess.Should().BeTrue();
+            actual.Value.Should().Be("1hola");
+        }
+
+        [Fact]
+        public async Task Successful_results_are_combined_with_binding()
+        {
+            var r1 = Result.Success(1);
+            var r2 = Result.Success("hola");
+
+            var actual = await r1
+                .WithBind(r2, (a, b) => Task.FromResult(Result.Success(a + b)));
+
+            actual.IsSuccess.Should().BeTrue();
+            actual.Value.Should().Be("1hola");
+        }
+
+        [Fact]
+        public async Task Successful_results_are_combined_into_success()
+        {
+            var r1 = Result.Success(1);
+            var r2 = Result.Success("hola");
+
+            var actual = await r1
+                .WithBind(r2, (a, b) => Task.FromResult(Result.Success()));
+
+            actual.IsSuccess.Should().BeTrue();
+        }
+
+        [Fact]
+        public async Task Failures_are_combined_into_failure()
+        {
+            var r1 = Result.Failure<int>("Failed");
+            var r2 = Result.Success("hola");
+
+            var actual = await r1
+                .WithBind(r2, (a, b) => Task.FromResult(Result.Success()));
+
+            actual.IsSuccess.Should().BeFalse();
+        }
+    }
+}

--- a/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/With/ResultOfTETests.cs
+++ b/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/With/ResultOfTETests.cs
@@ -1,0 +1,44 @@
+﻿using FluentAssertions;
+using Xunit;
+
+namespace CSharpFunctionalExtensions.Tests.ResultTests.Extensions.With
+{
+    public class ResultOfTETests
+    {
+        [Fact]
+        public async void Successful_results_are_combined_with_map()
+        {
+            var r1 = Result.Success<int, string>(1);
+            var r2 = Result.Success<int, string>(2);
+
+            var actual = r1.WithMap(r2, (a, b) => a + b, (e1, e2) => "");
+
+            actual.IsSuccess.Should().BeTrue();
+            actual.Value.Should().Be(3);
+        }
+
+        [Fact]
+        public async void Successful_results_are_combined_with_binding()
+        {
+            var r1 = Result.Success<int, string>(1);
+            var r2 = Result.Success<int, string>(2);
+
+            var actual = r1.WithBind<int, string>(r2, (a, b) => Result.Success<int, string>(a + b), (e1, e2) => "");
+
+            actual.IsSuccess.Should().BeTrue();
+            actual.Value.Should().Be(3);
+        }
+
+        [Fact]
+        public async void Successful_results_are_combined_with_binding_different_types()
+        {
+            var r1 = Result.Success<string, string>("Hi");
+            var r2 = Result.Success<int, string>(2);
+
+            var actual = r1.WithBind(r2, (a, b) => Result.Success<string, string>(a + b), (e1, e2) => "");
+
+            actual.IsSuccess.Should().BeTrue();
+            actual.Value.Should().Be("Hi2");
+        }
+    }
+}

--- a/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/With/ResultOfTTest.cs
+++ b/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/With/ResultOfTTest.cs
@@ -1,0 +1,41 @@
+﻿using FluentAssertions;
+using Xunit;
+
+namespace CSharpFunctionalExtensions.Tests.ResultTests.Extensions.With
+{
+    public class ResultOfTTest
+    {
+        [Fact]
+        public void Results_of_same_type_are_combined_correctly()
+        {
+            var r1 = Result.Success("Hello");
+            var r2 = Result.Success("world");
+
+            var actual = r1.With(r2);
+            actual.IsSuccess.Should().BeTrue();
+            actual.Value.Should().Be(("Hello", "world"));
+        }
+
+        [Fact]
+        public void Results_of_different_type_are_mapped_correctly()
+        {
+            var r1 = Result.Success("Hello");
+            var r2 = Result.Success("world");
+
+            var actual = r1.WithMap(r2, (a, b) => a + b);
+            actual.IsSuccess.Should().BeTrue();
+            actual.Value.Should().Be("Helloworld");
+        }
+
+        [Fact]
+        public void Results_of_different_type_are_bound_correctly()
+        {
+            var r1 = Result.Success("Hello");
+            var r2 = Result.Success("world");
+
+            var actual = r1.WithBind(r2, (a, b) => Result.Success(a + b));
+            actual.IsSuccess.Should().BeTrue();
+            actual.Value.Should().Be("Helloworld");
+        }
+    }
+}

--- a/CSharpFunctionalExtensions/CSharpFunctionalExtensions.csproj
+++ b/CSharpFunctionalExtensions/CSharpFunctionalExtensions.csproj
@@ -36,6 +36,10 @@
   <ItemGroup Condition="'$(TargetFramework)'=='net40'">
     <PackageReference Include="Microsoft.Bcl.Async" Version="1.0.168" />
   </ItemGroup>
+	
+  <ItemGroup Condition="$(TargetFramework.StartsWith('net4')) OR $(TargetFramework)=='netstandard2.0'">
+    <PackageReference Include="System.ValueTuple" Version="4.*" />
+  </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0">

--- a/CSharpFunctionalExtensions/Result/Extensions/BindError.cs
+++ b/CSharpFunctionalExtensions/Result/Extensions/BindError.cs
@@ -1,0 +1,29 @@
+﻿using System;
+
+namespace CSharpFunctionalExtensions
+{
+    public partial class ResultExtensions
+    {
+        public static Result<T, E2> BindError<T, E, E2>(this Result<T, E> self,
+            Func<E, Result<T, E2>> func)
+        {
+            if (self.IsSuccess)
+            {
+                return Result.Success<T, E2>(self.Value);
+            }
+
+            return func(self.Error);
+        }
+
+        public static Result<T> BindError<T>(this Result<T> self,
+            Func<string, Result<T>> func)
+        {
+            if (self.IsSuccess)
+            {
+                return Result.Success(self.Value);
+            }
+
+            return func(self.Error);
+        }
+    }
+}

--- a/CSharpFunctionalExtensions/Result/Extensions/With/AsyncResultOfT.cs
+++ b/CSharpFunctionalExtensions/Result/Extensions/With/AsyncResultOfT.cs
@@ -1,0 +1,53 @@
+﻿using System;
+using System.Threading.Tasks;
+
+namespace CSharpFunctionalExtensions
+{
+    public static partial class ResultExtensions
+    {
+        public static Task<Result<TResult>> WithMap<T1, T2, TResult>(this Result<T1> a,
+            Result<T2> b,
+            Func<T1, T2, Task<TResult>> func)
+        {
+            var mapSuccess =
+                a.BindError(e1 => b
+                        .MapError(e2 => Errors.Join(e1, e2))
+                        .Bind(_ => Result.Failure<T1>(e1)))
+                    .Bind(x => b
+                        .Map(y => func(x, y))
+                        .MapError(el => el));
+
+            return mapSuccess;
+        }
+
+        public static Task<Result<TResult>> WithBind<T1, T2, TResult>(this Result<T1> a,
+            Result<T2> b,
+            Func<T1, T2, Task<Result<TResult>>> func)
+        {
+            var mapSuccess =
+                a.BindError(e1 => b
+                        .MapError(e2 => Errors.Join(e1, e2))
+                        .Bind(_ => Result.Failure<T1>(e1)))
+                    .Bind(x => b
+                        .Bind(y => func(x, y))
+                        .MapError(el => el));
+
+            return mapSuccess;
+        }
+
+        public static Task<Result> WithBind<T1, T2>(this Result<T1> a,
+            Result<T2> b,
+            Func<T1, T2, Task<Result>> map)
+        {
+            var mapSuccess =
+                a.BindError(el1 => b
+                        .MapError(el2 => string.Join(Result.ErrorMessagesSeparator, el1, el2))
+                        .Bind(_ => Result.Failure<T1>(el1)))
+                    .Bind(x => b
+                        .Bind(y => map(x, y))
+                        .MapError(el => el));
+
+            return mapSuccess;
+        }
+    }
+}

--- a/CSharpFunctionalExtensions/Result/Extensions/With/AsyncResultOfTE.cs
+++ b/CSharpFunctionalExtensions/Result/Extensions/With/AsyncResultOfTE.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.Threading.Tasks;
+
+namespace CSharpFunctionalExtensions
+{
+    public static partial class ResultExtensions
+    {
+        public static Task<Result<TResult, E>> WithMap<T1, T2, E, TResult>(this Result<T1, E> a,
+            Result<T2, E> b,
+            Func<T1, T2, Task<TResult>> map, Func<E, E, E> combineError)
+        {
+            var mapSuccess =
+                a.BindError(e1 => b
+                        .MapError(e2 => combineError(e1, e2))
+                        .Bind(_ => Result.Failure<T1, E>(e1)))
+                    .Bind(x => b
+                        .Map(y => map(x, y))
+                        .MapError(el => el));
+
+            return mapSuccess;
+        }
+
+        public static Task<Result<TResult, E>> WithBind<T1, T2, E, TResult>(this Result<T1, E> a,
+            Result<T2, E> b,
+            Func<T1, T2, Task<Result<TResult, E>>> map, Func<E, E, E> combineError)
+        {
+            var mapSuccess =
+                a.BindError(e1 => b
+                        .MapError(e2 => combineError(e1, e2))
+                        .Bind(_ => Result.Failure<T1, E>(e1)))
+                    .Bind(x => b
+                        .Bind(y => map(x, y))
+                        .MapError(el => el));
+
+            return mapSuccess;
+        }
+    }
+}

--- a/CSharpFunctionalExtensions/Result/Extensions/With/Errors.cs
+++ b/CSharpFunctionalExtensions/Result/Extensions/With/Errors.cs
@@ -1,0 +1,10 @@
+﻿namespace CSharpFunctionalExtensions
+{
+    public static class Errors
+    {
+        public static string Join(string e1, string e2)
+        {
+            return string.Join(Result.ErrorMessagesSeparator, e1, e2);
+        }
+    }
+}

--- a/CSharpFunctionalExtensions/Result/Extensions/With/ResultOfT.cs
+++ b/CSharpFunctionalExtensions/Result/Extensions/With/ResultOfT.cs
@@ -1,0 +1,40 @@
+﻿using System;
+
+namespace CSharpFunctionalExtensions
+{
+    public static partial class ResultExtensions
+    {
+        public static Result<(T1, T2)> With<T1, T2>(this Result<T1> a, Result<T2> b)
+        {
+            return a.WithMap(b, (x, y) => (x, y));
+        }
+
+        public static Result<TResult> WithMap<T, K, TResult>(
+            this Result<T> a,
+            Result<K> b,
+            Func<T, K, TResult> func)
+        {
+            return a
+                .BindError(e1 => b
+                    .MapError(e2 => Errors.Join(e1, e2))
+                    .Bind(_ => Result.Failure<T>(e1))
+                ).Bind(x => b
+                    .Map(y => func(x, y))
+                    .MapError(e => e));
+        }
+
+        public static Result<TResult> WithBind<T, K, TResult>(
+            this Result<T> a,
+            Result<K> b,
+            Func<T, K, Result<TResult>> func)
+        {
+            return a
+                .BindError(e1 => b
+                    .MapError(e2 => Errors.Join(e1, e2))
+                    .Bind(_ => Result.Failure<T>(e1))
+                ).Bind(x => b
+                    .Bind(y => func(x, y))
+                    .MapError(e => e));
+        }
+    }
+}

--- a/CSharpFunctionalExtensions/Result/Extensions/With/ResultOfTE.cs
+++ b/CSharpFunctionalExtensions/Result/Extensions/With/ResultOfTE.cs
@@ -1,0 +1,52 @@
+﻿using System;
+
+namespace CSharpFunctionalExtensions
+{
+    public static partial class ResultExtensions
+    {
+        public static Result<R, E> WithMap<T1, T2, E, R>(this Result<T1, E> a,
+            Result<T2, E> b,
+            Func<T1, T2, R> func, Func<E, E, E> combineError)
+        {
+            var mapSuccess =
+                a.BindError(e1 => b
+                        .MapError(e2 => combineError(e1, e2))
+                        .Bind(_ => Result.Failure<T1, E>(e1)))
+                    .Bind(x => b
+                        .Map(y => func(x, y))
+                        .MapError(el => el));
+
+            return mapSuccess;
+        }
+
+        public static Result<T, E> WithBind<T, E>(
+            this Result<T, E> a,
+            Result<T, E> b,
+            Func<T, T, Result<T, E>> func, Func<E, E, E> combineError)
+        {
+            return a
+                .BindError(e1 => b
+                    .MapError(e2 => combineError(e1, e2))
+                    .Bind(_ => Result.Failure<T, E>(e1)))
+                .Bind(x => b
+                    .Bind(y => func(x, y))
+                    .MapError(el => el));
+        }
+
+
+        public static Result<R, E> WithBind<T1, T2, E, R>(this Result<T1, E> a,
+            Result<T2, E> b,
+            Func<T1, T2, Result<R, E>> func, Func<E, E, E> combineError)
+        {
+            var mapSuccess =
+                a.BindError(e1 => b
+                        .MapError(e2 => combineError(e1, e2))
+                        .Bind(_ => Result.Failure<T1, E>(e1)))
+                    .Bind(x => b
+                        .Bind(y => func(x, y))
+                        .MapError(el => el));
+
+            return mapSuccess;
+        }
+    }
+}


### PR DESCRIPTION
These extensions will allow you combine Results.
This is done by combining successful values using a factory + merging errors using a factory

### Example

```
var r1 = Result.Success(1);
var r2 = Result.Success(3);
var combined = r1.With(r2, (x, y) => x + y);
```

combined will contain a success with a value of **4**