### PR TITLE
Add type Result as predicate for .Ensure()

### DIFF
--- a/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/EnsureAsyncBothTests.cs
+++ b/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/EnsureAsyncBothTests.cs
@@ -1,0 +1,97 @@
+﻿using System.Threading.Tasks;
+using FluentAssertions;
+using Xunit;
+
+namespace CSharpFunctionalExtensions.Tests.ResultTests.Extensions
+{
+  public class EnsureAsyncBothTests
+  {
+    [Fact]
+    public async Task Ensure_with_successInput_and_successPredicate()
+    {
+      var initialResult = Task.FromResult(Result.Success("Initial message"));
+
+      var result = await initialResult.Ensure(() => Task.FromResult(Result.Success("Success message")));
+
+      result.IsSuccess.Should().BeTrue("Initial result and predicate succeeded");
+      result.Value.Should().Be("Initial message");
+    }
+
+    [Fact]
+    public async Task Ensure_with_successInput_and_failurePredicate()
+    {
+      var initialResult = Task.FromResult(Result.Success("Initial Result"));
+
+      var result = await initialResult.Ensure(() => Task.FromResult(Result.Failure("Error message")));
+
+      result.IsSuccess.Should().BeFalse("Predicate is failure result");
+      result.Error.Should().Be("Error message");
+    }
+    
+    [Fact]
+    public async Task Ensure_with_failureInput_and_successPredicate()
+    {
+      var initialResult = Task.FromResult(Result.Failure("Initial Error message"));
+
+      var result = await initialResult.Ensure(() => Task.FromResult(Result.Success("Success message")));
+
+      result.IsSuccess.Should().BeFalse("Initial result is failure result");
+      result.Error.Should().Be("Initial Error message");
+    }
+
+    [Fact]
+    public async Task Ensure_with_failureInput_and_failurePredicate()
+    {
+      var initialResult = Task.FromResult(Result.Failure("Initial Error message"));
+
+      var result = await initialResult.Ensure(() => Task.FromResult(Result.Failure("Error message")));
+
+      result.IsSuccess.Should().BeFalse("Initial result is failure result");
+      result.Error.Should().Be("Initial Error message");
+    }
+    
+    [Fact]
+    public async Task Ensure_with_successInput_and_paramerterisedFailurePredicate()
+    {
+      var initialResult = Task.FromResult(Result.Success("Initial Success message"));
+
+      var result = await initialResult.Ensure(_ => Task.FromResult(Result.Failure("Error Message")));
+
+      result.IsSuccess.Should().BeFalse("Predicate is failure result");
+      result.Error.Should().Be("Error Message");
+    }
+    
+    [Fact]
+    public async Task Ensure_with_successInput_and_paramerterisedSuccessPredicate()
+    {
+      var initialResult = Task.FromResult(Result.Success("Initial Success message"));
+
+      var result = await initialResult.Ensure(_ => Task.FromResult(Result.Success("Success Message")));
+
+      result.IsSuccess.Should().BeTrue("Initial result and predicate succeeded");;
+      result.Value.Should().Be("Initial Success message");
+    }
+    
+    [Fact]
+    public async Task Ensure_with_failureInput_and_paramerterisedSuccessPredicate()
+    {
+      var initialResult = Task.FromResult(Result.Failure<string>("Initial Error message"));
+
+      var result = await initialResult.Ensure(_ => Task.FromResult(Result.Success("Success Message")));
+
+      result.IsSuccess.Should().BeFalse("Initial result is failure result");;
+      result.Error.Should().Be("Initial Error message");
+    }
+    
+    [Fact]
+    public async Task Ensure_with_failureInput_and_paramerterisedFailurePredicate()
+    {
+      var initialResult = Task.FromResult(Result.Failure<string>("Initial Error message"));
+
+      var result = await initialResult.Ensure(_ => Task.FromResult(Result.Failure("Success Message")));
+
+      result.IsSuccess.Should().BeFalse("Initial result and predicate is failure result");;
+      result.Error.Should().Be("Initial Error message");
+    }
+  }
+}

