### PR TITLE
WithTransactionScope: isolation level "READ COMMITTED" instead of "SE…

### DIFF
--- a/CSharpFunctionalExtensions/Result/Extensions/WithTransactionScope.cs
+++ b/CSharpFunctionalExtensions/Result/Extensions/WithTransactionScope.cs
@@ -7,10 +7,16 @@ namespace CSharpFunctionalExtensions
 {
     public static partial class ResultExtensions
     {
+        private static readonly TransactionOptions _transactionOptions = new TransactionOptions
+        {
+            IsolationLevel = IsolationLevel.ReadCommitted,
+            Timeout = TransactionManager.DefaultTimeout
+        };
+
         private static T WithTransactionScope<T>(Func<T> f)
             where T : IResult
         {
-            using (var trans = new TransactionScope(TransactionScopeAsyncFlowOption.Enabled))
+            using (var trans = new TransactionScope(TransactionScopeOption.Required, _transactionOptions, TransactionScopeAsyncFlowOption.Enabled))
             {
                 var result = f();
                 if (result.IsSuccess)
@@ -24,7 +30,7 @@ namespace CSharpFunctionalExtensions
         private async static Task<T> WithTransactionScope<T>(Func<Task<T>> f)
             where T : IResult
         {
-            using (var trans = new TransactionScope(TransactionScopeAsyncFlowOption.Enabled))
+            using (var trans = new TransactionScope(TransactionScopeOption.Required, _transactionOptions, TransactionScopeAsyncFlowOption.Enabled))
             {
                 var result = await f().DefaultAwait();
                 if (result.IsSuccess)


### PR DESCRIPTION
…RIALIZABLE".

For the motivation behind this pull request, please see:

[using new TransactionScope() Considered Harmful](https://docs.microsoft.com/en-us/archive/blogs/dbrowne/using-new-transactionscope-considered-harmful)

My code changes correspond to the fix suggested by "Josh the coder":

[TransactionScope Considered Annoying](https://joshthecoder.com/2020/07/27/transactionscope-considered-annoying.html)