### PR TITLE
And Compensate extensions and tests for them

### DIFF
--- a/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/CompensateAsyncBothTests.cs
+++ b/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/CompensateAsyncBothTests.cs
@@ -1,0 +1,309 @@
+﻿using System.Threading.Tasks;
+using Xunit;
+
+namespace CSharpFunctionalExtensions.Tests.ResultTests.Extensions
+{
+    public class CompensateAsyncBothTests : CompensateTestsBase
+    {
+        [Fact]
+        public async Task Compensate_returns_success_and_does_not_execute_func()
+        {
+            Task<Result> input = Result.Success().AsTask();
+
+            Result output = await input.Compensate(GetErrorResultAsync);
+
+            AssertSuccess(output, executed: false);
+        }
+
+        [Fact]
+        public async Task Compensate_returns_failure_and_does_not_execute_func()
+        {
+            Task<Result> input = Result.Failure(ErrorMessage).AsTask();
+
+            Result output = await input.Compensate(GetSuccessResultAsync);
+
+            AssertSuccess(output);
+        }
+
+        [Fact]
+        public async Task Compensate_returns_success_and_execute_func()
+        {
+            Task<Result> input = Result.Failure(ErrorMessage).AsTask();
+
+            Result output = await input.Compensate(GetErrorResultAsync);
+
+            AssertFailure(output, executed: true);
+        }
+
+        [Fact]
+        public async Task Compensate_returns_E_success_and_does_not_execute_func()
+        {
+            Task<Result> input = Result.Success().AsTask();
+
+            UnitResult<E> output = await input.Compensate(GetErrorUnitResultAsync);
+
+            AssertSuccess(output, executed: false);
+        }
+
+        [Fact]
+        public async Task Compensate_returns_E_failure_and_does_not_execute_func()
+        {
+            Task<Result> input = Result.Failure(ErrorMessage).AsTask();
+
+            UnitResult<E> output = await input.Compensate(GetSuccessUnitResultAsync);
+
+            AssertSuccess(output);
+        }
+
+        [Fact]
+        public async Task Compensate_returns_E_success_and_execute_func()
+        {
+            Task<Result> input = Result.Failure(ErrorMessage).AsTask();
+
+            UnitResult<E> output = await input.Compensate(GetErrorUnitResultAsync);
+
+            AssertFailure(output, executed: true);
+        }
+
+        [Fact]
+        public async Task Compensate_T_returns_success_and_does_not_execute_func()
+        {
+            Task<Result<T>> input = Result.Success(T.Value).AsTask();
+
+            Result output = await input.Compensate(GetErrorResultAsync);
+
+            AssertSuccess(output, executed: false);
+        }
+
+        [Fact]
+        public async Task Compensate_T_returns_failure_and_does_not_execute_func()
+        {
+            Task<Result<T>> input = Result.Failure<T>(ErrorMessage).AsTask();
+
+            Result output = await input.Compensate(GetSuccessResultAsync);
+
+            AssertSuccess(output);
+        }
+
+        [Fact]
+        public async Task Compensate_T_returns_success_and_execute_func()
+        {
+            Task<Result<T>> input = Result.Failure<T>(ErrorMessage).AsTask();
+
+            Result output = await input.Compensate(GetErrorResultAsync);
+
+            AssertFailure(output, executed: true);
+        }
+
+        [Fact]
+        public async Task Compensate_T_returns_T_success_and_does_not_execute_func()
+        {
+            Task<Result<T>> input = Result.Success(T.Value).AsTask();
+
+            Result<T> output = await input.Compensate(GetErrorValueResultAsync);
+
+            AssertSuccess(output, executed: false);
+        }
+
+        [Fact]
+        public async Task Compensate_T_returns_T_failure_and_does_not_execute_func()
+        {
+            Task<Result<T>> input = Result.Failure<T>(ErrorMessage).AsTask();
+
+            Result<T> output = await input.Compensate(GetSuccessValueResultAsync);
+
+            AssertSuccess(output);
+        }
+
+        [Fact]
+        public async Task Compensate_T_returns_T_success_and_execute_func()
+        {
+            Task<Result<T>> input = Result.Failure<T>(ErrorMessage).AsTask();
+
+            Result<T> output = await input.Compensate(GetErrorValueResultAsync);
+
+            AssertFailure(output, executed: true);
+        }
+
+        [Fact]
+        public async Task Compensate_T_returns_T_E_success_and_does_not_execute_func()
+        {
+            Task<Result<T>> input = Result.Success(T.Value).AsTask();
+
+            Result<T, E> output = await input.Compensate(GetErrorValueErrorResultAsync);
+
+            AssertSuccess(output, executed: false);
+        }
+
+        [Fact]
+        public async Task Compensate_T_returns_T_E_failure_and_does_not_execute_func()
+        {
+            Task<Result<T>> input = Result.Failure<T>(ErrorMessage).AsTask();
+
+            Result<T, E> output = await input.Compensate(GetSuccessValueErrorResultAsync);
+
+            AssertSuccess(output);
+        }
+
+        [Fact]
+        public async Task Compensate_T_returns_T_E_success_and_execute_func()
+        {
+            Task<Result<T>> input = Result.Failure<T>(ErrorMessage).AsTask();
+
+            Result<T, E> output = await input.Compensate(GetErrorValueErrorResultAsync);
+
+            AssertFailure(output, executed: true);
+        }
+
+        [Fact]
+        public async Task Compensate_E_returns_success_and_does_not_execute_func()
+        {
+            Task<UnitResult<E>> input = UnitResult.Success<E>().AsTask();
+
+            Result output = await input.Compensate(GetErrorResultAsync);
+
+            AssertSuccess(output, executed: false);
+        }
+
+        [Fact]
+        public async Task Compensate_E_returns_failure_and_does_not_execute_func()
+        {
+            Task<UnitResult<E>> input = UnitResult.Failure(E.Value).AsTask();
+
+            Result output = await input.Compensate(GetSuccessResultAsync);
+
+            AssertSuccess(output);
+        }
+
+        [Fact]
+        public async Task Compensate_E_returns_success_and_execute_func()
+        {
+            Task<UnitResult<E>> input = UnitResult.Failure(E.Value).AsTask();
+
+            Result output = await input.Compensate(GetErrorResultAsync);
+
+            AssertFailure(output, executed: true);
+        }
+
+        [Fact]
+        public async Task Compensate_E_returns_E2_success_and_does_not_execute_func()
+        {
+            Task<UnitResult<E>> input = UnitResult.Success<E>().AsTask();
+
+            UnitResult<E2> output = await input.Compensate(GetErrorUnitResultAsync);
+
+            AssertSuccess(output, executed: false);
+        }
+
+        [Fact]
+        public async Task Compensate_E_returns_E2_failure_and_does_not_execute_func()
+        {
+            Task<UnitResult<E>> input = UnitResult.Failure(E.Value).AsTask();
+
+            UnitResult<E2> output = await input.Compensate(GetSuccessUnitResultAsync);
+
+            AssertSuccess(output);
+        }
+
+        [Fact]
+        public async Task Compensate_E_returns_E2_success_and_execute_func()
+        {
+            Task<UnitResult<E>> input = UnitResult.Failure(E.Value).AsTask();
+
+            UnitResult<E2> output = await input.Compensate(GetErrorUnitResultAsync);
+
+            AssertFailure(output, executed: true);
+        }
+
+        [Fact]
+        public async Task Compensate_T_E_returns_success_and_does_not_execute_func()
+        {
+            Task<Result<T, E>> input = Result.Success<T, E>(T.Value).AsTask();
+
+            Result output = await input.Compensate(GetErrorResultAsync);
+
+            AssertSuccess(output, executed: false);
+        }
+
+        [Fact]
+        public async Task Compensate_T_E_returns_failure_and_does_not_execute_func()
+        {
+            Task<Result<T, E>> input = Result.Failure<T, E>(E.Value).AsTask();
+
+            Result output = await input.Compensate(GetSuccessResultAsync);
+
+            AssertSuccess(output);
+        }
+
+        [Fact]
+        public async Task Compensate_T_E_returns_success_and_execute_func()
+        {
+            Task<Result<T, E>> input = Result.Failure<T, E>(E.Value).AsTask();
+
+            Result output = await input.Compensate(GetErrorResultAsync);
+
+            AssertFailure(output, executed: true);
+        }
+
+        [Fact]
+        public async Task Compensate_T_E_returns_E2_success_and_does_not_execute_func()
+        {
+            Task<Result<T, E>> input = Result.Success<T, E>(T.Value).AsTask();
+
+            UnitResult<E2> output = await input.Compensate(GetErrorUnitResultAsync);
+
+            AssertSuccess(output, executed: false);
+        }
+
+        [Fact]
+        public async Task Compensate_T_E_returns_E2_failure_and_does_not_execute_func()
+        {
+            Task<Result<T, E>> input = Result.Failure<T, E>(E.Value).AsTask();
+
+            UnitResult<E2> output = await input.Compensate(GetSuccessUnitResultAsync);
+
+            AssertSuccess(output);
+        }
+
+        [Fact]
+        public async Task Compensate_T_E_returns_E2_success_and_execute_func()
+        {
+            Task<Result<T, E>> input = Result.Failure<T, E>(E.Value).AsTask();
+
+            UnitResult<E2> output = await input.Compensate(GetErrorUnitResultAsync);
+
+            AssertFailure(output, executed: true);
+        }
+
+
+        [Fact]
+        public async Task Compensate_T_E_returns_T_E2_success_and_does_not_execute_func()
+        {
+            Task<Result<T, E>> input = Result.Success<T, E>(T.Value).AsTask();
+
+            Result<T, E2> output = await input.Compensate(GetErrorValueErrorResultAsync);
+
+            AssertSuccess(output, executed: false);
+        }
+
+        [Fact]
+        public async Task Compensate_T_E_returns_T_E2_failure_and_does_not_execute_func()
+        {
+            Task<Result<T, E>> input = Result.Failure<T, E>(E.Value).AsTask();
+
+            Result<T, E2> output = await input.Compensate(GetSuccessValueErrorResultAsync);
+
+            AssertSuccess(output);
+        }
+
+        [Fact]
+        public async Task Compensate_T_E_returns_T_E2_success_and_execute_func()
+        {
+            Task<Result<T, E>> input = Result.Failure<T, E>(E.Value).AsTask();
+
+            Result<T, E2> output = await input.Compensate(GetErrorValueErrorResultAsync);
+
+            AssertFailure(output, executed: true);
+        }
+    }
+}