--- a/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/EnsureAsyncLeftTests.cs
+++ b/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/EnsureAsyncLeftTests.cs
@@ -63,5 +63,93 @@ namespace CSharpFunctionalExtensions.Tests.ResultTests.Extensions
             result.IsSuccess.Should().BeFalse("Input Result fails predicate condition");
             result.Error.Should().Be("new error message: string should not be empty");
         }
+
+        [Fact]
+        public async Task Ensure_with_successInput_and_successPredicate()
+        {
+          var initialResult = Task.FromResult(Result.Success("Initial message"));
+
+          var result = await initialResult.Ensure(() => Result.Success("Success message"));
+
+          result.IsSuccess.Should().BeTrue("Initial result and predicate succeeded");
+          result.Value.Should().Be("Initial message");
+        }
+
+        [Fact]
+        public async Task Ensure_with_successInput_and_failurePredicate()
+        {
+          var initialResult = Task.FromResult(Result.Success("Initial Result"));
+
+          var result = await initialResult.Ensure(() => Result.Failure("Error message"));
+
+          result.IsSuccess.Should().BeFalse("Predicate is failure result");
+          result.Error.Should().Be("Error message");
+        }
+        
+        [Fact]
+        public async Task Ensure_with_failureInput_and_successPredicate()
+        {
+          var initialResult = Task.FromResult(Result.Failure("Initial Error message"));
+
+          var result = await initialResult.Ensure(() => Result.Success("Success message"));
+
+          result.IsSuccess.Should().BeFalse("Initial result is failure result");
+          result.Error.Should().Be("Initial Error message");
+        }
+
+        [Fact]
+        public async Task Ensure_with_failureInput_and_failurePredicate()
+        {
+          var initialResult = Task.FromResult(Result.Failure("Initial Error message"));
+
+          var result = await initialResult.Ensure(() => Result.Failure("Error message"));
+
+          result.IsSuccess.Should().BeFalse("Initial result is failure result");
+          result.Error.Should().Be("Initial Error message");
+        }
+        
+        [Fact]
+        public async Task Ensure_with_successInput_and_paramerterisedFailurePredicate()
+        {
+          var initialResult = Task.FromResult(Result.Success("Initial Success message"));
+
+          var result = await initialResult.Ensure(_ => Result.Failure("Error Message"));
+
+          result.IsSuccess.Should().BeFalse("Predicate is failure result");
+          result.Error.Should().Be("Error Message");
+        }
+    
+        [Fact]
+        public async Task Ensure_with_successInput_and_paramerterisedSuccessPredicate()
+        {
+          var initialResult = Task.FromResult(Result.Success("Initial Success message"));
+
+          var result = await initialResult.Ensure(_ => Result.Success("Success Message"));
+
+          result.IsSuccess.Should().BeTrue("Initial result and predicate succeeded");;
+          result.Value.Should().Be("Initial Success message");
+        }
+    
+        [Fact]
+        public async Task Ensure_with_failureInput_and_paramerterisedSuccessPredicate()
+        {
+          var initialResult = Task.FromResult(Result.Failure<string>("Initial Error message"));
+
+          var result = await initialResult.Ensure(_ => Result.Success("Success Message"));
+
+          result.IsSuccess.Should().BeFalse("Initial result is failure result");;
+          result.Error.Should().Be("Initial Error message");
+        }
+    
+        [Fact]
+        public async Task Ensure_with_failureInput_and_paramerterisedFailurePredicate()
+        {
+          var initialResult = Task.FromResult(Result.Failure<string>("Initial Error message"));
+
+          var result = await initialResult.Ensure(_ => Result.Failure("Success Message"));
+
+          result.IsSuccess.Should().BeFalse("Initial result and predicate is failure result");;
+          result.Error.Should().Be("Initial Error message");
+        }
     }
 }

