### PR TITLE
Target net6.0 and remove trimming warning

### DIFF
--- a/CSharpFunctionalExtensions.Tests/CSharpFunctionalExtensions.Tests.csproj
+++ b/CSharpFunctionalExtensions.Tests/CSharpFunctionalExtensions.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <LangVersion>8.0</LangVersion>
     <NoWarn>0618</NoWarn>
   </PropertyGroup>

--- a/CSharpFunctionalExtensions/CSharpFunctionalExtensions.csproj
+++ b/CSharpFunctionalExtensions/CSharpFunctionalExtensions.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net40;net45;net461;net472;netstandard2.0;net5.0</TargetFrameworks>
+    <TargetFrameworks>net40;net45;net461;net472;netstandard2.0;net5.0;net6.0</TargetFrameworks>
     <PackageId>CSharpFunctionalExtensions</PackageId>
     <Authors>Vladimir Khorikov</Authors>
     <Description>CSharpFunctionalExtensions - functional extensions for C#</Description>
@@ -31,6 +31,9 @@
   </PropertyGroup>
   <PropertyGroup Condition="'$(TargetFramework)'=='net5.0'">
     <AssemblyTitle>CSharpFunctionalExtensions .NET 5.0</AssemblyTitle>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(TargetFramework)'=='net6.0'">
+    <AssemblyTitle>CSharpFunctionalExtensions .NET 6.0</AssemblyTitle>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(TargetFramework)'=='net40'">

--- a/CSharpFunctionalExtensions/CSharpFunctionalExtensions.csproj
+++ b/CSharpFunctionalExtensions/CSharpFunctionalExtensions.csproj
@@ -34,6 +34,7 @@
   </PropertyGroup>
   <PropertyGroup Condition="'$(TargetFramework)'=='net6.0'">
     <AssemblyTitle>CSharpFunctionalExtensions .NET 6.0</AssemblyTitle>
+    <IsTrimmable>true</IsTrimmable>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(TargetFramework)'=='net40'">

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:5.0 as build
+FROM mcr.microsoft.com/dotnet/sdk:6.0 as build
 
 ARG Version
 WORKDIR /app


### PR DESCRIPTION
Resolves #364 when used in a project targetting .NET 6.0 and using [trimming](https://docs.microsoft.com/en-us/dotnet/core/deploying/trimming/trim-self-contained).

To check that these changes actually solve the problem I created a project referencing the library with `<PublishTrimmed>true</PublishTrimmed>` in `.csproj` file, and used `dotnet publish --self-contained -r linux-x64`. When CSharpFunctionalExtensions has `<IsTrimmable>true</IsTrimmable>` (available in .NET 6+) it doesn't produce trimming warnings (IL2104). Note that to repeat this test I found it necessary to "hard" clean the solution, i.e. remove all `bin` and `obj` directories.

Documentation:
* [Prepare .NET libraries for trimming](https://docs.microsoft.com/en-us/dotnet/core/deploying/trimming/prepare-libraries-for-trimming) (specifically [this](https://docs.microsoft.com/en-us/dotnet/core/deploying/trimming/prepare-libraries-for-trimming#set-istrimmable) and [this](https://docs.microsoft.com/en-us/dotnet/core/deploying/trimming/prepare-libraries-for-trimming#show-all-warnings) section)