--- a/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/CompensateAsyncLeftTests.cs
+++ b/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/CompensateAsyncLeftTests.cs
@@ -1,0 +1,309 @@
+﻿using System.Threading.Tasks;
+using Xunit;
+
+namespace CSharpFunctionalExtensions.Tests.ResultTests.Extensions
+{
+    public class CompensateAsyncLeftTests : CompensateTestsBase
+    {
+        [Fact]
+        public async Task Compensate_returns_success_and_does_not_execute_func()
+        {
+            Task<Result> input = Result.Success().AsTask();
+
+            Result output = await input.Compensate(GetErrorResult);
+
+            AssertSuccess(output, executed: false);
+        }
+
+        [Fact]
+        public async Task Compensate_returns_failure_and_does_not_execute_func()
+        {
+            Task<Result> input = Result.Failure(ErrorMessage).AsTask();
+
+            Result output = await input.Compensate(GetSuccessResult);
+
+            AssertSuccess(output);
+        }
+
+        [Fact]
+        public async Task Compensate_returns_success_and_execute_func()
+        {
+            Task<Result> input = Result.Failure(ErrorMessage).AsTask();
+
+            Result output = await input.Compensate(GetErrorResult);
+
+            AssertFailure(output, executed: true);
+        }
+
+        [Fact]
+        public async Task Compensate_returns_E_success_and_does_not_execute_func()
+        {
+            Task<Result> input = Result.Success().AsTask();
+
+            UnitResult<E> output = await input.Compensate(GetErrorUnitResult);
+
+            AssertSuccess(output, executed: false);
+        }
+
+        [Fact]
+        public async Task Compensate_returns_E_failure_and_does_not_execute_func()
+        {
+            Task<Result> input = Result.Failure(ErrorMessage).AsTask();
+
+            UnitResult<E> output = await input.Compensate(GetSuccessUnitResult);
+
+            AssertSuccess(output);
+        }
+
+        [Fact]
+        public async Task Compensate_returns_E_success_and_execute_func()
+        {
+            Task<Result> input = Result.Failure(ErrorMessage).AsTask();
+
+            UnitResult<E> output = await input.Compensate(GetErrorUnitResult);
+
+            AssertFailure(output, executed: true);
+        }
+
+        [Fact]
+        public async Task Compensate_T_returns_success_and_does_not_execute_func()
+        {
+            Task<Result<T>> input = Result.Success(T.Value).AsTask();
+
+            Result output = await input.Compensate(GetErrorResult);
+
+            AssertSuccess(output, executed: false);
+        }
+
+        [Fact]
+        public async Task Compensate_T_returns_failure_and_does_not_execute_func()
+        {
+            Task<Result<T>> input = Result.Failure<T>(ErrorMessage).AsTask();
+
+            Result output = await input.Compensate(GetSuccessResult);
+
+            AssertSuccess(output);
+        }
+
+        [Fact]
+        public async Task Compensate_T_returns_success_and_execute_func()
+        {
+            Task<Result<T>> input = Result.Failure<T>(ErrorMessage).AsTask();
+
+            Result output = await input.Compensate(GetErrorResult);
+
+            AssertFailure(output, executed: true);
+        }
+
+        [Fact]
+        public async Task Compensate_T_returns_T_success_and_does_not_execute_func()
+        {
+            Task<Result<T>> input = Result.Success(T.Value).AsTask();
+
+            Result<T> output = await input.Compensate(GetErrorValueResult);
+
+            AssertSuccess(output, executed: false);
+        }
+
+        [Fact]
+        public async Task Compensate_T_returns_T_failure_and_does_not_execute_func()
+        {
+            Task<Result<T>> input = Result.Failure<T>(ErrorMessage).AsTask();
+
+            Result<T> output = await input.Compensate(GetSuccessValueResult);
+
+            AssertSuccess(output);
+        }
+
+        [Fact]
+        public async Task Compensate_T_returns_T_success_and_execute_func()
+        {
+            Task<Result<T>> input = Result.Failure<T>(ErrorMessage).AsTask();
+
+            Result<T> output = await input.Compensate(GetErrorValueResult);
+
+            AssertFailure(output, executed: true);
+        }
+
+        [Fact]
+        public async Task Compensate_T_returns_T_E_success_and_does_not_execute_func()
+        {
+            Task<Result<T>> input = Result.Success(T.Value).AsTask();
+
+            Result<T, E> output = await input.Compensate(GetErrorValueErrorResult);
+
+            AssertSuccess(output, executed: false);
+        }
+
+        [Fact]
+        public async Task Compensate_T_returns_T_E_failure_and_does_not_execute_func()
+        {
+            Task<Result<T>> input = Result.Failure<T>(ErrorMessage).AsTask();
+
+            Result<T, E> output = await input.Compensate(GetSuccessValueErrorResult);
+
+            AssertSuccess(output);
+        }
+
+        [Fact]
+        public async Task Compensate_T_returns_T_E_success_and_execute_func()
+        {
+            Task<Result<T>> input = Result.Failure<T>(ErrorMessage).AsTask();
+
+            Result<T, E> output = await input.Compensate(GetErrorValueErrorResult);
+
+            AssertFailure(output, executed: true);
+        }
+
+        [Fact]
+        public async Task Compensate_E_returns_success_and_does_not_execute_func()
+        {
+            Task<UnitResult<E>> input = UnitResult.Success<E>().AsTask();
+
+            Result output = await input.Compensate(GetErrorResult);
+
+            AssertSuccess(output, executed: false);
+        }
+
+        [Fact]
+        public async Task Compensate_E_returns_failure_and_does_not_execute_func()
+        {
+            Task<UnitResult<E>> input = UnitResult.Failure(E.Value).AsTask();
+
+            Result output = await input.Compensate(GetSuccessResult);
+
+            AssertSuccess(output);
+        }
+
+        [Fact]
+        public async Task Compensate_E_returns_success_and_execute_func()
+        {
+            Task<UnitResult<E>> input = UnitResult.Failure(E.Value).AsTask();
+
+            Result output = await input.Compensate(GetErrorResult);
+
+            AssertFailure(output, executed: true);
+        }
+
+        [Fact]
+        public async Task Compensate_E_returns_E2_success_and_does_not_execute_func()
+        {
+            Task<UnitResult<E>> input = UnitResult.Success<E>().AsTask();
+
+            UnitResult<E2> output = await input.Compensate(GetErrorUnitResult);
+
+            AssertSuccess(output, executed: false);
+        }
+
+        [Fact]
+        public async Task Compensate_E_returns_E2_failure_and_does_not_execute_func()
+        {
+            Task<UnitResult<E>> input = UnitResult.Failure(E.Value).AsTask();
+
+            UnitResult<E2> output = await input.Compensate(GetSuccessUnitResult);
+
+            AssertSuccess(output);
+        }
+
+        [Fact]
+        public async Task Compensate_E_returns_E2_success_and_execute_func()
+        {
+            Task<UnitResult<E>> input = UnitResult.Failure(E.Value).AsTask();
+
+            UnitResult<E2> output = await input.Compensate(GetErrorUnitResult);
+
+            AssertFailure(output, executed: true);
+        }
+
+        [Fact]
+        public async Task Compensate_T_E_returns_success_and_does_not_execute_func()
+        {
+            Task<Result<T, E>> input = Result.Success<T, E>(T.Value).AsTask();
+
+            Result output = await input.Compensate(GetErrorResult);
+
+            AssertSuccess(output, executed: false);
+        }
+
+        [Fact]
+        public async Task Compensate_T_E_returns_failure_and_does_not_execute_func()
+        {
+            Task<Result<T, E>> input = Result.Failure<T, E>(E.Value).AsTask();
+
+            Result output = await input.Compensate(GetSuccessResult);
+
+            AssertSuccess(output);
+        }
+
+        [Fact]
+        public async Task Compensate_T_E_returns_success_and_execute_func()
+        {
+            Task<Result<T, E>> input = Result.Failure<T, E>(E.Value).AsTask();
+
+            Result output = await input.Compensate(GetErrorResult);
+
+            AssertFailure(output, executed: true);
+        }
+
+        [Fact]
+        public async Task Compensate_T_E_returns_E2_success_and_does_not_execute_func()
+        {
+            Task<Result<T, E>> input = Result.Success<T, E>(T.Value).AsTask();
+
+            UnitResult<E2> output = await input.Compensate(GetErrorUnitResult);
+
+            AssertSuccess(output, executed: false);
+        }
+
+        [Fact]
+        public async Task Compensate_T_E_returns_E2_failure_and_does_not_execute_func()
+        {
+            Task<Result<T, E>> input = Result.Failure<T, E>(E.Value).AsTask();
+
+            UnitResult<E2> output = await input.Compensate(GetSuccessUnitResult);
+
+            AssertSuccess(output);
+        }
+
+        [Fact]
+        public async Task Compensate_T_E_returns_E2_success_and_execute_func()
+        {
+            Task<Result<T, E>> input = Result.Failure<T, E>(E.Value).AsTask();
+
+            UnitResult<E2> output = await input.Compensate(GetErrorUnitResult);
+
+            AssertFailure(output, executed: true);
+        }
+
+
+        [Fact]
+        public async Task Compensate_T_E_returns_T_E2_success_and_does_not_execute_func()
+        {
+            Task<Result<T, E>> input = Result.Success<T, E>(T.Value).AsTask();
+
+            Result<T, E2> output = await input.Compensate(GetErrorValueErrorResult);
+
+            AssertSuccess(output, executed: false);
+        }
+
+        [Fact]
+        public async Task Compensate_T_E_returns_T_E2_failure_and_does_not_execute_func()
+        {
+            Task<Result<T, E>> input = Result.Failure<T, E>(E.Value).AsTask();
+
+            Result<T, E2> output = await input.Compensate(GetSuccessValueErrorResult);
+
+            AssertSuccess(output);
+        }
+
+        [Fact]
+        public async Task Compensate_T_E_returns_T_E2_success_and_execute_func()
+        {
+            Task<Result<T, E>> input = Result.Failure<T, E>(E.Value).AsTask();
+
+            Result<T, E2> output = await input.Compensate(GetErrorValueErrorResult);
+
+            AssertFailure(output, executed: true);
+        }
+    }
+}