--- a/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/EnsureAsyncRightTests.cs
+++ b/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/EnsureAsyncRightTests.cs
@@ -1,0 +1,97 @@
+﻿using System.Threading.Tasks;
+using FluentAssertions;
+using Xunit;
+
+namespace CSharpFunctionalExtensions.Tests.ResultTests.Extensions
+{
+  public class EnsureAsyncRightTests
+  {
+    [Fact]
+    public async Task Ensure_with_successInput_and_successPredicate()
+    {
+      var initialResult = Result.Success("Initial message");
+
+      var result = await initialResult.Ensure(() => Task.FromResult(Result.Success("Success message")));
+
+      result.IsSuccess.Should().BeTrue("Initial result and predicate succeeded");
+      result.Value.Should().Be("Initial message");
+    }
+
+    [Fact]
+    public async Task Ensure_with_successInput_and_failurePredicate()
+    {
+      var initialResult = Result.Success("Initial Result");
+
+      var result = await initialResult.Ensure(() => Task.FromResult(Result.Failure("Error message")));
+
+      result.IsSuccess.Should().BeFalse("Predicate is failure result");
+      result.Error.Should().Be("Error message");
+    }
+    
+    [Fact]
+    public async Task Ensure_with_failureInput_and_successPredicate()
+    {
+      var initialResult = Result.Failure("Initial Error message");
+
+      var result = await initialResult.Ensure(() => Task.FromResult(Result.Success("Success message")));
+
+      result.IsSuccess.Should().BeFalse("Initial result is failure result");
+      result.Error.Should().Be("Initial Error message");
+    }
+
+    [Fact]
+    public async Task Ensure_with_failureInput_and_failurePredicate()
+    {
+      var initialResult = Result.Failure("Initial Error message");
+
+      var result = await initialResult.Ensure(() => Task.FromResult(Result.Failure("Error message")));
+
+      result.IsSuccess.Should().BeFalse("Initial result is failure result");
+      result.Error.Should().Be("Initial Error message");
+    }
+    
+    [Fact]
+    public async Task Ensure_with_successInput_and_paramerterisedFailurePredicate()
+    {
+      var initialResult = Result.Success("Initial Success message");
+
+      var result = await initialResult.Ensure(_ => Task.FromResult(Result.Failure("Error Message")));
+
+      result.IsSuccess.Should().BeFalse("Predicate is failure result");
+      result.Error.Should().Be("Error Message");
+    }
+    
+    [Fact]
+    public async Task Ensure_with_successInput_and_paramerterisedSuccessPredicate()
+    {
+      var initialResult = Result.Success("Initial Success message");
+
+      var result = await initialResult.Ensure(_ => Task.FromResult(Result.Success("Success Message")));
+
+      result.IsSuccess.Should().BeTrue("Initial result and predicate succeeded");;
+      result.Value.Should().Be("Initial Success message");
+    }
+    
+    [Fact]
+    public async Task Ensure_with_failureInput_and_paramerterisedSuccessPredicate()
+    {
+      var initialResult = Result.Failure<string>("Initial Error message");
+
+      var result = await initialResult.Ensure(_ => Task.FromResult(Result.Success("Success Message")));
+
+      result.IsSuccess.Should().BeFalse("Initial result is failure result");;
+      result.Error.Should().Be("Initial Error message");
+    }
+    
+    [Fact]
+    public async Task Ensure_with_failureInput_and_paramerterisedFailurePredicate()
+    {
+      var initialResult = Result.Failure<string>("Initial Error message");
+
+      var result = await initialResult.Ensure(_ => Task.FromResult(Result.Failure("Success Message")));
+
+      result.IsSuccess.Should().BeFalse("Initial result and predicate is failure result");;
+      result.Error.Should().Be("Initial Error message");
+    }
+  }
+}

