### PR TITLE
Fix unessesary shadowing

### DIFF
--- a/CSharpFunctionalExtensions.Tests/MaybeTests/BasicTests.cs
+++ b/CSharpFunctionalExtensions.Tests/MaybeTests/BasicTests.cs
@@ -161,6 +161,7 @@ namespace CSharpFunctionalExtensions.Tests.MaybeTests
             result.Should().Be(value);
         }
       
+        [Fact]
         public void Maybe_None_doesnt_throw_on_Deconstruct()
         {
             Maybe<int> maybe = Maybe.None;
@@ -173,6 +174,7 @@ namespace CSharpFunctionalExtensions.Tests.MaybeTests
             act.Should().NotThrow();
         }
         
+        [Fact]
         public void Maybe_struct_default_is_none()
         {
             Maybe<int> maybe = default;
@@ -181,6 +183,7 @@ namespace CSharpFunctionalExtensions.Tests.MaybeTests
             maybe.HasNoValue.Should().BeTrue();
         }
         
+        [Fact]
         public void Maybe_struct_value_is_some()
         {
             Maybe<int> maybe = 5;
@@ -189,6 +192,7 @@ namespace CSharpFunctionalExtensions.Tests.MaybeTests
             maybe.HasNoValue.Should().BeFalse();
         }
         
+        [Fact]
         public void Maybe_class_null_is_none()
         {
             Maybe<MyClass> maybe = null;

--- a/CSharpFunctionalExtensions.Tests/MaybeTests/BasicTests.cs
+++ b/CSharpFunctionalExtensions.Tests/MaybeTests/BasicTests.cs
@@ -172,6 +172,30 @@ namespace CSharpFunctionalExtensions.Tests.MaybeTests
             
             act.Should().NotThrow();
         }