--- a/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/CompensateAsyncRightTests.cs
+++ b/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/CompensateAsyncRightTests.cs
@@ -1,0 +1,309 @@
+﻿using System.Threading.Tasks;
+using Xunit;
+
+namespace CSharpFunctionalExtensions.Tests.ResultTests.Extensions
+{
+    public class CompensateAsyncRightTests : CompensateTestsBase
+    {
+        [Fact]
+        public async Task Compensate_returns_success_and_does_not_execute_func()
+        {
+            Result input = Result.Success();
+
+            Result output = await input.Compensate(GetErrorResultAsync);
+
+            AssertSuccess(output, executed: false);
+        }
+
+        [Fact]
+        public async Task Compensate_returns_failure_and_does_not_execute_func()
+        {
+            Result input = Result.Failure(ErrorMessage);
+
+            Result output = await input.Compensate(GetSuccessResultAsync);
+
+            AssertSuccess(output);
+        }
+
+        [Fact]
+        public async Task Compensate_returns_success_and_execute_func()
+        {
+            Result input = Result.Failure(ErrorMessage);
+
+            Result output = await input.Compensate(GetErrorResultAsync);
+
+            AssertFailure(output, executed: true);
+        }
+
+        [Fact]
+        public async Task Compensate_returns_E_success_and_does_not_execute_func()
+        {
+            Result input = Result.Success();
+
+            UnitResult<E> output = await input.Compensate(GetErrorUnitResultAsync);
+
+            AssertSuccess(output, executed: false);
+        }
+
+        [Fact]
+        public async Task Compensate_returns_E_failure_and_does_not_execute_func()
+        {
+            Result input = Result.Failure(ErrorMessage);
+
+            UnitResult<E> output = await input.Compensate(GetSuccessUnitResultAsync);
+
+            AssertSuccess(output);
+        }
+
+        [Fact]
+        public async Task Compensate_returns_E_success_and_execute_func()
+        {
+            Result input = Result.Failure(ErrorMessage);
+
+            UnitResult<E> output = await input.Compensate(GetErrorUnitResultAsync);
+
+            AssertFailure(output, executed: true);
+        }
+
+        [Fact]
+        public async Task Compensate_T_returns_success_and_does_not_execute_func()
+        {
+            Result<T> input = Result.Success(T.Value);
+
+            Result output = await input.Compensate(GetErrorResultAsync);
+
+            AssertSuccess(output, executed: false);
+        }
+
+        [Fact]
+        public async Task Compensate_T_returns_failure_and_does_not_execute_func()
+        {
+            Result<T> input = Result.Failure<T>(ErrorMessage);
+
+            Result output = await input.Compensate(GetSuccessResultAsync);
+
+            AssertSuccess(output);
+        }
+
+        [Fact]
+        public async Task Compensate_T_returns_success_and_execute_func()
+        {
+            Result<T> input = Result.Failure<T>(ErrorMessage);
+
+            Result output = await input.Compensate(GetErrorResultAsync);
+
+            AssertFailure(output, executed: true);
+        }
+
+        [Fact]
+        public async Task Compensate_T_returns_T_success_and_does_not_execute_func()
+        {
+            Result<T> input = Result.Success(T.Value);
+
+            Result<T> output = await input.Compensate(GetErrorValueResultAsync);
+
+            AssertSuccess(output, executed: false);
+        }
+
+        [Fact]
+        public async Task Compensate_T_returns_T_failure_and_does_not_execute_func()
+        {
+            Result<T> input = Result.Failure<T>(ErrorMessage);
+
+            Result<T> output = await input.Compensate(GetSuccessValueResultAsync);
+
+            AssertSuccess(output);
+        }
+
+        [Fact]
+        public async Task Compensate_T_returns_T_success_and_execute_func()
+        {
+            Result<T> input = Result.Failure<T>(ErrorMessage);
+
+            Result<T> output = await input.Compensate(GetErrorValueResultAsync);
+
+            AssertFailure(output, executed: true);
+        }
+
+        [Fact]
+        public async Task Compensate_T_returns_T_E_success_and_does_not_execute_func()
+        {
+            Result<T> input = Result.Success(T.Value);
+
+            Result<T, E> output = await input.Compensate(GetErrorValueErrorResultAsync);
+
+            AssertSuccess(output, executed: false);
+        }
+
+        [Fact]
+        public async Task Compensate_T_returns_T_E_failure_and_does_not_execute_func()
+        {
+            Result<T> input = Result.Failure<T>(ErrorMessage);
+
+            Result<T, E> output = await input.Compensate(GetSuccessValueErrorResultAsync);
+
+            AssertSuccess(output);
+        }
+
+        [Fact]
+        public async Task Compensate_T_returns_T_E_success_and_execute_func()
+        {
+            Result<T> input = Result.Failure<T>(ErrorMessage);
+
+            Result<T, E> output = await input.Compensate(GetErrorValueErrorResultAsync);
+
+            AssertFailure(output, executed: true);
+        }
+
+        [Fact]
+        public async Task Compensate_E_returns_success_and_does_not_execute_func()
+        {
+            UnitResult<E> input = UnitResult.Success<E>();
+
+            Result output = await input.Compensate(GetErrorResultAsync);
+
+            AssertSuccess(output, executed: false);
+        }
+
+        [Fact]
+        public async Task Compensate_E_returns_failure_and_does_not_execute_func()
+        {
+            UnitResult<E> input = UnitResult.Failure(E.Value);
+
+            Result output = await input.Compensate(GetSuccessResultAsync);
+
+            AssertSuccess(output);
+        }
+
+        [Fact]
+        public async Task Compensate_E_returns_success_and_execute_func()
+        {
+            UnitResult<E> input = UnitResult.Failure(E.Value);
+
+            Result output = await input.Compensate(GetErrorResultAsync);
+
+            AssertFailure(output, executed: true);
+        }
+
+        [Fact]
+        public async Task Compensate_E_returns_E2_success_and_does_not_execute_func()
+        {
+            UnitResult<E> input = UnitResult.Success<E>();
+
+            UnitResult<E2> output = await input.Compensate(GetErrorUnitResultAsync);
+
+            AssertSuccess(output, executed: false);
+        }
+
+        [Fact]
+        public async Task Compensate_E_returns_E2_failure_and_does_not_execute_func()
+        {
+            UnitResult<E> input = UnitResult.Failure(E.Value);
+
+            UnitResult<E2> output = await input.Compensate(GetSuccessUnitResultAsync);
+
+            AssertSuccess(output);
+        }
+
+        [Fact]
+        public async Task Compensate_E_returns_E2_success_and_execute_func()
+        {
+            UnitResult<E> input = UnitResult.Failure(E.Value);
+
+            UnitResult<E2> output = await input.Compensate(GetErrorUnitResultAsync);
+
+            AssertFailure(output, executed: true);
+        }
+
+        [Fact]
+        public async Task Compensate_T_E_returns_success_and_does_not_execute_func()
+        {
+            Result<T, E> input = Result.Success<T, E>(T.Value);
+
+            Result output = await input.Compensate(GetErrorResultAsync);
+
+            AssertSuccess(output, executed: false);
+        }
+
+        [Fact]
+        public async Task Compensate_T_E_returns_failure_and_does_not_execute_func()
+        {
+            Result<T, E> input = Result.Failure<T, E>(E.Value);
+
+            Result output = await input.Compensate(GetSuccessResultAsync);
+
+            AssertSuccess(output);
+        }
+
+        [Fact]
+        public async Task Compensate_T_E_returns_success_and_execute_func()
+        {
+            Result<T, E> input = Result.Failure<T, E>(E.Value);
+
+            Result output = await input.Compensate(GetErrorResultAsync);
+
+            AssertFailure(output, executed: true);
+        }
+
+        [Fact]
+        public async Task Compensate_T_E_returns_E2_success_and_does_not_execute_func()
+        {
+            Result<T, E> input = Result.Success<T, E>(T.Value);
+
+            UnitResult<E2> output = await input.Compensate(GetErrorUnitResultAsync);
+
+            AssertSuccess(output, executed: false);
+        }
+
+        [Fact]
+        public async Task Compensate_T_E_returns_E2_failure_and_does_not_execute_func()
+        {
+            Result<T, E> input = Result.Failure<T, E>(E.Value);
+
+            UnitResult<E2> output = await input.Compensate(GetSuccessUnitResultAsync);
+
+            AssertSuccess(output);
+        }
+
+        [Fact]
+        public async Task Compensate_T_E_returns_E2_success_and_execute_func()
+        {
+            Result<T, E> input = Result.Failure<T, E>(E.Value);
+
+            UnitResult<E2> output = await input.Compensate(GetErrorUnitResultAsync);
+
+            AssertFailure(output, executed: true);
+        }
+
+
+        [Fact]
+        public async Task Compensate_T_E_returns_T_E2_success_and_does_not_execute_func()
+        {
+            Result<T, E> input = Result.Success<T, E>(T.Value);
+
+            Result<T, E2> output = await input.Compensate(GetErrorValueErrorResultAsync);
+
+            AssertSuccess(output, executed: false);
+        }
+
+        [Fact]
+        public async Task Compensate_T_E_returns_T_E2_failure_and_does_not_execute_func()
+        {
+            Result<T, E> input = Result.Failure<T, E>(E.Value);
+
+            Result<T, E2> output = await input.Compensate(GetSuccessValueErrorResultAsync);
+
+            AssertSuccess(output);
+        }
+
+        [Fact]
+        public async Task Compensate_T_E_returns_T_E2_success_and_execute_func()
+        {
+            Result<T, E> input = Result.Failure<T, E>(E.Value);
+
+            Result<T, E2> output = await input.Compensate(GetErrorValueErrorResultAsync);
+
+            AssertFailure(output, executed: true);
+        }
+    }
+}

