### PR TITLE
Make Result.DefaultTryErrorHandler Configurable

### DIFF
--- a/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/OnSuccessTryAsyncBothTests.cs
+++ b/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/OnSuccessTryAsyncBothTests.cs
@@ -24,7 +24,20 @@ namespace CSharpFunctionalExtensions.Tests.ResultTests.Extensions
             result.IsFailure.Should().BeTrue();
             result.Error.Should().Be(ErrorMessage);
         }
-        
+
+        [Fact]
+        public async Task OnSuccessTry_execute_action_failed_with_configured_default_error_handler_failed_result_expected()
+        {
+            var defaultTryErrorHandler = Result.DefaultTryErrorHandler;
+            Result.DefaultTryErrorHandler = ErrorHandler;
+            var success = Result.Success().AsTask();
+            var result = await success.OnSuccessTry(Throwing_Func_Task);
+            Result.DefaultTryErrorHandler = defaultTryErrorHandler;
+
+            result.IsFailure.Should().BeTrue();
+            result.Error.Should().Be(ErrorHandlerMessage);
+        }
+
         [Fact]
         public async Task OnSuccessTry_execute_action_failed_with_error_handler_failed_result_expected()
         {

--- a/CSharpFunctionalExtensions.Tests/ResultTests/TryAsyncTests.cs
+++ b/CSharpFunctionalExtensions.Tests/ResultTests/TryAsyncTests.cs
@@ -33,6 +33,18 @@ namespace CSharpFunctionalExtensions.Tests.ResultTests
             result.Error.Should().Be(ErrorHandlerMessage);
         }
 
+        [Fact]
+        public async Task ResultTry_Async_execute_action_failed_with_configured_default_error_handler_failed_result_expected()
+        {
+            var defaultTryErrorHandler = Result.DefaultTryErrorHandler;
+            Result.DefaultTryErrorHandler = ErrorHandler;
+            var result = await Result.Try(Throwing_Func_Task);
+            Result.DefaultTryErrorHandler = defaultTryErrorHandler;
+
+            result.IsFailure.Should().BeTrue();
+            result.Error.Should().Be(ErrorHandlerMessage);
+        }
+
         [Fact] 
         public async Task ResultTry_Async_T_execute_function_success_without_error_handler_function_result_expected()
         {

--- a/CSharpFunctionalExtensions/Result/Configuration/Configuration.cs
+++ b/CSharpFunctionalExtensions/Result/Configuration/Configuration.cs
@@ -1,4 +1,6 @@
-﻿namespace CSharpFunctionalExtensions
+﻿using System;
+
+namespace CSharpFunctionalExtensions
 {
     public partial struct Result
     {
@@ -7,5 +9,7 @@
         public static bool DefaultConfigureAwait = false;
 
         public static string DefaultNoValueExceptionMessage = "Maybe has no value.";
+
+        public static Func<Exception, string> DefaultTryErrorHandler = exc => exc.Message;
     }
 }

--- a/CSharpFunctionalExtensions/Result/Methods/Try.cs
+++ b/CSharpFunctionalExtensions/Result/Methods/Try.cs
@@ -5,8 +5,6 @@ namespace CSharpFunctionalExtensions
 {
     public partial struct Result
     {
-        private static readonly Func<Exception, string> DefaultTryErrorHandler = exc => exc.Message;
-
         /// <summary>
         ///     Attempts to execute the supplied action. Returns a Result indicating whether the action executed successfully.
         /// </summary>


### PR DESCRIPTION
Many times when I am using Try/OnSuccessTry I want to have a consistent different error handling than `exc=>exc.Message`.
I started using my own constant `CSharpFunctionalExtensionsConfiguration.ErrorHandler` but sometimes the developers just don't use it by mistake. 
I don't want to have my own XResult.Try(Act) just to have my own ErrorHandler behavior by calling Result.Try(Act, MyHandler).
I think we should allow this configuration to be just part of Result.