+        
+        public void Maybe_struct_default_is_none()
+        {
+            Maybe<int> maybe = default;
+
+            maybe.HasValue.Should().BeFalse();
+            maybe.HasNoValue.Should().BeTrue();
+        }
+        
+        public void Maybe_struct_value_is_some()
+        {
+            Maybe<int> maybe = 5;
+
+            maybe.HasValue.Should().BeTrue();
+            maybe.HasNoValue.Should().BeFalse();
+        }
+        
+        public void Maybe_class_null_is_none()
+        {
+            Maybe<MyClass> maybe = null;
+
+            maybe.HasValue.Should().BeFalse();
+            maybe.HasNoValue.Should().BeTrue();
+        }
 
         private class MyClass
         {

--- a/CSharpFunctionalExtensions/Maybe/Maybe.cs
+++ b/CSharpFunctionalExtensions/Maybe/Maybe.cs
@@ -143,7 +143,7 @@ namespace CSharpFunctionalExtensions
     /// <summary>
     /// Non-generic entrypoint for <see cref="Maybe{T}" /> members
     /// </summary>
-    public struct Maybe
+    public readonly struct Maybe
     {
         public static Maybe None => new Maybe();
 

--- a/CSharpFunctionalExtensions/Maybe/Maybe.cs
+++ b/CSharpFunctionalExtensions/Maybe/Maybe.cs
@@ -1,9 +1,10 @@
 ﻿using System;
+using System.Collections.Generic;
 
 namespace CSharpFunctionalExtensions
 {
     [Serializable]
-    public struct Maybe<T> : IEquatable<Maybe<T>>, IMaybe<T>
+    public readonly struct Maybe<T> : IEquatable<Maybe<T>>, IEquatable<object>, IMaybe<T>
     {
         private readonly bool _isValueSet;
 
@@ -80,6 +81,16 @@ namespace CSharpFunctionalExtensions
             return !(maybe == value);
         }
 
+        public static bool operator ==(Maybe<T> maybe, object other)
+        {
+            return maybe.Equals(other);
+        }
+        
+        public static bool operator !=(Maybe<T> maybe, object other)
+        {
+            return !(maybe == other);
+        }
+
         public static bool operator ==(Maybe<T> first, Maybe<T> second)
         {
             return first.Equals(second);
@@ -92,22 +103,13 @@ namespace CSharpFunctionalExtensions
 
         public override bool Equals(object obj)
         {
-            if (obj == null)
+            if (obj is null)
                 return false;
-
-            if (obj.GetType() != typeof(Maybe<T>))
-            {
-                if (obj is T objT)
-                {
-                    obj = new Maybe<T>(objT);
-                }
-
-                if (!(obj is Maybe<T>))
-                    return false;
-            }
-
-            var other = (Maybe<T>)obj;
-            return Equals(other);
+            if (obj is Maybe<T> other)
+                return Equals(other);
+            if (obj is T value)
+                return Equals(value);
+            return false;
         }
 
         public bool Equals(Maybe<T> other)
@@ -118,7 +120,7 @@ namespace CSharpFunctionalExtensions
             if (HasNoValue || other.HasNoValue)
                 return false;
 
-            return _value.Equals(other._value);
+            return EqualityComparer<T>.Default.Equals(_value, other._value);
         }
 
         public override int GetHashCode()

--- a/CSharpFunctionalExtensions/Maybe/Maybe.cs
+++ b/CSharpFunctionalExtensions/Maybe/Maybe.cs
@@ -51,18 +51,13 @@ namespace CSharpFunctionalExtensions
             _isValueSet = true;
             _value = value;
         }
-
-        public static implicit operator Maybe<T>(T value)
+        
+        public static implicit operator Maybe<T>(in T value)
         {
-            if (value?.GetType() == typeof(Maybe<T>))
-            {
-                return (Maybe<T>)(object)value;
-            }
-
-            return new Maybe<T>(value);
+            return EqualityComparer<T>.Default.Equals(default, value) ? default : new Maybe<T>(value);
         }
 
-        public static implicit operator Maybe<T>(Maybe value) => None;
+        public static implicit operator Maybe<T>(in Maybe value) => None;
 
         public static Maybe<T> From(T obj)
         {

--- a/CSharpFunctionalExtensions/Maybe/Maybe.cs
+++ b/CSharpFunctionalExtensions/Maybe/Maybe.cs
@@ -53,12 +53,12 @@ namespace CSharpFunctionalExtensions
             _value = value;
         }
         
-        public static implicit operator Maybe<T>(in T value)
+        public static implicit operator Maybe<T>(T value)
         {
             return EqualityComparer<T>.Default.Equals(default, value) ? default : new Maybe<T>(value);
         }
 
-        public static implicit operator Maybe<T>(in Maybe value) => None;
+        public static implicit operator Maybe<T>(Maybe value) => None;
 
         public static Maybe<T> From(T obj)
         {

--- a/CSharpFunctionalExtensions/Maybe/MaybeExtensions.cs
+++ b/CSharpFunctionalExtensions/Maybe/MaybeExtensions.cs
@@ -8,7 +8,7 @@ namespace CSharpFunctionalExtensions
 {
     public static class MaybeExtensions
     {
-        public static Result<T> ToResult<T>(this Maybe<T> maybe, string errorMessage)
+        public static Result<T> ToResult<T>(in this Maybe<T> maybe, string errorMessage)
         {
             if (maybe.HasNoValue)
                 return Result.Failure<T>(errorMessage);
@@ -16,7 +16,7 @@ namespace CSharpFunctionalExtensions
             return Result.Success(maybe.GetValueOrThrow());
         }
 
-        public static Result<T, E> ToResult<T, E>(this Maybe<T> maybe, E error)
+        public static Result<T, E> ToResult<T, E>(in this Maybe<T> maybe, E error)
         {
             if (maybe.HasNoValue)
                 return Result.Failure<T, E>(error);
@@ -24,7 +24,7 @@ namespace CSharpFunctionalExtensions
             return Result.Success<T, E>(maybe.GetValueOrThrow());
         }
 
-        public static T GetValueOrDefault<T>(this Maybe<T> maybe, Func<T> defaultValue)
+        public static T GetValueOrDefault<T>(in this Maybe<T> maybe, Func<T> defaultValue)
         {
             if (maybe.HasNoValue)
                 return defaultValue();
@@ -32,7 +32,7 @@ namespace CSharpFunctionalExtensions
             return maybe.GetValueOrThrow();
         }
 
-        public static K GetValueOrDefault<T, K>(this Maybe<T> maybe, Func<T, K> selector, K defaultValue = default)
+        public static K GetValueOrDefault<T, K>(in this Maybe<T> maybe, Func<T, K> selector, K defaultValue = default)
         {
             if (maybe.HasNoValue)
                 return defaultValue;
@@ -40,7 +40,7 @@ namespace CSharpFunctionalExtensions
             return selector(maybe.GetValueOrThrow());
         }
 
-        public static K GetValueOrDefault<T, K>(this Maybe<T> maybe, Func<T, K> selector, Func<K> defaultValue)
+        public static K GetValueOrDefault<T, K>(in this Maybe<T> maybe, Func<T, K> selector, Func<K> defaultValue)
         {
             if (maybe.HasNoValue)
                 return defaultValue();
@@ -50,24 +50,24 @@ namespace CSharpFunctionalExtensions
 
         [EditorBrowsable(EditorBrowsableState.Never)]
         [Obsolete("Use GetValueOrDefault() instead.")]
-        public static T Unwrap<T>(this Maybe<T> maybe, T defaultValue = default)
+        public static T Unwrap<T>(in this Maybe<T> maybe, T defaultValue = default)
         {
             return maybe.GetValueOrDefault(defaultValue);
         }
 
         [EditorBrowsable(EditorBrowsableState.Never)]
         [Obsolete("Use GetValueOrDefault() instead.")]
-        public static K Unwrap<T, K>(this Maybe<T> maybe, Func<T, K> selector, K defaultValue = default(K))
+        public static K Unwrap<T, K>(in this Maybe<T> maybe, Func<T, K> selector, K defaultValue = default(K))
         {
             return maybe.GetValueOrDefault(selector, defaultValue);
         }
 
-        public static List<T> ToList<T>(this Maybe<T> maybe)
+        public static List<T> ToList<T>(in this Maybe<T> maybe)
         {
             return maybe.GetValueOrDefault(value => new List<T> { value }, new List<T>());
         }
 
-        public static Maybe<T> Where<T>(this Maybe<T> maybe, Func<T, bool> predicate)
+        public static Maybe<T> Where<T>(in this Maybe<T> maybe, Func<T, bool> predicate)
         {
             if (maybe.HasNoValue)
                 return Maybe<T>.None;
@@ -78,24 +78,24 @@ namespace CSharpFunctionalExtensions
             return Maybe<T>.None;
         }
 
-        public static Maybe<K> Select<T, K>(this Maybe<T> maybe, Func<T, K> selector)
+        public static Maybe<K> Select<T, K>(in this Maybe<T> maybe, Func<T, K> selector)
         {
             return maybe.Map(selector);
         }
 
         [EditorBrowsable(EditorBrowsableState.Never)]
         [Obsolete("Use Bind instead of this method")]
-        public static Maybe<K> Select<T, K>(this Maybe<T> maybe, Func<T, Maybe<K>> selector)
+        public static Maybe<K> Select<T, K>(in this Maybe<T> maybe, Func<T, Maybe<K>> selector)
         {
             return maybe.Bind(selector);
         }
 
-        public static Maybe<K> SelectMany<T, K>(this Maybe<T> maybe, Func<T, Maybe<K>> selector)
+        public static Maybe<K> SelectMany<T, K>(in this Maybe<T> maybe, Func<T, Maybe<K>> selector)
         {
             return maybe.Bind(selector);
         }
 
-        public static Maybe<V> SelectMany<T, U, V>(this Maybe<T> maybe,
+        public static Maybe<V> SelectMany<T, U, V>(in this Maybe<T> maybe,
             Func<T, Maybe<U>> selector,
             Func<T, U, V> project)
         {
@@ -104,7 +104,7 @@ namespace CSharpFunctionalExtensions
                 Maybe<V>.None);
         }
 
-        public static Maybe<K> Map<T, K>(this Maybe<T> maybe, Func<T, K> selector)
+        public static Maybe<K> Map<T, K>(in this Maybe<T> maybe, Func<T, K> selector)
         {
             if (maybe.HasNoValue)
                 return Maybe<K>.None;
@@ -112,7 +112,7 @@ namespace CSharpFunctionalExtensions
             return selector(maybe.GetValueOrThrow());
         }
 
-        public static Maybe<K> Bind<T, K>(this Maybe<T> maybe, Func<T, Maybe<K>> selector)
+        public static Maybe<K> Bind<T, K>(in this Maybe<T> maybe, Func<T, Maybe<K>> selector)
         {
             if (maybe.HasNoValue)
                 return Maybe<K>.None;
@@ -126,7 +126,7 @@ namespace CSharpFunctionalExtensions
         /// <param name="maybe"></param>
         /// <param name="action"></param>
         /// <typeparam name="T"></typeparam>
-        public static void Execute<T>(this Maybe<T> maybe, Action<T> action)
+        public static void Execute<T>(in this Maybe<T> maybe, Action<T> action)
         {
             if (maybe.HasNoValue)
                 return;
@@ -140,7 +140,7 @@ namespace CSharpFunctionalExtensions
         /// <param name="maybe"></param>
         /// <param name="action"></param>
         /// <typeparam name="T"></typeparam>
-        public static void ExecuteNoValue<T>(this Maybe<T> maybe, Action action)
+        public static void ExecuteNoValue<T>(in this Maybe<T> maybe, Action action)
         {
             if (maybe.HasValue)
                 return;
@@ -183,7 +183,7 @@ namespace CSharpFunctionalExtensions
         /// <param name="fallbackOperation"></param>
         /// <typeparam name="T"></typeparam>
         /// <returns></returns>
-        public static Maybe<T> Or<T>(this Maybe<T> maybe, Func<T> fallbackOperation)
+        public static Maybe<T> Or<T>(in this Maybe<T> maybe, Func<T> fallbackOperation)
         {
             if (maybe.HasNoValue)
                 return fallbackOperation();
@@ -213,7 +213,7 @@ namespace CSharpFunctionalExtensions
         /// <param name="fallback"></param>
         /// <typeparam name="T"></typeparam>
         /// <returns></returns>
-        public static Maybe<T> Or<T>(this Maybe<T> maybe, Maybe<T> fallback)
+        public static Maybe<T> Or<T>(in this Maybe<T> maybe, Maybe<T> fallback)
         {
             if (maybe.HasNoValue)
                 return fallback;
@@ -243,7 +243,7 @@ namespace CSharpFunctionalExtensions
         /// <param name="fallbackOperation"></param>
         /// <typeparam name="T"></typeparam>
         /// <returns></returns>
-        public static Maybe<T> Or<T>(this Maybe<T> maybe, Func<Maybe<T>> fallbackOperation)
+        public static Maybe<T> Or<T>(in this Maybe<T> maybe, Func<Maybe<T>> fallbackOperation)
         {
             if (maybe.HasNoValue)
                 return fallbackOperation();
@@ -266,14 +266,14 @@ namespace CSharpFunctionalExtensions
             return maybe;
         }
 
-        public static TE Match<TE, T>(this Maybe<T> maybe, Func<T, TE> Some, Func<TE> None)
+        public static TE Match<TE, T>(in this Maybe<T> maybe, Func<T, TE> Some, Func<TE> None)
         {
             return maybe.HasValue
                 ? Some(maybe.GetValueOrThrow())
                 : None();
         }
 
-        public static void Match<T>(this Maybe<T> maybe, Action<T> Some, Action None)
+        public static void Match<T>(in this Maybe<T> maybe, Action<T> Some, Action None)
         {
             if (maybe.HasValue)
             {
@@ -285,10 +285,10 @@ namespace CSharpFunctionalExtensions
             }
         }
 
-        public static TE Match<TE, TKey, TValue>(this Maybe<KeyValuePair<TKey, TValue>> maybe, Func<TKey, TValue, TE> Some, Func<TE> None) =>
+        public static TE Match<TE, TKey, TValue>(in this Maybe<KeyValuePair<TKey, TValue>> maybe, Func<TKey, TValue, TE> Some, Func<TE> None) =>
             maybe.HasValue ? Some.Invoke(maybe.GetValueOrThrow().Key, maybe.GetValueOrThrow().Value) : None.Invoke();
 
-        public static void Match<TKey, TValue>(this Maybe<KeyValuePair<TKey, TValue>> maybe, Action<TKey, TValue> Some, Action None)
+        public static void Match<TKey, TValue>(in this Maybe<KeyValuePair<TKey, TValue>> maybe, Action<TKey, TValue> Some, Action None)
         {
             if (maybe.HasValue)
             {
@@ -398,7 +398,7 @@ namespace CSharpFunctionalExtensions
         }
 #endif
 
-        public static void Deconstruct<T>(this Maybe<T> result, out bool hasValue, out T value)
+        public static void Deconstruct<T>(in this Maybe<T> result, out bool hasValue, out T value)
         {
             hasValue = result.HasValue;
             value = result.GetValueOrDefault();

--- a/CSharpFunctionalExtensions/Maybe/MaybeExtensions.cs
+++ b/CSharpFunctionalExtensions/Maybe/MaybeExtensions.cs
@@ -377,7 +377,7 @@ namespace CSharpFunctionalExtensions
             return Maybe<T>.None;
         }
 
-#if NET40
+#if !NETCORE || !NET45_OR_GREATER || !NETSTANDARD
         public static Maybe<V> TryFind<K, V>(this IDictionary<K, V> dict, K key)
         {
             if (dict.ContainsKey(key))

--- a/CSharpFunctionalExtensions/Maybe/MaybeExtensions.cs
+++ b/CSharpFunctionalExtensions/Maybe/MaybeExtensions.cs
@@ -403,5 +403,14 @@ namespace CSharpFunctionalExtensions
             hasValue = result.HasValue;
             value = result.GetValueOrDefault();
         }
+        
+        /// <summary>
+        /// Flattens nested <see cref="Maybe{T}"/>s into a single <see cref="Maybe{T}"/>.
+        /// </summary>
+        /// <returns>The flattened <see cref="Maybe{T}"/>.</returns>
+        public static Maybe<T> Flatten<T>(in this Maybe<Maybe<T>> maybe)
+        {
+            return maybe.GetValueOrDefault();
+        }
     }
 }

--- a/CSharpFunctionalExtensions/Result/Methods/FailureIf.cs
+++ b/CSharpFunctionalExtensions/Result/Methods/FailureIf.cs
@@ -35,7 +35,7 @@ namespace CSharpFunctionalExtensions
         /// <summary>
         ///     Creates a result whose success/failure depends on the supplied predicate. Opposite of SuccessIf().
         /// </summary>
-        public static Result<T> FailureIf<T>(Func<bool> failurePredicate, T value, string error)
+        public static Result<T> FailureIf<T>(Func<bool> failurePredicate, in T value, string error)
             => SuccessIf(!failurePredicate(), value, error);
 
         /// <summary>
@@ -50,13 +50,13 @@ namespace CSharpFunctionalExtensions
         /// <summary>
         ///     Creates a result whose success/failure reflects the supplied condition. Opposite of SuccessIf().
         /// </summary>
-        public static Result<T, E> FailureIf<T, E>(bool isFailure, T value, E error)
+        public static Result<T, E> FailureIf<T, E>(bool isFailure, in T value, in E error)
             => SuccessIf(!isFailure, value, error);
 
         /// <summary>
         ///     Creates a result whose success/failure depends on the supplied predicate. Opposite of SuccessIf().
         /// </summary>
-        public static Result<T, E> FailureIf<T, E>(Func<bool> failurePredicate, T value, E error)
+        public static Result<T, E> FailureIf<T, E>(Func<bool> failurePredicate, in T value, in E error)
             => SuccessIf(!failurePredicate(), value, error);
 
         /// <summary>
@@ -74,13 +74,13 @@ namespace CSharpFunctionalExtensions
         /// <summary>
         ///     Creates a result whose success/failure depends on the supplied predicate. Opposite of SuccessIf().
         /// </summary>
-        public static UnitResult<E> FailureIf<E>(bool isFailure, E error)
+        public static UnitResult<E> FailureIf<E>(bool isFailure, in E error)
             => SuccessIf(!isFailure, error);
 
         /// <summary>
         ///     Creates a result whose success/failure depends on the supplied predicate. Opposite of SuccessIf().
         /// </summary>
-        public static UnitResult<E> FailureIf<E>(Func<bool> failurePredicate, E error)
+        public static UnitResult<E> FailureIf<E>(Func<bool> failurePredicate, in E error)
             => SuccessIf(!failurePredicate(), error);
 
         /// <summary>

--- a/CSharpFunctionalExtensions/Result/Methods/SuccessIf.cs
+++ b/CSharpFunctionalExtensions/Result/Methods/SuccessIf.cs
@@ -35,7 +35,7 @@ namespace CSharpFunctionalExtensions
         /// <summary>
         ///     Creates a result whose success/failure reflects the supplied condition. Opposite of FailureIf().
         /// </summary>
-        public static Result<T> SuccessIf<T>(bool isSuccess, T value, string error)
+        public static Result<T> SuccessIf<T>(bool isSuccess, in T value, string error)
         {
             return isSuccess
                 ? Success(value)
@@ -45,7 +45,7 @@ namespace CSharpFunctionalExtensions
         /// <summary>
         ///     Creates a result whose success/failure depends on the supplied predicate. Opposite of FailureIf().
         /// </summary>
-        public static Result<T> SuccessIf<T>(Func<bool> predicate, T value, string error)
+        public static Result<T> SuccessIf<T>(Func<bool> predicate, in T value, string error)
         {
             return SuccessIf(predicate(), value, error);
         }
@@ -62,7 +62,7 @@ namespace CSharpFunctionalExtensions
         /// <summary>
         ///     Creates a result whose success/failure reflects the supplied condition. Opposite of FailureIf().
         /// </summary>
-        public static Result<T, E> SuccessIf<T, E>(bool isSuccess, T value, E error)
+        public static Result<T, E> SuccessIf<T, E>(bool isSuccess, in T value, in E error)
         {
             return isSuccess
                 ? Success<T, E>(value)
@@ -72,7 +72,7 @@ namespace CSharpFunctionalExtensions
         /// <summary>
         ///     Creates a result whose success/failure depends on the supplied predicate. Opposite of FailureIf().
         /// </summary>
-        public static Result<T, E> SuccessIf<T, E>(Func<bool> predicate, T value, E error)
+        public static Result<T, E> SuccessIf<T, E>(Func<bool> predicate, in T value, in E error)
         {
             return SuccessIf(predicate(), value, error);
         }
@@ -95,7 +95,7 @@ namespace CSharpFunctionalExtensions
         /// <summary>
         ///     Creates a result whose success/failure reflects the supplied condition. Opposite of FailureIf().
         /// </summary>
-        public static UnitResult<E> SuccessIf<E>(bool isSuccess, E error)
+        public static UnitResult<E> SuccessIf<E>(bool isSuccess, in E error)
         {
             return isSuccess
                 ? Success<E>()
@@ -105,7 +105,7 @@ namespace CSharpFunctionalExtensions
         /// <summary>
         ///     Creates a result whose success/failure depends on the supplied predicate. Opposite of FailureIf().
         /// </summary>
-        public static UnitResult<E> SuccessIf<E>(Func<bool> predicate, E error)
+        public static UnitResult<E> SuccessIf<E>(Func<bool> predicate, in E error)
         {
             return SuccessIf(predicate(), error);
         }

--- a/CSharpFunctionalExtensions/Result/Result.cs
+++ b/CSharpFunctionalExtensions/Result/Result.cs
@@ -5,7 +5,7 @@ using System.Runtime.Serialization;
 namespace CSharpFunctionalExtensions
 {
     [Serializable]
-    public partial struct Result : IResult, ISerializable
+    public readonly partial struct Result : IResult, ISerializable
     {
         public bool IsFailure { get; }
         public bool IsSuccess => !IsFailure;
@@ -31,7 +31,7 @@ namespace CSharpFunctionalExtensions
             ResultCommonLogic.GetObjectData(this, info);
         }
 
-        public static implicit operator UnitResult<string>(Result result)
+        public static implicit operator UnitResult<string>(in Result result)
         {
             if (result.IsSuccess)
                 return UnitResult.Success<string>();

--- a/CSharpFunctionalExtensions/Result/Result.cs
+++ b/CSharpFunctionalExtensions/Result/Result.cs
@@ -31,7 +31,7 @@ namespace CSharpFunctionalExtensions
             ResultCommonLogic.GetObjectData(this, info);
         }
 
-        public static implicit operator UnitResult<string>(in Result result)
+        public static implicit operator UnitResult<string>(Result result)
         {
             if (result.IsSuccess)
                 return UnitResult.Success<string>();

--- a/CSharpFunctionalExtensions/Result/ResultT.cs
+++ b/CSharpFunctionalExtensions/Result/ResultT.cs
@@ -5,7 +5,7 @@ using System.Runtime.Serialization;
 namespace CSharpFunctionalExtensions
 {
     [Serializable]
-    public partial struct Result<T> : IResult<T>, ISerializable
+    public readonly partial struct Result<T> : IResult<T>, ISerializable
     {
         public bool IsFailure { get; }
         public bool IsSuccess => !IsFailure;
@@ -36,7 +36,7 @@ namespace CSharpFunctionalExtensions
             ResultCommonLogic.GetObjectData(this, info);
         }
 
-        public static implicit operator Result<T>(T value)
+        public static implicit operator Result<T>(in T value)
         {
             if (value is IResult<T> result)
             {
@@ -49,7 +49,7 @@ namespace CSharpFunctionalExtensions
             return Result.Success(value);
         }
 
-        public static implicit operator Result(Result<T> result)
+        public static implicit operator Result(in Result<T> result)
         {
             if (result.IsSuccess)
                 return Result.Success();
@@ -57,7 +57,7 @@ namespace CSharpFunctionalExtensions
                 return Result.Failure(result.Error);
         }
 
-        public static implicit operator UnitResult<string>(Result<T> result)
+        public static implicit operator UnitResult<string>(in Result<T> result)
         {
             if (result.IsSuccess)
                 return UnitResult.Success<string>();

--- a/CSharpFunctionalExtensions/Result/ResultT.cs
+++ b/CSharpFunctionalExtensions/Result/ResultT.cs
@@ -36,7 +36,7 @@ namespace CSharpFunctionalExtensions
             ResultCommonLogic.GetObjectData(this, info);
         }
 
-        public static implicit operator Result<T>(in T value)
+        public static implicit operator Result<T>(T value)
         {
             if (value is IResult<T> result)
             {
@@ -49,7 +49,7 @@ namespace CSharpFunctionalExtensions
             return Result.Success(value);
         }
 
-        public static implicit operator Result(in Result<T> result)
+        public static implicit operator Result(Result<T> result)
         {
             if (result.IsSuccess)
                 return Result.Success();
@@ -57,7 +57,7 @@ namespace CSharpFunctionalExtensions
                 return Result.Failure(result.Error);
         }
 
-        public static implicit operator UnitResult<string>(in Result<T> result)
+        public static implicit operator UnitResult<string>(Result<T> result)
         {
             if (result.IsSuccess)
                 return UnitResult.Success<string>();

--- a/CSharpFunctionalExtensions/Result/ResultTE.cs
+++ b/CSharpFunctionalExtensions/Result/ResultTE.cs
@@ -5,7 +5,7 @@ using System.Runtime.Serialization;
 namespace CSharpFunctionalExtensions
 {
     [Serializable]
-    public partial struct Result<T, E> : IResult<T, E>, ISerializable
+    public readonly partial struct Result<T, E> : IResult<T, E>, ISerializable
     {
         public bool IsFailure { get; }
         public bool IsSuccess => !IsFailure;
@@ -36,7 +36,7 @@ namespace CSharpFunctionalExtensions
             ResultCommonLogic.GetObjectData(this, info);
         }
 
-        public static implicit operator Result<T, E>(T value)
+        public static implicit operator Result<T, E>(in T value)
         {
             if (value is IResult<T, E> result)
             {
@@ -49,7 +49,7 @@ namespace CSharpFunctionalExtensions
             return Result.Success<T, E>(value);
         }
 
-        public static implicit operator Result<T, E>(E error)
+        public static implicit operator Result<T, E>(in E error)
         {
             if (error is IResult<T, E> result)
             {
@@ -62,7 +62,7 @@ namespace CSharpFunctionalExtensions
             return Result.Failure<T, E>(error);
         }
 
-        public static implicit operator UnitResult<E>(Result<T, E> result)
+        public static implicit operator UnitResult<E>(in Result<T, E> result)
         {
             if (result.IsSuccess)
                 return UnitResult.Success<E>();

--- a/CSharpFunctionalExtensions/Result/ResultTE.cs
+++ b/CSharpFunctionalExtensions/Result/ResultTE.cs
@@ -36,7 +36,7 @@ namespace CSharpFunctionalExtensions
             ResultCommonLogic.GetObjectData(this, info);
         }
 
-        public static implicit operator Result<T, E>(in T value)
+        public static implicit operator Result<T, E>(T value)
         {
             if (value is IResult<T, E> result)
             {
@@ -49,7 +49,7 @@ namespace CSharpFunctionalExtensions
             return Result.Success<T, E>(value);
         }
 
-        public static implicit operator Result<T, E>(in E error)
+        public static implicit operator Result<T, E>(E error)
         {
             if (error is IResult<T, E> result)
             {
@@ -62,7 +62,7 @@ namespace CSharpFunctionalExtensions
             return Result.Failure<T, E>(error);
         }
 
-        public static implicit operator UnitResult<E>(in Result<T, E> result)
+        public static implicit operator UnitResult<E>(Result<T, E> result)
         {
             if (result.IsSuccess)
                 return UnitResult.Success<E>();

--- a/CSharpFunctionalExtensions/Result/UnitResult.cs
+++ b/CSharpFunctionalExtensions/Result/UnitResult.cs
@@ -37,7 +37,7 @@ namespace CSharpFunctionalExtensions
             ResultCommonLogic.GetObjectData(this, info);
         }
 
-        public static implicit operator UnitResult<E>(in E error)
+        public static implicit operator UnitResult<E>(E error)
         {
             if (error is IUnitResult<E> result)
             {

--- a/CSharpFunctionalExtensions/Result/UnitResult.cs
+++ b/CSharpFunctionalExtensions/Result/UnitResult.cs
@@ -11,7 +11,7 @@ namespace CSharpFunctionalExtensions
     ///     The error type returned by a failed operation.
     /// </typeparam>
     [Serializable]
-    public partial struct UnitResult<E> : IUnitResult<E>, ISerializable
+    public readonly partial struct UnitResult<E> : IUnitResult<E>, ISerializable
     {
         public bool IsFailure { get; }
         public bool IsSuccess => !IsFailure;
@@ -19,7 +19,7 @@ namespace CSharpFunctionalExtensions
         private readonly E _error;
         public E Error => ResultCommonLogic.GetErrorWithSuccessGuard(IsFailure, _error);
 
-        internal UnitResult(bool isFailure, E error)
+        internal UnitResult(bool isFailure, in E error)
         {
             IsFailure = ResultCommonLogic.ErrorStateGuard(isFailure, error);
             _error = error;
@@ -37,7 +37,7 @@ namespace CSharpFunctionalExtensions
             ResultCommonLogic.GetObjectData(this, info);
         }
 
-        public static implicit operator UnitResult<E>(E error)
+        public static implicit operator UnitResult<E>(in E error)
         {
             if (error is IUnitResult<E> result)
             {
@@ -57,7 +57,7 @@ namespace CSharpFunctionalExtensions
         /// <summary>
         ///     Creates a failure result with the given error.
         /// </summary>
-        public static UnitResult<E> Failure<E>(E error)
+        public static UnitResult<E> Failure<E>(in E error)
         {
             return new UnitResult<E>(true, error);
         }


### PR DESCRIPTION
Mainly declaring structs as `readonly` and all functions as contravariant, so that the compiler does not create shadow copies per call, instead passes the stack pointers on.
For more information on the performance and memory benefits, here is some further reading
[In parameter modifier](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/in-parameter-modifier)
https://devblogs.microsoft.com/premier-developer/the-in-modifier-and-the-readonly-structs-in-c/

During that, I noticed that reflection performed during equality checking. Which is not good at all. Upon further exploring, I noticed, that during the equality comparison from `Maybe` to `object` the value is boxed up to two times, and one reflection object is created, and not cached using the  `Objeckt.GetType` method.
This is circumvented using `EqualityComparer<T>.Default` which is a lazily initialized `IEqualityComparer<T>` that performs a `Buffer.MemCmp` for structs and `Object.ReferenceEquals` for classes that do not implement `IEqualtable<T>`; otherwise it compiles an expression of the `Equals` method and wraps it in a `IEqualityComparer<T>`. Per generic type, we have a reasonable timeout because of the JIT on first call, even that is tiny compared to reflection. The functionallity of `EqualityComparer<T>.Default` can be explored [here](https://sharplab.io/#v2:C4LgTgrgdgNAJiA1AHwAICYCMBYAUKgBgAJVMAWAbj0JMwDoAlaYASwFsBTOgYQHs2ADiwA2HMAGUxANxYBjDgGcquPAuCRZwIgEE8Aej1EjREEQCSAUQCOEAIbBbAI1EAebQD48AbzzGiLKC0AfSlbYQgOZT9UAGYdAAoArVDwjgBKIi8iELCIogBeIhSIiiIAXzx9Q2NYokdeXmEiazthBXjtIl5gAAsxNKq/H1wDP2iAdmzijgLC7r6wOhzU5VHjCtwN6nQiACFMvC38ONIANhId7gPcaPQd4bHjTqkCojgOADNbCGFgKMfaABOeJmBQAOR+wniUjSaX+j32Uh2hSgkPhY1IwNBEOEUKRsPRfk6UBeKI4AHd4pg4b4AZiQeDIfESQTaQiiCTkRyKfEaTc6ZgsYzccz8Xy/Bs/GyiABtACyHF6vDgZkEUIVSpVaoA8gJWLwoAo6NoAOYmsCKBQsKQcMxQYQBAImtIAXWltTOdQaTWxkJcABV3IkoER/UVculrgCiNKJs0bGEWMAAJ58QS2C1gAPuOgAEU+31+dBaYXa7y+P2AMHDqXF60OQA==)