--- a/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/EnsureTests.cs
+++ b/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/EnsureTests.cs
@@ -1,0 +1,98 @@
+﻿using System;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Xunit;
+
+namespace CSharpFunctionalExtensions.Tests.ResultTests.Extensions
+{
+  public class EnsureTests
+  {
+    [Fact]
+    public void Ensure_with_successInput_and_successPredicate()
+    {
+      var initialResult = Result.Success("Initial message");
+
+      var result = initialResult.Ensure(() => Result.Success("Success message"));
+
+      result.IsSuccess.Should().BeTrue("Initial result and predicate succeeded");
+      result.Value.Should().Be("Initial message");
+    }
+
+    [Fact]
+    public void Ensure_with_successInput_and_failurePredicate()
+    {
+      var initialResult = Result.Success("Initial Result");
+
+      var result = initialResult.Ensure(() => Result.Failure("Error message"));
+
+      result.IsSuccess.Should().BeFalse("Predicate is failure result");
+      result.Error.Should().Be("Error message");
+    }
+    
+    [Fact]
+    public void Ensure_with_failureInput_and_successPredicate()
+    {
+      var initialResult = Result.Failure("Initial Error message");
+
+      var result = initialResult.Ensure(() => Result.Success("Success message"));
+
+      result.IsSuccess.Should().BeFalse("Initial result is failure result");
+      result.Error.Should().Be("Initial Error message");
+    }
+
+    [Fact]
+    public void Ensure_with_failureInput_and_failurePredicate()
+    {
+      var initialResult = Result.Failure("Initial Error message");
+
+      var result = initialResult.Ensure(() => Result.Failure("Error message"));
+
+      result.IsSuccess.Should().BeFalse("Initial result is failure result");
+      result.Error.Should().Be("Initial Error message");
+    }
+    
+    [Fact]
+    public void Ensure_with_successInput_and_paramerterisedFailurePredicate()
+    {
+      var initialResult = Result.Success("Initial Success message");
+
+      var result = initialResult.Ensure(_ => Result.Failure("Error Message"));
+
+      result.IsSuccess.Should().BeFalse("Predicate is failure result");
+      result.Error.Should().Be("Error Message");
+    }
+    
+    [Fact]
+    public void Ensure_with_successInput_and_paramerterisedSuccessPredicate()
+    {
+      var initialResult = Result.Success("Initial Success message");
+
+      var result = initialResult.Ensure(_ => Result.Success("Success Message"));
+
+      result.IsSuccess.Should().BeTrue("Initial result and predicate succeeded");;
+      result.Value.Should().Be("Initial Success message");
+    }
+    
+    [Fact]
+    public void Ensure_with_failureInput_and_paramerterisedSuccessPredicate()
+    {
+      var initialResult = Result.Failure<string>("Initial Error message");
+
+      var result = initialResult.Ensure(_ => Result.Success("Success Message"));
+
+      result.IsSuccess.Should().BeFalse("Initial result is failure result");;
+      result.Error.Should().Be("Initial Error message");
+    }
+    
+    [Fact]
+    public void Ensure_with_failureInput_and_paramerterisedFailurePredicate()
+    {
+      var initialResult = Result.Failure<string>("Initial Error message");
+
+      var result = initialResult.Ensure(_ => Result.Failure("Success Message"));
+
+      result.IsSuccess.Should().BeFalse("Initial result and predicate is failure result");;
+      result.Error.Should().Be("Initial Error message");
+    }
+  }
+}

--- a/CSharpFunctionalExtensions/Result/Extensions/Ensure.cs
+++ b/CSharpFunctionalExtensions/Result/Extensions/Ensure.cs
@@ -73,5 +73,101 @@ namespace CSharpFunctionalExtensions
 
             return result;
         }