--- a/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/CompensateTests.cs
+++ b/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/CompensateTests.cs
@@ -1,0 +1,308 @@
+﻿using Xunit;
+
+namespace CSharpFunctionalExtensions.Tests.ResultTests.Extensions
+{
+    public class CompensateTests : CompensateTestsBase
+    {
+        [Fact]
+        public void Compensate_returns_success_and_does_not_execute_func()
+        {
+            Result input = Result.Success();
+
+            Result output = input.Compensate(GetErrorResult);
+
+            AssertSuccess(output, executed: false);
+        }
+
+        [Fact]
+        public void Compensate_returns_failure_and_does_not_execute_func()
+        {
+            Result input = Result.Failure(ErrorMessage);
+
+            Result output = input.Compensate(GetSuccessResult);
+
+            AssertSuccess(output);
+        }
+
+        [Fact]
+        public void Compensate_returns_success_and_execute_func()
+        {
+            Result input = Result.Failure(ErrorMessage);
+
+            Result output = input.Compensate(GetErrorResult);
+
+            AssertFailure(output, executed: true);
+        }
+
+        [Fact]
+        public void Compensate_returns_E_success_and_does_not_execute_func()
+        {
+            Result input = Result.Success();
+
+            UnitResult<E> output = input.Compensate(GetErrorUnitResult);
+
+            AssertSuccess(output, executed: false);
+        }
+
+        [Fact]
+        public void Compensate_returns_E_failure_and_does_not_execute_func()
+        {
+            Result input = Result.Failure(ErrorMessage);
+
+            UnitResult<E> output = input.Compensate(GetSuccessUnitResult);
+
+            AssertSuccess(output);
+        }
+
+        [Fact]
+        public void Compensate_returns_E_success_and_execute_func()
+        {
+            Result input = Result.Failure(ErrorMessage);
+
+            UnitResult<E> output = input.Compensate(GetErrorUnitResult);
+
+            AssertFailure(output, executed: true);
+        }
+
+        [Fact]
+        public void Compensate_T_returns_success_and_does_not_execute_func()
+        {
+            Result<T> input = Result.Success(T.Value);
+
+            Result output = input.Compensate(GetErrorResult);
+
+            AssertSuccess(output, executed: false);
+        }
+
+        [Fact]
+        public void Compensate_T_returns_failure_and_does_not_execute_func()
+        {
+            Result<T> input = Result.Failure<T>(ErrorMessage);
+
+            Result output = input.Compensate(GetSuccessResult);
+
+            AssertSuccess(output);
+        }
+
+        [Fact]
+        public void Compensate_T_returns_success_and_execute_func()
+        {
+            Result<T> input = Result.Failure<T>(ErrorMessage);
+
+            Result output = input.Compensate(GetErrorResult);
+
+            AssertFailure(output, executed: true);
+        }
+
+        [Fact]
+        public void Compensate_T_returns_T_success_and_does_not_execute_func()
+        {
+            Result<T> input = Result.Success(T.Value);
+
+            Result<T> output = input.Compensate(GetErrorValueResult);
+
+            AssertSuccess(output, executed: false);
+        }
+
+        [Fact]
+        public void Compensate_T_returns_T_failure_and_does_not_execute_func()
+        {
+            Result<T> input = Result.Failure<T>(ErrorMessage);
+
+            Result<T> output = input.Compensate(GetSuccessValueResult);
+
+            AssertSuccess(output);
+        }
+
+        [Fact]
+        public void Compensate_T_returns_T_success_and_execute_func()
+        {
+            Result<T> input = Result.Failure<T>(ErrorMessage);
+
+            Result<T> output = input.Compensate(GetErrorValueResult);
+
+            AssertFailure(output, executed: true);
+        }
+
+        [Fact]
+        public void Compensate_T_returns_T_E_success_and_does_not_execute_func()
+        {
+            Result<T> input = Result.Success(T.Value);
+
+            Result<T, E> output = input.Compensate(GetErrorValueErrorResult);
+
+            AssertSuccess(output, executed: false);
+        }
+
+        [Fact]
+        public void Compensate_T_returns_T_E_failure_and_does_not_execute_func()
+        {
+            Result<T> input = Result.Failure<T>(ErrorMessage);
+
+            Result<T, E> output = input.Compensate(GetSuccessValueErrorResult);
+
+            AssertSuccess(output);
+        }
+
+        [Fact]
+        public void Compensate_T_returns_T_E_success_and_execute_func()
+        {
+            Result<T> input = Result.Failure<T>(ErrorMessage);
+
+            Result<T, E> output = input.Compensate(GetErrorValueErrorResult);
+
+            AssertFailure(output, executed: true);
+        }
+
+        [Fact]
+        public void Compensate_E_returns_success_and_does_not_execute_func()
+        {
+            UnitResult<E> input = UnitResult.Success<E>();
+
+            Result output = input.Compensate(GetErrorResult);
+
+            AssertSuccess(output, executed: false);
+        }
+
+        [Fact]
+        public void Compensate_E_returns_failure_and_does_not_execute_func()
+        {
+            UnitResult<E> input = UnitResult.Failure(E.Value);
+
+            Result output = input.Compensate(GetSuccessResult);
+
+            AssertSuccess(output);
+        }
+
+        [Fact]
+        public void Compensate_E_returns_success_and_execute_func()
+        {
+            UnitResult<E> input = UnitResult.Failure(E.Value);
+
+            Result output = input.Compensate(GetErrorResult);
+
+            AssertFailure(output, executed: true);
+        }
+
+        [Fact]
+        public void Compensate_E_returns_E2_success_and_does_not_execute_func()
+        {
+            UnitResult<E> input = UnitResult.Success<E>();
+
+            UnitResult<E2> output = input.Compensate(GetErrorUnitResult);
+
+            AssertSuccess(output, executed: false);
+        }
+
+        [Fact]
+        public void Compensate_E_returns_E2_failure_and_does_not_execute_func()
+        {
+            UnitResult<E> input = UnitResult.Failure(E.Value);
+
+            UnitResult<E2> output = input.Compensate(GetSuccessUnitResult);
+
+            AssertSuccess(output);
+        }
+
+        [Fact]
+        public void Compensate_E_returns_E2_success_and_execute_func()
+        {
+            UnitResult<E> input = UnitResult.Failure(E.Value);
+
+            UnitResult<E2> output = input.Compensate(GetErrorUnitResult);
+
+            AssertFailure(output, executed: true);
+        }
+
+        [Fact]
+        public void Compensate_T_E_returns_success_and_does_not_execute_func()
+        {
+            Result<T, E> input = Result.Success<T, E>(T.Value);
+
+            Result output = input.Compensate(GetErrorResult);
+
+            AssertSuccess(output, executed: false);
+        }
+
+        [Fact]
+        public void Compensate_T_E_returns_failure_and_does_not_execute_func()
+        {
+            Result<T, E> input = Result.Failure<T, E>(E.Value);
+
+            Result output = input.Compensate(GetSuccessResult);
+
+            AssertSuccess(output);
+        }
+
+        [Fact]
+        public void Compensate_T_E_returns_success_and_execute_func()
+        {
+            Result<T, E> input = Result.Failure<T, E>(E.Value);
+
+            Result output = input.Compensate(GetErrorResult);
+
+            AssertFailure(output, executed: true);
+        }
+
+        [Fact]
+        public void Compensate_T_E_returns_E2_success_and_does_not_execute_func()
+        {
+            Result<T, E> input = Result.Success<T, E>(T.Value);
+
+            UnitResult<E2> output = input.Compensate(GetErrorUnitResult);
+
+            AssertSuccess(output, executed: false);
+        }
+
+        [Fact]
+        public void Compensate_T_E_returns_E2_failure_and_does_not_execute_func()
+        {
+            Result<T, E> input = Result.Failure<T, E>(E.Value);
+
+            UnitResult<E2> output = input.Compensate(GetSuccessUnitResult);
+
+            AssertSuccess(output);
+        }
+
+        [Fact]
+        public void Compensate_T_E_returns_E2_success_and_execute_func()
+        {
+            Result<T, E> input = Result.Failure<T, E>(E.Value);
+
+            UnitResult<E2> output = input.Compensate(GetErrorUnitResult);
+
+            AssertFailure(output, executed: true);
+        }
+
+
+        [Fact]
+        public void Compensate_T_E_returns_T_E2_success_and_does_not_execute_func()
+        {
+            Result<T, E> input = Result.Success<T, E>(T.Value);
+
+            Result<T, E2> output = input.Compensate(GetErrorValueErrorResult);
+
+            AssertSuccess(output, executed: false);
+        }
+
+        [Fact]
+        public void Compensate_T_E_returns_T_E2_failure_and_does_not_execute_func()
+        {
+            Result<T, E> input = Result.Failure<T, E>(E.Value);
+
+            Result<T, E2> output = input.Compensate(GetSuccessValueErrorResult);
+
+            AssertSuccess(output);
+        }
+
+        [Fact]
+        public void Compensate_T_E_returns_T_E2_success_and_execute_func()
+        {
+            Result<T, E> input = Result.Failure<T, E>(E.Value);
+
+            Result<T, E2> output = input.Compensate(GetErrorValueErrorResult);
+
+            AssertFailure(output, executed: true);
+        }
+    }
+}

