### PR TITLE
Applied EditorBrowsableAttribute to all Obsolete methods (Issue #417)

### DIFF
--- a/CSharpFunctionalExtensions/Result/Obsolete/Create.cs
+++ b/CSharpFunctionalExtensions/Result/Obsolete/Create.cs
@@ -1,42 +1,53 @@
 ﻿using System;
+using System.ComponentModel;
 using System.Threading.Tasks;
 
 namespace CSharpFunctionalExtensions
 {
     public partial struct Result
     {
+        
+        [EditorBrowsable(EditorBrowsableState.Never)]
         [Obsolete("Use SuccessIf() instead.")]
         public static Result Create(bool isSuccess, string error)
             => SuccessIf(isSuccess, error);
 
+        [EditorBrowsable(EditorBrowsableState.Never)]
         [Obsolete("Use SuccessIf() instead.")]
         public static Result Create(Func<bool> predicate, string error)
             => SuccessIf(predicate, error);
 
+        [EditorBrowsable(EditorBrowsableState.Never)]
         [Obsolete("Use SuccessIf() instead.")]
         public static Task<Result> Create(Func<Task<bool>> predicate, string error)
             => SuccessIf(predicate, error);
 
+        [EditorBrowsable(EditorBrowsableState.Never)]
         [Obsolete("Use SuccessIf() instead.")]
         public static Result<T> Create<T>(bool isSuccess, T value, string error)
             => SuccessIf(isSuccess, value, error);
 
+        [EditorBrowsable(EditorBrowsableState.Never)]
         [Obsolete("Use SuccessIf() instead.")]
         public static Result<T> Create<T>(Func<bool> predicate, T value, string error)
             => SuccessIf(predicate, value, error);
 
+        [EditorBrowsable(EditorBrowsableState.Never)]
         [Obsolete("Use SuccessIf() instead.")]
         public static Task<Result<T>> Create<T>(Func<Task<bool>> predicate, T value, string error)
             => SuccessIf(predicate, value, error);
 
+        [EditorBrowsable(EditorBrowsableState.Never)]
         [Obsolete("Use SuccessIf() instead.")]
         public static Result<T, E> Create<T, E>(bool isSuccess, T value, E error)
             => SuccessIf(isSuccess, value, error);
 
+        [EditorBrowsable(EditorBrowsableState.Never)]
         [Obsolete("Use SuccessIf() instead.")]
         public static Result<T, E> Create<T, E>(Func<bool> predicate, T value, E error)
             => SuccessIf(predicate, value, error);
 
+        [EditorBrowsable(EditorBrowsableState.Never)]
         [Obsolete("Use SuccessIf() instead.")]
         public static Task<Result<T, E>> Create<T, E>(Func<Task<bool>> predicate, T value, E error)
             => SuccessIf(predicate, value, error);

--- a/CSharpFunctionalExtensions/Result/Obsolete/CreateFailure.cs
+++ b/CSharpFunctionalExtensions/Result/Obsolete/CreateFailure.cs
@@ -1,42 +1,52 @@
 ﻿using System;
+using System.ComponentModel;
 using System.Threading.Tasks;
 
 namespace CSharpFunctionalExtensions
 {
     public partial struct Result
     {
+        [EditorBrowsable(EditorBrowsableState.Never)]
         [Obsolete("Use FailureIf() instead.")]
         public static Result CreateFailure(bool isFailure, string error)
             => FailureIf(isFailure, error);
 
+        [EditorBrowsable(EditorBrowsableState.Never)]
         [Obsolete("Use FailureIf() instead.")]
         public static Result CreateFailure(Func<bool> failurePredicate, string error)
             => FailureIf(failurePredicate, error);
 
+        [EditorBrowsable(EditorBrowsableState.Never)]
         [Obsolete("Use FailureIf() instead.")]
         public static Task<Result> CreateFailure(Func<Task<bool>> failurePredicate, string error)
             => FailureIf(failurePredicate, error);
 
+        [EditorBrowsable(EditorBrowsableState.Never)]
         [Obsolete("Use FailureIf() instead.")]
         public static Result<T> CreateFailure<T>(bool isFailure, T value, string error)
             => FailureIf(isFailure, value, error);
 
+        [EditorBrowsable(EditorBrowsableState.Never)]
         [Obsolete("Use FailureIf() instead.")]
         public static Result<T> CreateFailure<T>(Func<bool> failurePredicate, T value, string error)
             => FailureIf(failurePredicate, value, error);
 
+        [EditorBrowsable(EditorBrowsableState.Never)]
         [Obsolete("Use FailureIf() instead.")]
         public static Task<Result<T>> CreateFailure<T>(Func<Task<bool>> failurePredicate, T value, string error)
             => FailureIf(failurePredicate, value, error);
 
+        [EditorBrowsable(EditorBrowsableState.Never)]
         [Obsolete("Use FailureIf() instead.")]
         public static Result<T, E> CreateFailure<T, E>(bool isFailure, T value, E error)
             => FailureIf(isFailure, value, error);
 
+        [EditorBrowsable(EditorBrowsableState.Never)]
         [Obsolete("Use FailureIf() instead.")]
         public static Result<T, E> CreateFailure<T, E>(Func<bool> failurePredicate, T value, E error)
             => FailureIf(failurePredicate, value, error);
 
+        [EditorBrowsable(EditorBrowsableState.Never)]
         [Obsolete("Use FailureIf() instead.")]
         public static Task<Result<T, E>> CreateFailure<T, E>(Func<Task<bool>> failurePredicate, T value, E error)
             => FailureIf(failurePredicate, value, error);

--- a/CSharpFunctionalExtensions/Result/Obsolete/Fail.cs
+++ b/CSharpFunctionalExtensions/Result/Obsolete/Fail.cs
@@ -1,17 +1,21 @@
 ﻿using System;
+using System.ComponentModel;
 
 namespace CSharpFunctionalExtensions
 {
     public partial struct Result
     {
+        [EditorBrowsable(EditorBrowsableState.Never)]
         [Obsolete("Use Failure() instead.")]
         public static Result Fail(string error)
             => Failure(error);
 
+        [EditorBrowsable(EditorBrowsableState.Never)]
         [Obsolete("Use Failure() instead.")]
         public static Result<T> Fail<T>(string error)
             => Failure<T>(error);
 
+        [EditorBrowsable(EditorBrowsableState.Never)]
         [Obsolete("Use Failure() instead.")]
         public static Result<T, E> Fail<T, E>(E error)
             => Failure<T, E>(error);

--- a/CSharpFunctionalExtensions/Result/Obsolete/Ok.cs
+++ b/CSharpFunctionalExtensions/Result/Obsolete/Ok.cs
@@ -1,17 +1,21 @@
 ﻿using System;
+using System.ComponentModel;
 
 namespace CSharpFunctionalExtensions
 {
     public partial struct Result
     {
+        [EditorBrowsable(EditorBrowsableState.Never)]
         [Obsolete("Use Success() instead.")]
         public static Result Ok()
             => Success();
 
+        [EditorBrowsable(EditorBrowsableState.Never)]
         [Obsolete("Use Success() instead.")]
         public static Result<T> Ok<T>(T value)
             => Success(value);
 
+        [EditorBrowsable(EditorBrowsableState.Never)]
         [Obsolete("Use Success() instead.")]
         public static Result<T, E> Ok<T, E>(T value)
             => Success<T, E>(value);

--- a/CSharpFunctionalExtensions/Result/Obsolete/OnBoth.cs
+++ b/CSharpFunctionalExtensions/Result/Obsolete/OnBoth.cs
@@ -1,17 +1,21 @@
 using System;
+using System.ComponentModel;
 
 namespace CSharpFunctionalExtensions
 {
     public static partial class ResultExtensions
     {
+        [EditorBrowsable(EditorBrowsableState.Never)]
         [Obsolete("Use Finally() instead.")]
         public static T OnBoth<T>(this Result result, Func<Result, T> func)
             => Finally(result, func);
 
+        [EditorBrowsable(EditorBrowsableState.Never)]
         [Obsolete("Use Finally() instead.")]
         public static K OnBoth<T, K>(this Result<T> result, Func<Result<T>, K> func)
             => Finally(result, func);
 
+        [EditorBrowsable(EditorBrowsableState.Never)]
         [Obsolete("Use Finally() instead.")]
         public static K OnBoth<T, K, E>(this Result<T, E> result, Func<Result<T, E>, K> func)
             => Finally(result, func);

--- a/CSharpFunctionalExtensions/Result/Obsolete/OnBothAsyncBoth.cs
+++ b/CSharpFunctionalExtensions/Result/Obsolete/OnBothAsyncBoth.cs
@@ -1,18 +1,22 @@
 using System;
+using System.ComponentModel;
 using System.Threading.Tasks;
 
 namespace CSharpFunctionalExtensions
 {
     public static partial class AsyncResultExtensionsBothOperands
     {
+        [EditorBrowsable(EditorBrowsableState.Never)]
         [Obsolete("Use Finally() instead.")]
         public static Task<T> OnBoth<T>(this Task<Result> resultTask, Func<Result, Task<T>> func)
             => Finally(resultTask, func);
 
+        [EditorBrowsable(EditorBrowsableState.Never)]
         [Obsolete("Use Finally() instead.")]
         public static Task<K> OnBoth<T, K>(this Task<Result<T>> resultTask, Func<Result<T>, Task<K>> func)
             => Finally(resultTask, func);
 
+        [EditorBrowsable(EditorBrowsableState.Never)]
         [Obsolete("Use Finally() instead.")]
         public static Task<K> OnBoth<T, K, E>(this Task<Result<T, E>> resultTask, Func<Result<T, E>, Task<K>> func)
             => Finally(resultTask, func);

--- a/CSharpFunctionalExtensions/Result/Obsolete/OnBothAsyncLeft.cs
+++ b/CSharpFunctionalExtensions/Result/Obsolete/OnBothAsyncLeft.cs
@@ -1,18 +1,22 @@
 using System;
+using System.ComponentModel;
 using System.Threading.Tasks;
 
 namespace CSharpFunctionalExtensions
 {
     public static partial class AsyncResultExtensionsLeftOperand
     {
+        [EditorBrowsable(EditorBrowsableState.Never)]
         [Obsolete("Use Finally() instead.")]
         public static Task<T> OnBoth<T>(this Task<Result> resultTask, Func<Result, T> func)
             => Finally(resultTask, func);
 
+        [EditorBrowsable(EditorBrowsableState.Never)]
         [Obsolete("Use Finally() instead.")]
         public static Task<K> OnBoth<T, K>(this Task<Result<T>> resultTask, Func<Result<T>, K> func)
             => Finally(resultTask, func);
 
+        [EditorBrowsable(EditorBrowsableState.Never)]
         [Obsolete("Use Finally() instead.")]
         public static Task<K> OnBoth<T, K, E>(this Task<Result<T, E>> resultTask, Func<Result<T, E>, K> func)
             => Finally(resultTask, func);

--- a/CSharpFunctionalExtensions/Result/Obsolete/OnBothAsyncRight.cs
+++ b/CSharpFunctionalExtensions/Result/Obsolete/OnBothAsyncRight.cs
@@ -1,18 +1,22 @@
 using System;
+using System.ComponentModel;
 using System.Threading.Tasks;
 
 namespace CSharpFunctionalExtensions
 {
     public static partial class AsyncResultExtensionsRightOperand
     {
+        [EditorBrowsable(EditorBrowsableState.Never)]
         [Obsolete("Use Finally() instead.")]
         public static Task<T> OnBoth<T>(this Result result, Func<Result, Task<T>> func)
             => Finally(result, func);
 
+        [EditorBrowsable(EditorBrowsableState.Never)]
         [Obsolete("Use Finally() instead.")]
         public static Task<K> OnBoth<T, K>(this Result<T> result, Func<Result<T>, Task<K>> func)
             => Finally(result, func);
 
+        [EditorBrowsable(EditorBrowsableState.Never)]
         [Obsolete("Use Finally() instead.")]
         public static Task<K> OnBoth<T, K, E>(this Result<T, E> result, Func<Result<T, E>, Task<K>> func)
             => Finally(result, func);

--- a/CSharpFunctionalExtensions/Result/Obsolete/OnSuccess.cs
+++ b/CSharpFunctionalExtensions/Result/Obsolete/OnSuccess.cs
@@ -1,49 +1,61 @@
 using System;
+using System.ComponentModel;
 
 namespace CSharpFunctionalExtensions
 {
     public static partial class ResultExtensions
     {
+        [EditorBrowsable(EditorBrowsableState.Never)]
         [Obsolete("Use Map() instead.")]
         public static Result<K, E> OnSuccess<T, K, E>(this Result<T, E> result, Func<T, K> func)
             => Map(result, func);
 
+        [EditorBrowsable(EditorBrowsableState.Never)]
         [Obsolete("Use Map() instead.")]
         public static Result<K> OnSuccess<T, K>(this Result<T> result, Func<T, K> func)
             => Map(result, func);
 
+        [EditorBrowsable(EditorBrowsableState.Never)]
         [Obsolete("Use Map() instead.")]
         public static Result<K> OnSuccess<K>(this Result result, Func<K> func)
             => Map(result, func);
 
+        [EditorBrowsable(EditorBrowsableState.Never)]
         [Obsolete("Use Bind() instead.")]
         public static Result<K, E> OnSuccess<T, K, E>(this Result<T, E> result, Func<T, Result<K, E>> func)
             => Bind(result, func);
 
+        [EditorBrowsable(EditorBrowsableState.Never)]
         [Obsolete("Use Bind() instead.")]
         public static Result<K> OnSuccess<T, K>(this Result<T> result, Func<T, Result<K>> func)
             => Bind(result, func);
 
+        [EditorBrowsable(EditorBrowsableState.Never)]
         [Obsolete("Use Bind() instead.")]
         public static Result<K> OnSuccess<K>(this Result result, Func<Result<K>> func)
             => Bind(result, func);
 
+        [EditorBrowsable(EditorBrowsableState.Never)]
         [Obsolete("Use Bind() instead.")]
         public static Result OnSuccess<T>(this Result<T> result, Func<T, Result> func)
             => Bind(result, func);
 
+        [EditorBrowsable(EditorBrowsableState.Never)]
         [Obsolete("Use Bind() instead.")]
         public static Result OnSuccess(this Result result, Func<Result> func)
             => Bind(result, func);
 
+        [EditorBrowsable(EditorBrowsableState.Never)]
         [Obsolete("Use Tap() instead.")]
         public static Result<T, E> OnSuccess<T, E>(this Result<T, E> result, Action<T> action)
             => Tap(result, action);
 
+        [EditorBrowsable(EditorBrowsableState.Never)]
         [Obsolete("Use Tap() instead.")]
         public static Result<T> OnSuccess<T>(this Result<T> result, Action<T> action)
             => Tap(result, action);
 
+        [EditorBrowsable(EditorBrowsableState.Never)]
         [Obsolete("Use Tap() instead.")]
         public static Result OnSuccess(this Result result, Action action)
             => Tap(result, action);

--- a/CSharpFunctionalExtensions/Result/Obsolete/OnSuccessAsyncBoth.cs
+++ b/CSharpFunctionalExtensions/Result/Obsolete/OnSuccessAsyncBoth.cs
@@ -1,50 +1,62 @@
 using System;
+using System.ComponentModel;
 using System.Threading.Tasks;
 
 namespace CSharpFunctionalExtensions
 {
     public static partial class AsyncResultExtensionsBothOperands
     {
+        [EditorBrowsable(EditorBrowsableState.Never)]
         [Obsolete("Use Map() instead.")]
         public static Task<Result<K, E>> OnSuccess<T, K, E>(this Task<Result<T, E>> resultTask, Func<T, Task<K>> func)
             => Map(resultTask, func);
 
+        [EditorBrowsable(EditorBrowsableState.Never)]
         [Obsolete("Use Map() instead.")]
         public static Task<Result<K>> OnSuccess<T, K>(this Task<Result<T>> resultTask, Func<T, Task<K>> func)
             => Map(resultTask, func);
 
+        [EditorBrowsable(EditorBrowsableState.Never)]
         [Obsolete("Use Map() instead.")]
         public static Task<Result<K>> OnSuccess<K>(this Task<Result> resultTask, Func<Task<K>> func)
             => Map(resultTask, func);
 
+        [EditorBrowsable(EditorBrowsableState.Never)]
         [Obsolete("Use Bind() instead.")]
         public static Task<Result<K, E>> OnSuccess<T, K, E>(this Task<Result<T, E>> resultTask, Func<T, Task<Result<K, E>>> func)
             => Bind(resultTask, func);
 
+        [EditorBrowsable(EditorBrowsableState.Never)]
         [Obsolete("Use Bind() instead.")]
         public static Task<Result<K>> OnSuccess<T, K>(this Task<Result<T>> resultTask, Func<T, Task<Result<K>>> func)
             => Bind(resultTask, func);
 
+        [EditorBrowsable(EditorBrowsableState.Never)]
         [Obsolete("Use Bind() instead.")]
         public static Task<Result<K>> OnSuccess<K>(this Task<Result> resultTask, Func<Task<Result<K>>> func)
             => Bind(resultTask, func);
 
+        [EditorBrowsable(EditorBrowsableState.Never)]
         [Obsolete("Use Bind() instead.")]
         public static Task<Result> OnSuccess<T>(this Task<Result<T>> resultTask, Func<T, Task<Result>> func)
             => Bind(resultTask, func);
 
+        [EditorBrowsable(EditorBrowsableState.Never)]
         [Obsolete("Use Bind() instead.")]
         public static Task<Result> OnSuccess(this Task<Result> resultTask, Func<Task<Result>> func)
             => Bind(resultTask, func);
 
+        [EditorBrowsable(EditorBrowsableState.Never)]
         [Obsolete("Use Tap() instead.")]
         public static Task<Result<T, E>> OnSuccess<T, E>(this Task<Result<T, E>> resultTask, Func<T, Task> action)
             => Tap(resultTask, action);
 
+        [EditorBrowsable(EditorBrowsableState.Never)]
         [Obsolete("Use Tap() instead.")]
         public static Task<Result<T>> OnSuccess<T>(this Task<Result<T>> resultTask, Func<T, Task> action)
             => Tap(resultTask, action);
 
+        [EditorBrowsable(EditorBrowsableState.Never)]
         [Obsolete("Use Tap() instead.")]
         public static Task<Result> OnSuccess(this Task<Result> resultTask, Func<Task> action)
             => Tap(resultTask, action);

--- a/CSharpFunctionalExtensions/Result/Obsolete/OnSuccessAsyncLeft.cs
+++ b/CSharpFunctionalExtensions/Result/Obsolete/OnSuccessAsyncLeft.cs
@@ -1,46 +1,57 @@
 using System;
+using System.ComponentModel;
 using System.Threading.Tasks;
 
 namespace CSharpFunctionalExtensions
 {
     public static partial class AsyncResultExtensionsLeftOperand
     {
+        [EditorBrowsable(EditorBrowsableState.Never)]
         [Obsolete("Use Map() instead.")]
         public static Task<Result<K, E>> OnSuccess<T, K, E>(this Task<Result<T, E>> resultTask, Func<T, K> func)
             => Map(resultTask, func);
 
+        [EditorBrowsable(EditorBrowsableState.Never)]
         [Obsolete("Use Map() instead.")]
         public static Task<Result<K>> OnSuccess<T, K>(this Task<Result<T>> resultTask, Func<T, K> func)
             => Map(resultTask, func);
 
+        [EditorBrowsable(EditorBrowsableState.Never)]
         [Obsolete("Use Map() instead.")]
         public static Task<Result<K>> OnSuccess<K>(this Task<Result> resultTask, Func<K> func)
             => Map(resultTask, func);
 
+        [EditorBrowsable(EditorBrowsableState.Never)]
         [Obsolete("Use Bind() instead.")]
         public static Task<Result<K, E>> OnSuccess<T, K, E>(this Task<Result<T, E>> resultTask, Func<T, Result<K, E>> func)
             => Bind(resultTask, func);
 
+        [EditorBrowsable(EditorBrowsableState.Never)]
         [Obsolete("Use Bind() instead.")]
         public static Task<Result<K>> OnSuccess<T, K>(this Task<Result<T>> resultTask, Func<T, Result<K>> func)
             => Bind(resultTask, func);
 
+        [EditorBrowsable(EditorBrowsableState.Never)]
         [Obsolete("Use Bind() instead.")]
         public static Task<Result<K>> OnSuccess<K>(this Task<Result> resultTask, Func<Result<K>> func)
             => Bind(resultTask, func);
 
+        [EditorBrowsable(EditorBrowsableState.Never)]
         [Obsolete("Use Bind() instead.")]
         public static Task<Result> OnSuccess<T>(this Task<Result<T>> resultTask, Func<T, Result> func)
             => Bind(resultTask, func);
 
+        [EditorBrowsable(EditorBrowsableState.Never)]
         [Obsolete("Use Bind() instead.")]
         public static Task<Result> OnSuccess(this Task<Result> resultTask, Func<Result> func)
             => Bind(resultTask, func);
 
+        [EditorBrowsable(EditorBrowsableState.Never)]
         [Obsolete("Use Tap() instead.")]
         public static Task<Result<T>> OnSuccess<T>(this Task<Result<T>> resultTask, Action<T> action)
             => Tap(resultTask, action);
 
+        [EditorBrowsable(EditorBrowsableState.Never)]
         [Obsolete("Use Tap() instead.")]
         public static Task<Result> OnSuccess(this Task<Result> resultTask, Action action)
             => Tap(resultTask, action);

--- a/CSharpFunctionalExtensions/Result/Obsolete/OnSuccessAsyncRight.cs
+++ b/CSharpFunctionalExtensions/Result/Obsolete/OnSuccessAsyncRight.cs
@@ -1,50 +1,62 @@
 using System;
+using System.ComponentModel;
 using System.Threading.Tasks;
 
 namespace CSharpFunctionalExtensions
 {
     public static partial class AsyncResultExtensionsRightOperand
     {
+        [EditorBrowsable(EditorBrowsableState.Never)]
         [Obsolete("Use Map() instead.")]
         public static Task<Result<K, E>> OnSuccess<T, K, E>(this Result<T, E> result, Func<T, Task<K>> func)
             => Map(result, func);
 
+        [EditorBrowsable(EditorBrowsableState.Never)]
         [Obsolete("Use Map() instead.")]
         public static Task<Result<K>> OnSuccess<T, K>(this Result<T> result, Func<T, Task<K>> func)
             => Map(result, func);
 
+        [EditorBrowsable(EditorBrowsableState.Never)]
         [Obsolete("Use Map() instead.")]
         public static Task<Result<K>> OnSuccess<K>(this Result result, Func<Task<K>> func)
             => Map(result, func);
 
+        [EditorBrowsable(EditorBrowsableState.Never)]
         [Obsolete("Use Bind() instead.")]
         public static Task<Result<K, E>> OnSuccess<T, K, E>(this Result<T, E> result, Func<T, Task<Result<K, E>>> func)
             => Bind(result, func);
 
+        [EditorBrowsable(EditorBrowsableState.Never)]
         [Obsolete("Use Bind() instead.")]
         public static Task<Result<K>> OnSuccess<T, K>(this Result<T> result, Func<T, Task<Result<K>>> func)
             => Bind(result, func);
 
+        [EditorBrowsable(EditorBrowsableState.Never)]
         [Obsolete("Use Bind() instead.")]
         public static Task<Result<K>> OnSuccess<K>(this Result result, Func<Task<Result<K>>> func)
             => Bind(result, func);
 
+        [EditorBrowsable(EditorBrowsableState.Never)]
         [Obsolete("Use Bind() instead.")]
         public static Task<Result> OnSuccess<T>(this Result<T> result, Func<T, Task<Result>> func)
             => Bind(result, func);
 
+        [EditorBrowsable(EditorBrowsableState.Never)]
         [Obsolete("Use Bind() instead.")]
         public static Task<Result> OnSuccess(this Result result, Func<Task<Result>> func)
             => Bind(result, func);
 
+        [EditorBrowsable(EditorBrowsableState.Never)]
         [Obsolete("Use Tap() instead.")]
         public static Task<Result<T, E>> OnSuccess<T, E>(this Result<T, E> result, Func<T, Task> action)
             => Tap(result, action);
 
+        [EditorBrowsable(EditorBrowsableState.Never)]
         [Obsolete("Use Tap() instead.")]
         public static Task<Result<T>> OnSuccess<T>(this Result<T> result, Func<T, Task> action)
             => Tap(result, action);
 
+        [EditorBrowsable(EditorBrowsableState.Never)]
         [Obsolete("Use Tap() instead.")]
         public static Task<Result> OnSuccess(this Result result, Func<Task> action)
             => Tap(result, action);

--- a/CSharpFunctionalExtensions/Result/Obsolete/OnSuccessWithTransactionScope.cs
+++ b/CSharpFunctionalExtensions/Result/Obsolete/OnSuccessWithTransactionScope.cs
@@ -1,5 +1,6 @@
 #if NETSTANDARD2_0
 using System;
+using System.ComponentModel;
 using System.Threading.Tasks;
 
 namespace CSharpFunctionalExtensions
@@ -7,104 +8,128 @@ namespace CSharpFunctionalExtensions
     public static partial class ResultExtensions
     {
         // Non-async extensions
+        [EditorBrowsable(EditorBrowsableState.Never)]
         [Obsolete("Use MapWithTransactionScope() instead.")]
         public static Result<K> OnSuccessWithTransactionScope<T, K>(this Result<T> self, Func<T, K> f)
             => self.MapWithTransactionScope(f);
 
+        [EditorBrowsable(EditorBrowsableState.Never)]
         [Obsolete("Use MapWithTransactionScope() instead.")]
         public static Result<K> OnSuccessWithTransactionScope<K>(this Result self, Func<K> f)
             => self.MapWithTransactionScope(f);
 
+        [EditorBrowsable(EditorBrowsableState.Never)]
         [Obsolete("Use BindWithTransactionScope() instead.")]
         public static Result<K> OnSuccessWithTransactionScope<T, K>(this Result<T> self, Func<T, Result<K>> f)
             => self.BindWithTransactionScope(f);
 
+        [EditorBrowsable(EditorBrowsableState.Never)]
         [Obsolete("Use BindWithTransactionScope() instead.")]
         public static Result<K> OnSuccessWithTransactionScope<K>(this Result self, Func<Result<K>> f)
             => self.BindWithTransactionScope(f);
 
+        [EditorBrowsable(EditorBrowsableState.Never)]
         [Obsolete("Use BindWithTransactionScope() instead.")]
         public static Result OnSuccessWithTransactionScope<T>(this Result<T> self, Func<T, Result> f)
             => self.BindWithTransactionScope(f);
 
+        [EditorBrowsable(EditorBrowsableState.Never)]
         [Obsolete("Use BindWithTransactionScope() instead.")]
         public static Result OnSuccessWithTransactionScope(this Result self, Func<Result> f)
             => self.BindWithTransactionScope(f);
 
 
         // Async - both operands
+        [EditorBrowsable(EditorBrowsableState.Never)]
         [Obsolete("Use MapWithTransactionScope() instead.")]
         public static Task<Result<K>> OnSuccessWithTransactionScope<T, K>(this Task<Result<T>> self, Func<T, Task<K>> f)
             => self.MapWithTransactionScope(f);
 
+        [EditorBrowsable(EditorBrowsableState.Never)]
         [Obsolete("Use MapWithTransactionScope() instead.")]
         public static Task<Result<K>> OnSuccessWithTransactionScope<K>(this Task<Result> self, Func<Task<K>> f)
             => self.MapWithTransactionScope(f);
 
+        [EditorBrowsable(EditorBrowsableState.Never)]
         [Obsolete("Use BindWithTransactionScope() instead.")]
         public static Task<Result<K>> OnSuccessWithTransactionScope<T, K>(this Task<Result<T>> self, Func<T, Task<Result<K>>> f)
             => self.BindWithTransactionScope(f);
 
+        [EditorBrowsable(EditorBrowsableState.Never)]
         [Obsolete("Use BindWithTransactionScope() instead.")]
         public static Task<Result<K>> OnSuccessWithTransactionScope<K>(this Task<Result> self, Func<Task<Result<K>>> f)
             => self.BindWithTransactionScope(f);
 
+        [EditorBrowsable(EditorBrowsableState.Never)]
         [Obsolete("Use BindWithTransactionScope() instead.")]
         public static Task<Result> OnSuccessWithTransactionScope<T>(this Task<Result<T>> self, Func<T, Task<Result>> f)
             => self.BindWithTransactionScope(f);
 
+        [EditorBrowsable(EditorBrowsableState.Never)]
         [Obsolete("Use BindWithTransactionScope() instead.")]
         public static Task<Result> OnSuccessWithTransactionScope(this Task<Result> self, Func<Task<Result>> f)
             => self.BindWithTransactionScope(f);
 
 
         // Async - left operands
+        [EditorBrowsable(EditorBrowsableState.Never)]
         [Obsolete("Use MapWithTransactionScope() instead.")]
         public static Task<Result<K>> OnSuccessWithTransactionScope<T, K>(this Task<Result<T>> self, Func<T, K> f)
             => self.MapWithTransactionScope(f);
 
+        [EditorBrowsable(EditorBrowsableState.Never)]
         [Obsolete("Use MapWithTransactionScope() instead.")]
         public static Task<Result<K>> OnSuccessWithTransactionScope<K>(this Task<Result> self, Func<K> f)
             => self.MapWithTransactionScope(f);
 
+        [EditorBrowsable(EditorBrowsableState.Never)]
         [Obsolete("Use BindWithTransactionScope() instead.")]
         public static Task<Result<K>> OnSuccessWithTransactionScope<T, K>(this Task<Result<T>> self, Func<T, Result<K>> f)
             => self.BindWithTransactionScope(f);
 
+        [EditorBrowsable(EditorBrowsableState.Never)]
         [Obsolete("Use BindWithTransactionScope() instead.")]
         public static Task<Result<K>> OnSuccessWithTransactionScope<K>(this Task<Result> self, Func<Result<K>> f)
             => self.BindWithTransactionScope(f);
 
+        [EditorBrowsable(EditorBrowsableState.Never)]
         [Obsolete("Use BindWithTransactionScope() instead.")]
         public static Task<Result> OnSuccessWithTransactionScope<T>(this Task<Result<T>> self, Func<T, Result> f)
             => self.BindWithTransactionScope(f);
 
+        [EditorBrowsable(EditorBrowsableState.Never)]
         [Obsolete("Use BindWithTransactionScope() instead.")]
         public static Task<Result> OnSuccessWithTransactionScope(this Task<Result> self, Func<Result> f)
             => self.BindWithTransactionScope(f);
 
 
         // Async - right operands
+        [EditorBrowsable(EditorBrowsableState.Never)]
         [Obsolete("Use MapWithTransactionScope() instead.")]
         public static Task<Result<K>> OnSuccessWithTransactionScope<T, K>(this Result<T> self, Func<T, Task<K>> f)
             => self.MapWithTransactionScope(f);
 
+        [EditorBrowsable(EditorBrowsableState.Never)]
         [Obsolete("Use MapWithTransactionScope() instead.")]
         public static Task<Result<K>> OnSuccessWithTransactionScope<K>(this Result self, Func<Task<K>> f)
             => self.MapWithTransactionScope(f);
 
+        [EditorBrowsable(EditorBrowsableState.Never)]
         [Obsolete("Use BindWithTransactionScope() instead.")]
         public static Task<Result<K>> OnSuccessWithTransactionScope<T, K>(this Result<T> self, Func<T, Task<Result<K>>> f)
             => self.BindWithTransactionScope(f);
 
+        [EditorBrowsable(EditorBrowsableState.Never)]
         [Obsolete("Use BindWithTransactionScope() instead.")]
         public static Task<Result<K>> OnSuccessWithTransactionScope<K>(this Result self, Func<Task<Result<K>>> f)
             => self.BindWithTransactionScope(f);
 
+        [EditorBrowsable(EditorBrowsableState.Never)]
         [Obsolete("Use BindWithTransactionScope() instead.")]
         public static Task<Result> OnSuccessWithTransactionScope<T>(this Result<T> self, Func<T, Task<Result>> f)
             => self.BindWithTransactionScope(f);
 
+        [EditorBrowsable(EditorBrowsableState.Never)]
         [Obsolete("Use BindWithTransactionScope() instead.")]
         public static Task<Result> OnSuccessWithTransactionScope(this Result self, Func<Task<Result>> f)
             => self.BindWithTransactionScope(f);

--- a/CSharpFunctionalExtensions/Result/Obsolete/Tap.cs
+++ b/CSharpFunctionalExtensions/Result/Obsolete/Tap.cs
@@ -1,17 +1,21 @@
 using System;
+using System.ComponentModel;
 
 namespace CSharpFunctionalExtensions
 {
     public static partial class ResultExtensions
     {
+        [EditorBrowsable(EditorBrowsableState.Never)]
         [Obsolete("Use Check() instead.")]
         public static Result<T> Tap<T>(this Result<T> result, Func<T, Result> func) 
             => Check(result, func);
 
+        [EditorBrowsable(EditorBrowsableState.Never)]
         [Obsolete("Use Check() instead.")]
         public static Result<T> Tap<T, K>(this Result<T> result, Func<T, Result<K>> func) 
             => Check(result, func);
 
+        [EditorBrowsable(EditorBrowsableState.Never)]
         [Obsolete("Use Check() instead.")]
         public static Result<T, E> Tap<T, K, E>(this Result<T, E> result, Func<T, Result<K, E>> func) 
             => Check(result, func);

--- a/CSharpFunctionalExtensions/Result/Obsolete/TapAsyncBoth.cs
+++ b/CSharpFunctionalExtensions/Result/Obsolete/TapAsyncBoth.cs
@@ -1,18 +1,22 @@
 using System;
+using System.ComponentModel;
 using System.Threading.Tasks;
 
 namespace CSharpFunctionalExtensions
 {
     public static partial class AsyncResultExtensionsBothOperands
     {
+        [EditorBrowsable(EditorBrowsableState.Never)]
         [Obsolete("Use Check() instead.")]
         public static Task<Result<T>> Tap<T>(this Task<Result<T>> resultTask, Func<T, Task<Result>> func) =>
             Check(resultTask, func);
 
+        [EditorBrowsable(EditorBrowsableState.Never)]
         [Obsolete("Use Check() instead.")]
         public static Task<Result<T>> Tap<T, K>(this Task<Result<T>> resultTask, Func<T, Task<Result<K>>> func) =>
             Check(resultTask, func);
 
+        [EditorBrowsable(EditorBrowsableState.Never)]
         [Obsolete("Use Check() instead.")]
         public static Task<Result<T, E>> Tap<T, K, E>(this Task<Result<T, E>> resultTask, Func<T, Task<Result<K, E>>> func) => 
             Check(resultTask, func);

--- a/CSharpFunctionalExtensions/Result/Obsolete/TapAsyncLeft.cs
+++ b/CSharpFunctionalExtensions/Result/Obsolete/TapAsyncLeft.cs
@@ -1,18 +1,22 @@
 using System;
+using System.ComponentModel;
 using System.Threading.Tasks;
 
 namespace CSharpFunctionalExtensions
 {
     public static partial class AsyncResultExtensionsLeftOperand
     {
+        [EditorBrowsable(EditorBrowsableState.Never)]
         [Obsolete("Use Check() instead.")]
         public static Task<Result<T>> Tap<T>(this Task<Result<T>> resultTask, Func<T, Result> func) =>
             Check(resultTask, func);
 
+        [EditorBrowsable(EditorBrowsableState.Never)]
         [Obsolete("Use Check() instead.")]
         public static Task<Result<T>> Tap<T, K>(this Task<Result<T>> resultTask, Func<T, Result<K>> func) =>
             Check(resultTask, func);
 
+        [EditorBrowsable(EditorBrowsableState.Never)]
         [Obsolete("Use Check() instead.")]
         public static Task<Result<T, E>> Tap<T, K, E>(this Task<Result<T, E>> resultTask, Func<T, Result<K, E>> func) =>
             Check(resultTask, func);

--- a/CSharpFunctionalExtensions/Result/Obsolete/TapAsyncRight.cs
+++ b/CSharpFunctionalExtensions/Result/Obsolete/TapAsyncRight.cs
@@ -1,17 +1,21 @@
 using System;
+using System.ComponentModel;
 using System.Threading.Tasks;
 
 namespace CSharpFunctionalExtensions
 {
     public static partial class AsyncResultExtensionsRightOperand
     {
+        [EditorBrowsable(EditorBrowsableState.Never)]
         [Obsolete("Use Check() instead.")]
         public static Task<Result<T>> Tap<T>(this Result<T> result, Func<T, Task<Result>> func) => Check(result, func);
 
+        [EditorBrowsable(EditorBrowsableState.Never)]
         [Obsolete("Use Check() instead.")]
         public static Task<Result<T>> Tap<T, K>(this Result<T> result, Func<T, Task<Result<K>>> func) =>
             Check(result, func);
 
+        [EditorBrowsable(EditorBrowsableState.Never)]
         [Obsolete("Use Check() instead.")]
         public static Task<Result<T, E>> Tap<T, K, E>(this Result<T, E> result, Func<T, Task<Result<K, E>>> func) =>
             Check(result, func);

--- a/CSharpFunctionalExtensions/Result/Obsolete/TapIf.cs
+++ b/CSharpFunctionalExtensions/Result/Obsolete/TapIf.cs
@@ -1,29 +1,36 @@
 using System;
+using System.ComponentModel;
 
 namespace CSharpFunctionalExtensions
 {
     public static partial class ResultExtensions
     {
+        [EditorBrowsable(EditorBrowsableState.Never)]
         [Obsolete("Use CheckIf() instead.")]
         public static Result<T> TapIf<T>(this Result<T> result, bool condition, Func<T, Result> func) =>
             CheckIf(result, condition, func);
 
+        [EditorBrowsable(EditorBrowsableState.Never)]
         [Obsolete("Use CheckIf() instead.")]
         public static Result<T> TapIf<T, K>(this Result<T> result, bool condition, Func<T, Result<K>> func) =>
             CheckIf(result, condition, func);
 
+        [EditorBrowsable(EditorBrowsableState.Never)]
         [Obsolete("Use CheckIf() instead.")]
         public static Result<T, E> TapIf<T, K, E>(this Result<T, E> result, bool condition, Func<T, Result<K, E>> func) =>
             CheckIf(result, condition, func);
 
+        [EditorBrowsable(EditorBrowsableState.Never)]
         [Obsolete("Use CheckIf() instead.")]
         public static Result<T> TapIf<T>(this Result<T> result, Func<T, bool> predicate, Func<T, Result> func) =>
             CheckIf(result, predicate, func);
 
+        [EditorBrowsable(EditorBrowsableState.Never)]
         [Obsolete("Use CheckIf() instead.")]
         public static Result<T> TapIf<T, K>(this Result<T> result, Func<T, bool> predicate, Func<T, Result<K>> func) =>
             CheckIf(result, predicate, func);
 
+        [EditorBrowsable(EditorBrowsableState.Never)]
         [Obsolete("Use CheckIf() instead.")]
         public static Result<T, E> TapIf<T, K, E>(this Result<T, E> result, Func<T, bool> predicate, Func<T, Result<K, E>> func) =>
             CheckIf(result, predicate, func);

--- a/CSharpFunctionalExtensions/Result/Obsolete/TapIfAsyncBoth.cs
+++ b/CSharpFunctionalExtensions/Result/Obsolete/TapIfAsyncBoth.cs
@@ -1,30 +1,37 @@
 using System;
+using System.ComponentModel;
 using System.Threading.Tasks;
 
 namespace CSharpFunctionalExtensions
 {
     public static partial class AsyncResultExtensionsBothOperands
     {
+        [EditorBrowsable(EditorBrowsableState.Never)]
         [Obsolete("Use CheckIf() instead.")]
         public static Task<Result<T>> TapIf<T>(this Task<Result<T>> resultTask, bool condition, Func<T, Task<Result>> func) =>
             CheckIf(resultTask, condition, func);
 
+        [EditorBrowsable(EditorBrowsableState.Never)]
         [Obsolete("Use CheckIf() instead.")]
         public static Task<Result<T>> TapIf<T, K>(this Task<Result<T>> resultTask, bool condition, Func<T, Task<Result<K>>> func) =>
             CheckIf(resultTask, condition, func);
 
+        [EditorBrowsable(EditorBrowsableState.Never)]
         [Obsolete("Use CheckIf() instead.")]
         public static Task<Result<T, E>> TapIf<T, K, E>(this Task<Result<T, E>> resultTask, bool condition, Func<T, Task<Result<K, E>>> func) =>
             CheckIf(resultTask, condition, func);
 
+        [EditorBrowsable(EditorBrowsableState.Never)]
         [Obsolete("Use CheckIf() instead.")]
         public static Task<Result<T>> TapIf<T>(this Task<Result<T>> resultTask, Func<T, bool> predicate, Func<T, Task<Result>> func) =>
             CheckIf(resultTask, predicate, func);
 
+        [EditorBrowsable(EditorBrowsableState.Never)]
         [Obsolete("Use CheckIf() instead.")]
         public static Task<Result<T>> TapIf<T, K>(this Task<Result<T>> resultTask, Func<T, bool> predicate, Func<T, Task<Result<K>>> func) =>
             CheckIf(resultTask, predicate, func);
 
+        [EditorBrowsable(EditorBrowsableState.Never)]
         [Obsolete("Use CheckIf() instead.")]
         public static Task<Result<T, E>> TapIf<T, K, E>(this Task<Result<T, E>> resultTask, Func<T, bool> predicate, Func<T, Task<Result<K, E>>> func) =>
             CheckIf(resultTask, predicate, func);

--- a/CSharpFunctionalExtensions/Result/Obsolete/TapIfAsyncLeft.cs
+++ b/CSharpFunctionalExtensions/Result/Obsolete/TapIfAsyncLeft.cs
@@ -1,30 +1,37 @@
 using System;
+using System.ComponentModel;
 using System.Threading.Tasks;
 
 namespace CSharpFunctionalExtensions
 {
     public static partial class AsyncResultExtensionsLeftOperand
     {
+        [EditorBrowsable(EditorBrowsableState.Never)]
         [Obsolete("Use CheckIf() instead.")]
         public static Task<Result<T>> TapIf<T>(this Task<Result<T>> resultTask, bool condition, Func<T, Result> func) =>
             CheckIf(resultTask, condition, func);
 
+        [EditorBrowsable(EditorBrowsableState.Never)]
         [Obsolete("Use CheckIf() instead.")]
         public static Task<Result<T>> TapIf<T, K>(this Task<Result<T>> resultTask, bool condition, Func<T, Result<K>> func) =>
             CheckIf(resultTask, condition, func);
 
+        [EditorBrowsable(EditorBrowsableState.Never)]
         [Obsolete("Use CheckIf() instead.")]
         public static Task<Result<T, E>> TapIf<T, K, E>(this Task<Result<T, E>> resultTask, bool condition, Func<T, Result<K, E>> func) =>
             CheckIf(resultTask, condition, func);
 
+        [EditorBrowsable(EditorBrowsableState.Never)]
         [Obsolete("Use CheckIf() instead.")]
         public static Task<Result<T>> TapIf<T>(this Task<Result<T>> resultTask, Func<T, bool> predicate, Func<T, Result> func) =>
             CheckIf(resultTask, predicate, func);
 
+        [EditorBrowsable(EditorBrowsableState.Never)]
         [Obsolete("Use CheckIf() instead.")]
         public static Task<Result<T>> TapIf<T, K>(this Task<Result<T>> resultTask, Func<T, bool> predicate, Func<T, Result<K>> func) =>
             CheckIf(resultTask, predicate, func);
 
+        [EditorBrowsable(EditorBrowsableState.Never)]
         [Obsolete("Use CheckIf() instead.")]
         public static Task<Result<T, E>> TapIf<T, K, E>(this Task<Result<T, E>> resultTask, Func<T, bool> predicate, Func<T, Result<K, E>> func) =>
             CheckIf(resultTask, predicate, func);

--- a/CSharpFunctionalExtensions/Result/Obsolete/TapIfAsyncRight.cs
+++ b/CSharpFunctionalExtensions/Result/Obsolete/TapIfAsyncRight.cs
@@ -1,30 +1,37 @@
 using System;
+using System.ComponentModel;
 using System.Threading.Tasks;
 
 namespace CSharpFunctionalExtensions
 {
     public static partial class AsyncResultExtensionsRightOperand
     {
+        [EditorBrowsable(EditorBrowsableState.Never)]
         [Obsolete("Use CheckIf() instead.")]
         public static Task<Result<T>> TapIf<T>(this Result<T> result, bool condition, Func<T, Task<Result>> func) =>
             CheckIf(result, condition, func);
 
+        [EditorBrowsable(EditorBrowsableState.Never)]
         [Obsolete("Use CheckIf() instead.")]
         public static Task<Result<T>> TapIf<T, K>(this Result<T> result, bool condition, Func<T, Task<Result<K>>> func) =>
             CheckIf(result, condition, func);
 
+        [EditorBrowsable(EditorBrowsableState.Never)]
         [Obsolete("Use CheckIf() instead.")]
         public static Task<Result<T, E>> TapIf<T, K, E>(this Result<T, E> result, bool condition, Func<T, Task<Result<K, E>>> func) =>
             CheckIf(result, condition, func);
 
+        [EditorBrowsable(EditorBrowsableState.Never)]
         [Obsolete("Use CheckIf() instead.")]
         public static Task<Result<T>> TapIf<T>(this Result<T> result, Func<T, bool> predicate, Func<T, Task<Result>> func) =>
             CheckIf(result, predicate, func);
 
+        [EditorBrowsable(EditorBrowsableState.Never)]
         [Obsolete("Use CheckIf() instead.")]
         public static Task<Result<T>> TapIf<T, K>(this Result<T> result, Func<T, bool> predicate, Func<T, Task<Result<K>>> func) =>
             CheckIf(result, predicate, func);
 
+        [EditorBrowsable(EditorBrowsableState.Never)]
         [Obsolete("Use CheckIf() instead.")]
         public static Task<Result<T, E>> TapIf<T, K, E>(this Result<T, E> result, Func<T, bool> predicate, Func<T, Task<Result<K, E>>> func) =>
             CheckIf(result, predicate, func);


### PR DESCRIPTION
As discussed, have applied the `[EditorBrowsable(EditorBrowsableState.Never)]` attribute to all `Result` methods which had previously been marked as Obsolete.