+
+        /// <summary>
+        ///     Returns a new failure result if the predicate is a failure result. Otherwise returns the starting result.
+        /// </summary>
+        public static Result Ensure(this Result result, Func<Result> predicate)
+        {
+          if (result.IsFailure)
+            return result;
+
+          var predicateResult = predicate();
+          
+          if (predicateResult.IsFailure)
+            return Result.Failure(predicateResult.Error);
+
+          return result;
+        }
+        
+        /// <summary>
+        ///     Returns a new failure result if the predicate is a failure result. Otherwise returns the starting result.
+        /// </summary>
+        public static Result<T> Ensure<T>(this Result<T> result, Func<Result> predicate)
+        {
+          if (result.IsFailure)
+            return result;
+        
+          var predicateResult = predicate();
+          
+          if (predicateResult.IsFailure)
+            return Result.Failure<T>(predicateResult.Error);
+        
+          return result;
+        }
+        
+        /// <summary>
+        ///     Returns a new failure result if the predicate is a failure result. Otherwise returns the starting result.
+        /// </summary>
+        public static Result Ensure<T>(this Result result, Func<Result<T>> predicate)
+        {
+          if (result.IsFailure)
+            return result;
+        
+          var predicateResult = predicate();
+          
+          if (predicateResult.IsFailure)
+            return Result.Failure<T>(predicateResult.Error);
+        
+          return result;
+        }
+        
+        /// <summary>
+        ///     Returns a new failure result if the predicate is a failure result. Otherwise returns the starting result.
+        /// </summary>
+        public static Result<T> Ensure<T>(this Result<T> result, Func<Result<T>> predicate)
+        {
+          if (result.IsFailure)
+            return result;
+
+          var predicateResult = predicate();
+          
+          if (predicateResult.IsFailure)
+            return Result.Failure<T>(predicateResult.Error);
+
+          return result;
+        }
+
+        /// <summary>
+        ///     Returns a new failure result if the predicate is a failure result. Otherwise returns the starting result.
+        /// </summary>
+        public static Result<T> Ensure<T>(this Result<T> result, Func<T,Result> predicate)
+        {
+          if (result.IsFailure)
+            return result;
+        
+          var predicateResult = predicate(result.Value);
+          
+          if (predicateResult.IsFailure)
+            return Result.Failure<T>(predicateResult.Error);
+        
+          return result;
+        }
+        
+        /// <summary>
+        ///     Returns a new failure result if the predicate is a failure result. Otherwise returns the starting result.
+        /// </summary>
+        public static Result<T> Ensure<T>(this Result<T> result, Func<T,Result<T>> predicate)
+        {
+          if (result.IsFailure)
+            return result;
+        
+          var predicateResult = predicate(result.Value);
+          
+          if (predicateResult.IsFailure)
+            return Result.Failure<T>(predicateResult.Error);
+        
+          return result;
+        }
     }
 }

--- a/CSharpFunctionalExtensions/Result/Extensions/EnsureAsyncBoth.cs
+++ b/CSharpFunctionalExtensions/Result/Extensions/EnsureAsyncBoth.cs
@@ -116,5 +116,113 @@ namespace CSharpFunctionalExtensions
 
             return result;
         }