--- a/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/CompensateTestsBase.cs
+++ b/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/CompensateTestsBase.cs
@@ -1,0 +1,222 @@
+﻿using FluentAssertions;
+using System.Threading.Tasks;
+
+namespace CSharpFunctionalExtensions.Tests.ResultTests.Extensions
+{
+    public abstract class CompensateTestsBase : TestBase
+    {
+        protected bool funcExecuted;
+
+        protected CompensateTestsBase()
+        {
+            funcExecuted = false;
+        }
+
+        protected Result GetSuccessResult(string _)
+        {
+            funcExecuted.Should().BeFalse();
+
+            funcExecuted = true;
+            return Result.Success();
+        }
+
+        protected Result GetErrorResult(string error)
+        {
+            funcExecuted.Should().BeFalse();
+
+            funcExecuted = true;
+            return Result.Failure(error);
+        }
+
+        protected Result GetSuccessResult(E _)
+        {
+            funcExecuted.Should().BeFalse();
+
+            funcExecuted = true;
+            return Result.Success();
+        }
+
+        protected Result GetErrorResult(E error)
+        {
+            funcExecuted.Should().BeFalse();
+
+            funcExecuted = true;
+            return Result.Failure(ErrorMessage);
+        }
+
+        protected UnitResult<E> GetSuccessUnitResult(string _)
+        {
+            funcExecuted.Should().BeFalse();
+
+            funcExecuted = true;
+            return UnitResult.Success<E>();
+        }
+
+        protected UnitResult<E> GetErrorUnitResult(string _)
+        {
+            funcExecuted.Should().BeFalse();
+
+            funcExecuted = true;
+            return UnitResult.Failure(E.Value);
+        }
+
+        protected UnitResult<E2> GetSuccessUnitResult(E _)
+        {
+            funcExecuted.Should().BeFalse();
+
+            funcExecuted = true;
+            return UnitResult.Success<E2>();
+        }
+
+        protected UnitResult<E2> GetErrorUnitResult(E _)
+        {
+            funcExecuted.Should().BeFalse();
+
+            funcExecuted = true;
+            return UnitResult.Failure(E2.Value);
+        }
+
+        protected Result<T> GetSuccessValueResult(string _)
+        {
+            funcExecuted.Should().BeFalse();
+
+            funcExecuted = true;
+            return Result.Success(T.Value);
+        }
+
+        protected Result<T> GetErrorValueResult(string error)
+        {
+            funcExecuted.Should().BeFalse();
+
+            funcExecuted = true;
+            return Result.Failure<T>(error);
+        }
+
+        protected Result<T, E> GetSuccessValueErrorResult(string _)
+        {
+            funcExecuted.Should().BeFalse();
+
+            funcExecuted = true;
+            return Result.Success<T, E>(T.Value);
+        }
+
+        protected Result<T, E> GetErrorValueErrorResult(string _)
+        {
+            funcExecuted.Should().BeFalse();
+
+            funcExecuted = true;
+            return Result.Failure<T, E>(E.Value);
+        }
+
+        protected Result<T, E2> GetSuccessValueErrorResult(E _)
+        {
+            funcExecuted.Should().BeFalse();
+
+            funcExecuted = true;
+            return Result.Success<T, E2>(T.Value);
+        }
+
+        protected Result<T, E2> GetErrorValueErrorResult(E _)
+        {
+            funcExecuted.Should().BeFalse();
+
+            funcExecuted = true;
+            return Result.Failure<T, E2>(E2.Value);
+        }
+
+        protected Task<Result> GetSuccessResultAsync(string error) => GetSuccessResult(error).AsTask();
+
+        protected Task<Result> GetErrorResultAsync(string error) => GetErrorResult(error).AsTask();
+
+        protected Task<Result> GetSuccessResultAsync(E error) => GetSuccessResult(error).AsTask();
+
+        protected Task<Result> GetErrorResultAsync(E error) => GetErrorResult(error).AsTask();
+
+        protected Task<UnitResult<E>> GetSuccessUnitResultAsync(string error) => GetSuccessUnitResult(error).AsTask();
+
+        protected Task<UnitResult<E>> GetErrorUnitResultAsync(string error) => GetErrorUnitResult(error).AsTask();
+
+        protected Task<UnitResult<E2>> GetSuccessUnitResultAsync(E error) => GetSuccessUnitResult(error).AsTask();
+
+        protected Task<UnitResult<E2>> GetErrorUnitResultAsync(E error) => GetErrorUnitResult(error).AsTask();
+
+        protected Task<Result<T>> GetSuccessValueResultAsync(string error) => GetSuccessValueResult(error).AsTask();
+
+        protected Task<Result<T>> GetErrorValueResultAsync(string error) => GetErrorValueResult(error).AsTask();
+
+        protected Task<Result<T, E>> GetSuccessValueErrorResultAsync(string error) => GetSuccessValueErrorResult(error).AsTask();
+
+        protected Task<Result<T, E>> GetErrorValueErrorResultAsync(string error) => GetErrorValueErrorResult(error).AsTask();
+
+        protected Task<Result<T, E2>> GetSuccessValueErrorResultAsync(E error) => GetSuccessValueErrorResult(error).AsTask();
+
+        protected Task<Result<T, E2>> GetErrorValueErrorResultAsync(E error) => GetErrorValueErrorResult(error).AsTask();
+
+        protected void AssertFailure(Result output, bool executed = false)
+        {
+            funcExecuted.Should().Be(executed);
+            output.IsFailure.Should().BeTrue();
+            output.Error.Should().Be(ErrorMessage);
+        }
+
+        protected void AssertFailure(Result<K> output, bool executed = false)
+        {
+            funcExecuted.Should().Be(executed);
+            output.IsFailure.Should().BeTrue();
+            output.Error.Should().Be(ErrorMessage);
+        }
+
+        protected void AssertFailure(Result<K, E> output, bool executed = false)
+        {
+            funcExecuted.Should().Be(executed);
+            output.IsFailure.Should().BeTrue();
+            output.Error.Should().Be(E.Value);
+        }
+
+        protected void AssertFailure(UnitResult<E> output, bool executed = false)
+        {
+            funcExecuted.Should().Be(executed);
+            output.IsFailure.Should().BeTrue();
+            output.Error.Should().Be(E.Value);
+        }
+
+        protected void AssertFailure(UnitResult<E2> output, bool executed = false)
+        {
+            funcExecuted.Should().Be(executed);
+            output.IsFailure.Should().BeTrue();
+            output.Error.Should().Be(E2.Value);
+        }
+
+        protected void AssertSuccess(Result output, bool executed = true)
+        {
+            funcExecuted.Should().Be(executed);
+            output.IsSuccess.Should().BeTrue();
+        }
+
+        protected void AssertSuccess(Result<K> output, bool executed = true)
+        {
+            funcExecuted.Should().Be(executed);
+            output.IsSuccess.Should().BeTrue();
+            output.Value.Should().Be(K.Value);
+        }
+
+        protected void AssertSuccess(Result<K, E> output, bool executed = true)
+        {
+            funcExecuted.Should().Be(executed);
+            output.IsSuccess.Should().BeTrue();
+            output.Value.Should().Be(K.Value);
+        }
+
+        protected void AssertSuccess(UnitResult<E> output, bool executed = true)
+        {
+            funcExecuted.Should().Be(executed);
+            output.IsSuccess.Should().BeTrue();
+        }
+
+        protected void AssertSuccess(UnitResult<E2> output, bool executed = true)
+        {
+            funcExecuted.Should().Be(executed);
+            output.IsSuccess.Should().BeTrue();
+        }
+    }
+}

