### PR TITLE
Revert adding <IsTrimmable>true</IsTrimmable>

### DIFF
--- a/CSharpFunctionalExtensions/CSharpFunctionalExtensions.csproj
+++ b/CSharpFunctionalExtensions/CSharpFunctionalExtensions.csproj
@@ -34,7 +34,6 @@
   </PropertyGroup>
   <PropertyGroup Condition="'$(TargetFramework)'=='net6.0'">
     <AssemblyTitle>CSharpFunctionalExtensions .NET 6.0</AssemblyTitle>
-    <IsTrimmable>true</IsTrimmable>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(TargetFramework)'=='net40'">


### PR DESCRIPTION
I was too quick to assume #365 was actually _fixing_ the IL2104 warning when trimming assemblies - it is not. This PR reverts that change.

## Context

I experienced a similar issue to #364 in another library I'm using. I offered similar solution as the one applied in #365. It was explained to me that simply adding `<IsTrimmable>true</IsTrimmable>` to .csproj without actually resolving the problematic parts in the library (more on that later) is potentially dangerous. See the discussion starting at [this](https://github.com/dotnet/command-line-api/issues/1465#issuecomment-977148717) comment for full details.

Basically it boils down to the following: the IL2104 is an aggregate warning of the trimming analyzer that can have multiple more specific reasons. This particular warning is suppressed by `<IsTrimmable>true</IsTrimmable>`.

* With `<IsTrimmable>true</IsTrimmable>` added to the library, **the code is always trimmed** (!) and
    - when the consuming code does _not_ use problematic parts of the library which would cause IL2104 warning, no warning is generated (this was the case that led me to assume #365 fixes the problem).
    -  when the consuming code _does_ use problematic parts of the library which would cause IL2104 warning, specific multiple warnings get generated instead
* Without `<IsTrimmable>true</IsTrimmable>` added to the library, **the code does not actually get trimmed** and the IL2104 is generated always, even if the consuming code does not use the problematic library parts

Based on this **it's dangerous to mark CSharpFunctionalExtensions as trimmable, since there are actual trimming problems with some of the library code**.

## Trimming problems in CSharpFunctionalExtensions

Removing `<IsTrimmable>` and referencing the library project directly (instead of via NuGet package) in a project shows specific problems with the library code in regard to trimming when published:
```
Trim analysis warning IL2090: CSharpFunctionalExtensions.EnumValueObject<TEnumeration>.GetEnumerations(): 'this' argument does not satisfy 'DynamicallyAccessedMemberTypes.PublicFields' in call to 'System.Type.GetFields(BindingFlags)'. The generic parameter 'TEnumeration' of 'CSharpFunctionalExtensions.EnumValueObject<TEnumeration>' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.
```
and
```
Trim analysis warning IL2090: CSharpFunctionalExtensions.EnumValueObject<TEnumeration,TId>.GetEnumerations(): 'this' argument does not satisfy 'DynamicallyAccessedMemberTypes.PublicFields' in call to 'System.Type.GetFields(BindingFlags)'. The generic parameter 'TEnumeration' of 'CSharpFunctionalExtensions.EnumValueObject<TEnumeration,TId>' does not have matching annotations. The source value must declare at least the same requirements as those declared on the target location it is assigned to.
```
both are related to usage of `GetFields` in `EnumValueObject.GetEnumerations`. Fixing these two things would make the library ready for trimming and then `<IsTrimmable>true</IsTrimmable>` would be safe to add again. Unfortunately I don't know how to fix these issues for generic types currently. More info about IL2090 can be found [here](https://github.com/dotnet/linker/blob/main/docs/error-codes.md#il2090-trim-analysis-this-argument-does-not-satisfy-dynamicallyaccessedmembersattribute-in-call-to-target-method-the-generic-parameter-source-generic-parameter-of-source-method-or-type-does-not-have-matching-annotations-the-source-value-must-declare-at-least-the-same-requirements-as-those-declared-on-the-target-location-it-is-assigned-to).

## Temporary workaround for consuming apps

If your app consumes CSharpFunctionalExtensions and you publish it with trimming, but you are sure you don't use the problematic library parts (so it's ok to trim), the following addition to .csproj removes the warning:
```
  <ItemGroup>
    <TrimmableAssembly Include="CSharpFunctionalExtensions" />
  </ItemGroup>
```
It is basically equivalent to adding `<IsTrimmable>true</IsTrimmable>` to CSharpFunctionalExtensions, but from the consuming code level. This is the solution I will apply in my project, since I'm only using the `Result<>` class which does not generate any trimming warnings.

## Conclusion

I'm sorry for introducing this fault and leading you wrong way in #365. This PR repairs that to some extent. If in the future I find out how to actually fix the two warnings in `EnumValueObject` I'll let you know.