### PR TITLE
Docs: Add link to Typescript Functional Extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -571,6 +571,10 @@ result.Should().BeSuccess();
 - [Functional C#: Handling failures, input errors](https://enterprisecraftsmanship.com/2015/03/20/functional-c-handling-failures-input-errors/)
 - [Applying Functional Principles in C# Pluralsight course](https://enterprisecraftsmanship.com/ps-func)
 
+## Related Projects
+
+- [Typescript Functional Extensions](https://github.com/seangwright/typescript-functional-extensions)
+
 ## Contributors
 
 A big thanks to the project contributors!


### PR DESCRIPTION
I like these patterns a lot and I also write a lot of JS/TypeScript in my web apps, so I wanted a way to use the same semantics/patterns in that client-side code.

I've made a new project, [Typescript Functional Extensions](https://github.com/seangwright/typescript-functional-extensions), that I'm hoping is the JS/TS equivalent of this library.

It's still in alpha while I get my tests and documentation written, but I already have quite a bit of feature parity with your library.

I wanted to add a link to the README in case others are also looking for a similar client-side solution (or if anyone wanted to make suggestions or contribute).

---

Some of the big differences in the TypeScript version are from not being able to 'extend' the built in types like you can in C#, specifically Promises. So, instead there are `MaybeAsync` and `ResultAsync` types that have the same API as the sync `Maybe` and `Result` and it's easy enough to from sync to async.

You can begin to see what this looks like [in practice](https://github.com/seangwright/typescript-functional-extensions/blob/2d671972108a5c16426e2556a1a0a5c301dcc022/test/maybe/scenarios.spec.ts#L8).