--- a/CSharpFunctionalExtensions/Result/Extensions/Compensate.cs
+++ b/CSharpFunctionalExtensions/Result/Extensions/Compensate.cs
@@ -1,0 +1,107 @@
+using System;
+
+namespace CSharpFunctionalExtensions
+{
+    public static partial class ResultExtensions
+    {
+        public static Result Compensate(this Result result, Func<string, Result> func)
+        {
+            if (result.IsSuccess)
+            {
+                return Result.Success();
+            }
+
+            return func(result.Error);
+        }
+
+        public static UnitResult<E> Compensate<E>(this Result result, Func<string, UnitResult<E>> func)
+        {
+            if (result.IsSuccess)
+            {
+                return UnitResult.Success<E>();
+            }
+
+            return func(result.Error);
+        }
+
+        public static Result Compensate<T>(this Result<T> result, Func<string, Result> func)
+        {
+            if (result.IsSuccess)
+            {
+                return Result.Success();
+            }
+
+            return func(result.Error);
+        }
+
+        public static Result<T> Compensate<T>(this Result<T> result, Func<string, Result<T>> func)
+        {
+            if (result.IsSuccess)
+            {
+                return Result.Success(result.Value);
+            }
+
+            return func(result.Error);
+        }
+
+        public static Result<T, E> Compensate<T, E>(this Result<T> result, Func<string, Result<T, E>> func)
+        {
+            if (result.IsSuccess)
+            {
+                return Result.Success<T, E>(result.Value);
+            }
+
+            return func(result.Error);
+        }
+
+        public static Result Compensate<E>(this UnitResult<E> result, Func<E, Result> func)
+        {
+            if (result.IsSuccess)
+            {
+                return Result.Success();
+            }
+
+            return func(result.Error);
+        }
+
+        public static UnitResult<E2> Compensate<E, E2>(this UnitResult<E> result, Func<E, UnitResult<E2>> func)
+        {
+            if (result.IsSuccess)
+            {
+                return UnitResult.Success<E2>();
+            }
+
+            return func(result.Error);
+        }
+
+        public static Result Compensate<T, E>(this Result<T, E> result, Func<E, Result> func)
+        {
+            if (result.IsSuccess)
+            {
+                return Result.Success();
+            }
+
+            return func(result.Error);
+        }
+
+        public static UnitResult<E2> Compensate<T, E, E2>(this Result<T, E> result, Func<E, UnitResult<E2>> func)
+        {
+            if (result.IsSuccess)
+            {
+                return UnitResult.Success<E2>();
+            }
+
+            return func(result.Error);
+        }
+
+        public static Result<T, E2> Compensate<T, E, E2>(this Result<T, E> result, Func<E, Result<T, E2>> func)
+        {
+            if (result.IsSuccess)
+            {
+                return Result.Success<T, E2>(result.Value);
+            }
+
+            return func(result.Error);
+        }
+    }
+}

