### PR TITLE
ResultExtensions: Deconstruct() overloads without isFailure

### DIFF
--- a/CSharpFunctionalExtensions/Result/Extensions/Deconstruct.cs
+++ b/CSharpFunctionalExtensions/Result/Extensions/Deconstruct.cs
@@ -8,10 +8,21 @@ namespace CSharpFunctionalExtensions
             isFailure = result.IsFailure;
         }
 
+        public static void Deconstruct(this Result result, out bool isSuccess)
+        {
+            isSuccess = result.IsSuccess;
+        }
+
         public static void Deconstruct(this Result result, out bool isSuccess, out bool isFailure, out string error)
         {
             isSuccess = result.IsSuccess;
             isFailure = result.IsFailure;
+            error = result.IsFailure ? result.Error : default;
+        }
+
+        public static void Deconstruct(this Result result, out bool isSuccess, out string error)
+        {
+            isSuccess = result.IsSuccess;
             error = result.IsFailure ? result.Error : default;
         }
 
@@ -21,10 +32,21 @@ namespace CSharpFunctionalExtensions
             isFailure = result.IsFailure;
         }
 
+        public static void Deconstruct<T>(this Result<T> result, out bool isSuccess)
+        {
+            isSuccess = result.IsSuccess;
+        }
+
         public static void Deconstruct<T>(this Result<T> result, out bool isSuccess, out bool isFailure, out T value)
         {
             isSuccess = result.IsSuccess;
             isFailure = result.IsFailure;
+            value = result.IsSuccess ? result.Value : default;
+        }
+
+        public static void Deconstruct<T>(this Result<T> result, out bool isSuccess, out T value)
+        {
+            isSuccess = result.IsSuccess;
             value = result.IsSuccess ? result.Value : default;
         }
 
@@ -36,10 +58,22 @@ namespace CSharpFunctionalExtensions
             error = result.IsFailure ? result.Error : default;
         }
 
+        public static void Deconstruct<T>(this Result<T> result, out bool isSuccess, out T value, out string error)
+        {
+            isSuccess = result.IsSuccess;
+            value = result.IsSuccess ? result.Value : default;
+            error = result.IsFailure ? result.Error : default;
+        }
+
         public static void Deconstruct<T, E>(this Result<T, E> result, out bool isSuccess, out bool isFailure)
         {
             isSuccess = result.IsSuccess;
             isFailure = result.IsFailure;
+        }
+
+        public static void Deconstruct<T, E>(this Result<T, E> result, out bool isSuccess)
+        {
+            isSuccess = result.IsSuccess;
         }
 
         public static void Deconstruct<T, E>(this Result<T, E> result, out bool isSuccess, out bool isFailure, out T value)
@@ -49,10 +83,23 @@ namespace CSharpFunctionalExtensions
             value = result.IsSuccess ? result.Value : default;
         }
 
+        public static void Deconstruct<T, E>(this Result<T, E> result, out bool isSuccess, out T value)
+        {
+            isSuccess = result.IsSuccess;
+            value = result.IsSuccess ? result.Value : default;
+        }
+
         public static void Deconstruct<T, E>(this Result<T, E> result, out bool isSuccess, out bool isFailure, out T value, out E error)
         {
             isSuccess = result.IsSuccess;
             isFailure = result.IsFailure;
+            value = result.IsSuccess ? result.Value : default;
+            error = result.IsFailure ? result.Error : default;
+        }
+
+        public static void Deconstruct<T, E>(this Result<T, E> result, out bool isSuccess, out T value, out E error)
+        {
+            isSuccess = result.IsSuccess;
             value = result.IsSuccess ? result.Value : default;
             error = result.IsFailure ? result.Error : default;
         }


### PR DESCRIPTION
While having the two properties `IsSuccess` and `IsFailure` on the type `Result` eases reading in conditional statements, deconstructing a `Result` object ends up with the two properties being transformed into two variables in the same scope where