### PR TITLE
Finally(): superfluous async/await removed in static class AsyncResul…

### DIFF
--- a/CSharpFunctionalExtensions/Result/Extensions/FinallyAsyncRight.cs
+++ b/CSharpFunctionalExtensions/Result/Extensions/FinallyAsyncRight.cs
@@ -8,33 +8,25 @@ namespace CSharpFunctionalExtensions
         /// <summary>
         ///     Passes the result to the given function (regardless of success/failure state) to yield a final output value.
         /// </summary>
-        public static async Task<T> Finally<T>(this Result result, Func<Result, Task<T>> func)
-        {
-            return await func(result).DefaultAwait();
-        }
+        public static Task<T> Finally<T>(this Result result, Func<Result, Task<T>> func)
+          => func(result);
 
         /// <summary>
         ///     Passes the result to the given function (regardless of success/failure state) to yield a final output value.
         /// </summary>
-        public static async Task<K> Finally<T, K>(this Result<T> result, Func<Result<T>, Task<K>> func)
-        {
-            return await func(result).DefaultAwait();
-        }
+        public static Task<K> Finally<T, K>(this Result<T> result, Func<Result<T>, Task<K>> func)
+          => func(result);
 
         /// <summary>
         ///     Passes the result to the given function (regardless of success/failure state) to yield a final output value.
         /// </summary>
-        public static async Task<K> Finally<K, E>(this UnitResult<E> result, Func<UnitResult<E>, Task<K>> func)
-        {
-            return await func(result).DefaultAwait();
-        }
+        public static Task<K> Finally<K, E>(this UnitResult<E> result, Func<UnitResult<E>, Task<K>> func)
+          => func(result);
 
         /// <summary>
         ///     Passes the result to the given function (regardless of success/failure state) to yield a final output value.
         /// </summary>
-        public static async Task<K> Finally<T, K, E>(this Result<T, E> result, Func<Result<T, E>, Task<K>> func)
-        {
-            return await func(result).DefaultAwait();
-        }
+        public static Task<K> Finally<T, K, E>(this Result<T, E> result, Func<Result<T, E>, Task<K>> func)
+          => func(result);
     }
 }


### PR DESCRIPTION
…tExtensionsRightOperand.