--- a/CSharpFunctionalExtensions/Result/Extensions/CompensateAsyncBoth.cs
+++ b/CSharpFunctionalExtensions/Result/Extensions/CompensateAsyncBoth.cs
@@ -1,0 +1,68 @@
+using System;
+using System.Threading.Tasks;
+
+namespace CSharpFunctionalExtensions
+{
+    public static partial class ResultExtensions
+    {
+        public static async Task<Result> Compensate(this Task<Result> resultTask, Func<string, Task<Result>> func)
+        {
+            var result = await resultTask.DefaultAwait();
+            return await result.Compensate(func).DefaultAwait();
+        }
+
+        public static async Task<UnitResult<E>> Compensate<E>(this Task<Result> resultTask, Func<string, Task<UnitResult<E>>> func)
+        {
+            var result = await resultTask.DefaultAwait();
+            return await result.Compensate(func).DefaultAwait();
+        }
+
+        public static async Task<Result> Compensate<T>(this Task<Result<T>> resultTask, Func<string, Task<Result>> func)
+        {
+            var result = await resultTask.DefaultAwait();
+            return await result.Compensate(func).DefaultAwait();
+        }
+
+        public static async Task<Result<T>> Compensate<T>(this Task<Result<T>> resultTask, Func<string, Task<Result<T>>> func)
+        {
+            var result = await resultTask.DefaultAwait();
+            return await result.Compensate(func).DefaultAwait();
+        }
+
+        public static async Task<Result<T, E>> Compensate<T, E>(this Task<Result<T>> resultTask, Func<string, Task<Result<T, E>>> func)
+        {
+            var result = await resultTask.DefaultAwait();
+            return await result.Compensate(func).DefaultAwait();
+        }
+
+        public static async Task<Result> Compensate<E>(this Task<UnitResult<E>> resultTask, Func<E, Task<Result>> func)
+        {
+            var result = await resultTask.DefaultAwait();
+            return await result.Compensate(func).DefaultAwait();
+        }
+
+        public static async Task<UnitResult<E2>> Compensate<E, E2>(this Task<UnitResult<E>> resultTask, Func<E, Task<UnitResult<E2>>> func)
+        {
+            var result = await resultTask.DefaultAwait();
+            return await result.Compensate(func).DefaultAwait();
+        }
+
+        public static async Task<Result> Compensate<T, E>(this Task<Result<T, E>> resultTask, Func<E, Task<Result>> func)
+        {
+            var result = await resultTask.DefaultAwait();
+            return await result.Compensate(func).DefaultAwait();
+        }
+
+        public static async Task<UnitResult<E2>> Compensate<T, E, E2>(this Task<Result<T, E>> resultTask, Func<E, Task<UnitResult<E2>>> func)
+        {
+            var result = await resultTask.DefaultAwait();
+            return await result.Compensate(func).DefaultAwait();
+        }
+
+        public static async Task<Result<T, E2>> Compensate<T, E, E2>(this Task<Result<T, E>> resultTask, Func<E, Task<Result<T, E2>>> func)
+        {
+            var result = await resultTask.DefaultAwait();
+            return await result.Compensate(func).DefaultAwait();
+        }
+    }
+}