+        
+        /// <summary>
+        ///     Returns a new failure result if the predicate is a failure result. Otherwise returns the starting result.
+        /// </summary>
+        public static async Task<Result> Ensure(this Task<Result> resultTask, Func<Task<Result>> predicate)
+        {
+          Result result = await resultTask.DefaultAwait();
+          
+          if (result.IsFailure)
+            return result;
+
+          var predicateResult = await predicate();
+          
+          if (predicateResult.IsFailure)
+            return Result.Failure(predicateResult.Error);
+
+          return result;
+        }
+        
+        /// <summary>
+        ///     Returns a new failure result if the predicate is a failure result. Otherwise returns the starting result.
+        /// </summary>
+        public static async Task<Result<T>> Ensure<T>(this Task<Result<T>> resultTask, Func<Task<Result>> predicate)
+        {
+          Result<T> result = await resultTask.DefaultAwait();
+          
+          if (result.IsFailure)
+            return result;
+
+          var predicateResult = await predicate();
+          
+          if (predicateResult.IsFailure)
+            return Result.Failure<T>(predicateResult.Error);
+
+          return result;
+        }
+        
+        /// <summary>
+        ///     Returns a new failure result if the predicate is a failure result. Otherwise returns the starting result.
+        /// </summary>
+        public static async Task<Result> Ensure<T>(this Task<Result> resultTask, Func<Task<Result<T>>> predicate)
+        {
+          Result result = await resultTask.DefaultAwait();
+          
+          if (result.IsFailure)
+            return result;
+
+          var predicateResult = await predicate();
+          
+          if (predicateResult.IsFailure)
+            return Result.Failure<T>(predicateResult.Error);
+
+          return result;
+        }
+        
+        /// <summary>
+        ///     Returns a new failure result if the predicate is a failure result. Otherwise returns the starting result.
+        /// </summary>
+        public static async Task<Result<T>> Ensure<T>(this Task<Result<T>> resultTask, Func<Task<Result<T>>> predicate)
+        {
+          Result<T> result = await resultTask.DefaultAwait();
+          
+          if (result.IsFailure)
+            return result;
+        
+          var predicateResult = await predicate();
+          
+          if (predicateResult.IsFailure)
+            return Result.Failure<T>(predicateResult.Error);
+        
+          return result;
+        }
+        
+        /// <summary>
+        ///     Returns a new failure result if the predicate is a failure result. Otherwise returns the starting result.
+        /// </summary>
+        public static async Task<Result<T>> Ensure<T>(this Task<Result<T>> resultTask, Func<T,Task<Result>> predicate)
+        {
+          Result<T> result = await resultTask.DefaultAwait();
+          
+          if (result.IsFailure)
+            return result;
+
+          var predicateResult = await predicate(result.Value);
+          
+          if (predicateResult.IsFailure)
+            return Result.Failure<T>(predicateResult.Error);
+
+          return result;
+        }
+        
+        /// <summary>
+        ///     Returns a new failure result if the predicate is a failure result. Otherwise returns the starting result.
+        /// </summary>
+        public static async Task<Result<T>> Ensure<T>(this Task<Result<T>> resultTask, Func<T,Task<Result<T>>> predicate)
+        {
+          Result<T> result = await resultTask.DefaultAwait();
+          
+          if (result.IsFailure)
+            return result;
+
+          var predicateResult = await predicate(result.Value);
+          
+          if (predicateResult.IsFailure)
+            return Result.Failure<T>(predicateResult.Error);
+
+          return result;
+        }
     }
 }

--- a/CSharpFunctionalExtensions/Result/Extensions/EnsureAsyncLeft.cs
+++ b/CSharpFunctionalExtensions/Result/Extensions/EnsureAsyncLeft.cs
@@ -71,5 +71,59 @@ namespace CSharpFunctionalExtensions
             Result result = await resultTask.DefaultAwait();
             return result.Ensure(predicate, errorMessage);
         }
+        
+        /// <summary>
+        ///     Returns a new failure result if the predicate is a failure result. Otherwise returns the starting result.
+        /// </summary>
+        public static async Task<Result> Ensure(this Task<Result> resultTask, Func<Result> predicate)
+        {
+          Result result = await resultTask.DefaultAwait();
+          return result.Ensure(predicate);
+        }
+        
+        /// <summary>
+        ///     Returns a new failure result if the predicate is a failure result. Otherwise returns the starting result.
+        /// </summary>
+        public static async Task<Result<T>> Ensure<T>(this Task<Result<T>> resultTask, Func<Result> predicate)
+        {
+          Result<T> result = await resultTask.DefaultAwait();
+          return result.Ensure(predicate);
+        }
+        
+        /// <summary>
+        ///     Returns a new failure result if the predicate is a failure result. Otherwise returns the starting result.
+        /// </summary>
+        public static async Task<Result> Ensure<T>(this Task<Result> resultTask, Func<Result<T>> predicate)
+        {
+          Result result = await resultTask.DefaultAwait();
+          return result.Ensure(predicate);
+        }
+        
+        /// <summary>
+        ///     Returns a new failure result if the predicate is a failure result. Otherwise returns the starting result.
+        /// </summary>
+        public static async Task<Result<T>> Ensure<T>(this Task<Result<T>> resultTask, Func<Result<T>> predicate)
+        {
+          Result<T> result = await resultTask.DefaultAwait();
+          return result.Ensure(predicate);
+        }
+        
+        /// <summary>
+        ///     Returns a new failure result if the predicate is a failure result. Otherwise returns the starting result.
+        /// </summary>
+        public static async Task<Result<T>> Ensure<T>(this Task<Result<T>> resultTask, Func<T,Result> predicate)
+        {
+          Result<T> result = await resultTask.DefaultAwait();
+          return result.Ensure(predicate);
+        }
+        
+        /// <summary>
+        ///     Returns a new failure result if the predicate is a failure result. Otherwise returns the starting result.
+        /// </summary>
+        public static async Task<Result<T>> Ensure<T>(this Task<Result<T>> resultTask, Func<T,Result<T>> predicate)
+        {
+          Result<T> result = await resultTask.DefaultAwait();
+          return result.Ensure(predicate);
+        }
     }
 }