--- a/CSharpFunctionalExtensions/Result/Extensions/CompensateAsyncLeft.cs
+++ b/CSharpFunctionalExtensions/Result/Extensions/CompensateAsyncLeft.cs
@@ -1,0 +1,68 @@
+using System;
+using System.Threading.Tasks;
+
+namespace CSharpFunctionalExtensions
+{
+    public static partial class ResultExtensions
+    {
+        public static async Task<Result> Compensate(this Task<Result> resultTask, Func<string, Result> func)
+        {
+            var result = await resultTask.DefaultAwait();
+            return result.Compensate(func);
+        }
+
+        public static async Task<UnitResult<E>> Compensate<E>(this Task<Result> resultTask, Func<string, UnitResult<E>> func)
+        {
+            var result = await resultTask.DefaultAwait();
+            return result.Compensate(func);
+        }
+
+        public static async Task<Result> Compensate<T>(this Task<Result<T>> resultTask, Func<string, Result> func)
+        {
+            var result = await resultTask.DefaultAwait();
+            return result.Compensate(func);
+        }
+
+        public static async Task<Result<T>> Compensate<T>(this Task<Result<T>> resultTask, Func<string, Result<T>> func)
+        {
+            var result = await resultTask.DefaultAwait();
+            return result.Compensate(func);
+        }
+
+        public static async Task<Result<T, E>> Compensate<T, E>(this Task<Result<T>> resultTask, Func<string, Result<T, E>> func)
+        {
+            var result = await resultTask.DefaultAwait();
+            return result.Compensate(func);
+        }
+
+        public static async Task<Result> Compensate<E>(this Task<UnitResult<E>> resultTask, Func<E, Result> func)
+        {
+            var result = await resultTask.DefaultAwait();
+            return result.Compensate(func);
+        }
+
+        public static async Task<UnitResult<E2>> Compensate<E, E2>(this Task<UnitResult<E>> resultTask, Func<E, UnitResult<E2>> func)
+        {
+            var result = await resultTask.DefaultAwait();
+            return result.Compensate(func);
+        }
+
+        public static async Task<Result> Compensate<T, E>(this Task<Result<T, E>> resultTask, Func<E, Result> func)
+        {
+            var result = await resultTask.DefaultAwait();
+            return result.Compensate(func);
+        }
+
+        public static async Task<UnitResult<E2>> Compensate<T, E, E2>(this Task<Result<T, E>> resultTask, Func<E, UnitResult<E2>> func)
+        {
+            var result = await resultTask.DefaultAwait();
+            return result.Compensate(func);
+        }
+
+        public static async Task<Result<T, E2>> Compensate<T, E, E2>(this Task<Result<T, E>> resultTask, Func<E, Result<T, E2>> func)
+        {
+            var result = await resultTask.DefaultAwait();
+            return result.Compensate(func);
+        }
+    }
+}

--- a/CSharpFunctionalExtensions/Result/Extensions/CompensateAsyncRight.cs
+++ b/CSharpFunctionalExtensions/Result/Extensions/CompensateAsyncRight.cs
@@ -1,0 +1,108 @@
+using System;
+using System.Threading.Tasks;
+
+namespace CSharpFunctionalExtensions
+{
+    public static partial class ResultExtensions
+    {
+        public static Task<Result> Compensate(this Result result, Func<string, Task<Result>> func)
+        {
+            if (result.IsSuccess)
+            {
+                return Result.Success().AsCompletedTask();
+            }
+
+            return func(result.Error);
+        }
+
+        public static Task<UnitResult<E>> Compensate<E>(this Result result, Func<string, Task<UnitResult<E>>> func)
+        {
+            if (result.IsSuccess)
+            {
+                return UnitResult.Success<E>().AsCompletedTask();
+            }
+
+            return func(result.Error);
+        }
+
+        public static Task<Result> Compensate<T>(this Result<T> result, Func<string, Task<Result>> func)
+        {
+            if (result.IsSuccess)
+            {
+                return Result.Success().AsCompletedTask();
+            }
+
+            return func(result.Error);
+        }
+
+        public static Task<Result<T>> Compensate<T>(this Result<T> result, Func<string, Task<Result<T>>> func)
+        {
+            if (result.IsSuccess)
+            {
+                return Result.Success(result.Value).AsCompletedTask();
+            }
+
+            return func(result.Error);
+        }
+
+        public static Task<Result<T, E>> Compensate<T, E>(this Result<T> result, Func<string, Task<Result<T, E>>> func)
+        {
+            if (result.IsSuccess)
+            {
+                return Result.Success<T, E>(result.Value).AsCompletedTask();
+            }
+
+            return func(result.Error);
+        }
+
+        public static Task<Result> Compensate<E>(this UnitResult<E> result, Func<E, Task<Result>> func)
+        {
+            if (result.IsSuccess)
+            {
+                return Result.Success().AsCompletedTask();
+            }
+
+            return func(result.Error);
+        }
+
+        public static Task<UnitResult<E2>> Compensate<E, E2>(this UnitResult<E> result, Func<E, Task<UnitResult<E2>>> func)
+        {
+            if (result.IsSuccess)
+            {
+                return UnitResult.Success<E2>().AsCompletedTask();
+            }
+
+            return func(result.Error);
+        }
+
+        public static Task<Result> Compensate<T, E>(this Result<T, E> result, Func<E, Task<Result>> func)
+        {
+            if (result.IsSuccess)
+            {
+                return Result.Success().AsCompletedTask();
+            }
+
+            return func(result.Error);
+        }
+
+        public static Task<UnitResult<E2>> Compensate<T, E, E2>(this Result<T, E> result, Func<E, Task<UnitResult<E2>>> func)
+        {
+            if (result.IsSuccess)
+            {
+                return UnitResult.Success<E2>().AsCompletedTask();
+            }
+
+            return func(result.Error);
+        }
+
+        public static Task<Result<T, E2>> Compensate<T, E, E2>(this Result<T, E> result, Func<E, Task<Result<T, E2>>> func)
+        {
+            if (result.IsSuccess)
+            {
+                return Result.Success<T, E2>(result.Value).AsCompletedTask();
+            }
+
+            return func(result.Error);
+        }
+    }
+}


### PR DESCRIPTION
Compensate (naming as per https://github.com/vkhorikov/CSharpFunctionalExtensions/issues/312#issuecomment-939088642) is an improved version of legacy `OnFailureCompensate`.
The biggest issue with `OnFailureCompensate` (other than the long name) is the inability to change the type of  `TError`, and `Compensate` provides a rich set of overloads to easily both handle compensation and convert between different error types.