--- a/CSharpFunctionalExtensions/Result/Extensions/EnsureAsyncRight.cs
+++ b/CSharpFunctionalExtensions/Result/Extensions/EnsureAsyncRight.cs
@@ -105,5 +105,101 @@ namespace CSharpFunctionalExtensions
 
             return result;
         }
+        
+        /// <summary>
+        ///     Returns a new failure result if the predicate is a failure result. Otherwise returns the starting result.
+        /// </summary>
+        public static async Task<Result> Ensure(this Result result, Func<Task<Result>> predicate)
+        {
+          if (result.IsFailure)
+            return result;
+
+          var predicateResult = await predicate().DefaultAwait();
+          
+          if (predicateResult.IsFailure)
+            return Result.Failure(predicateResult.Error);
+
+          return result;
+        }
+        
+        /// <summary>
+        ///     Returns a new failure result if the predicate is a failure result. Otherwise returns the starting result.
+        /// </summary>
+        public static async Task<Result<T>> Ensure<T>(this Result<T> result, Func<Task<Result>> predicate)
+        {
+          if (result.IsFailure)
+            return result;
+
+          var predicateResult = await predicate().DefaultAwait();
+          
+          if (predicateResult.IsFailure)
+            return Result.Failure<T>(predicateResult.Error);
+
+          return result;
+        }
+        
+        /// <summary>
+        ///     Returns a new failure result if the predicate is a failure result. Otherwise returns the starting result.
+        /// </summary>
+        public static async Task<Result> Ensure<T>(this Result result, Func<Task<Result<T>>> predicate)
+        {
+          if (result.IsFailure)
+            return result;
+
+          var predicateResult = await predicate().DefaultAwait();
+          
+          if (predicateResult.IsFailure)
+            return Result.Failure<T>(predicateResult.Error);
+
+          return result;
+        }
+
+        /// <summary>
+        ///     Returns a new failure result if the predicate is a failure result. Otherwise returns the starting result.
+        /// </summary>
+        public static async Task<Result<T>> Ensure<T>(this Result<T> result, Func<Task<Result<T>>> predicate)
+        {
+          if (result.IsFailure)
+            return result;
+
+          var predicateResult = await predicate().DefaultAwait();
+          
+          if (predicateResult.IsFailure)
+            return Result.Failure<T>(predicateResult.Error);
+
+          return result;
+        }
+        
+        /// <summary>
+        ///     Returns a new failure result if the predicate is a failure result. Otherwise returns the starting result.
+        /// </summary>
+        public static async Task<Result<T>> Ensure<T>(this Result<T> result, Func<T,Task<Result>> predicate)
+        {
+          if (result.IsFailure)
+            return result;
+
+          var predicateResult = await predicate(result.Value).DefaultAwait();
+          
+          if (predicateResult.IsFailure)
+            return Result.Failure<T>(predicateResult.Error);
+
+          return result;
+        }
+        
+        /// <summary>
+        ///     Returns a new failure result if the predicate is a failure result. Otherwise returns the starting result.
+        /// </summary>
+        public static async Task<Result<T>> Ensure<T>(this Result<T> result, Func<T,Task<Result<T>>> predicate)
+        {
+          if (result.IsFailure)
+            return result;
+
+          var predicateResult = await predicate(result.Value).DefaultAwait();
+          
+          if (predicateResult.IsFailure)
+            return Result.Failure<T>(predicateResult.Error);
+
+          return result;
+        }
     }
 }


### PR DESCRIPTION
This PR resolves #337 by adding the possibility to use a predicate of type `Result` in the `.Ensure()` method.

It's implemented for all sync & async variants of the method and backed up with unit tests.