### PR TITLE
Rework: Fix unessesary shadowing

### DIFF
--- a/CSharpFunctionalExtensions/Maybe/Maybe.cs
+++ b/CSharpFunctionalExtensions/Maybe/Maybe.cs
@@ -55,6 +55,10 @@ namespace CSharpFunctionalExtensions
         
         public static implicit operator Maybe<T>(T value)
         {
+            if (value is Maybe<T> m)
+            {
+                return m;
+            }
             return EqualityComparer<T>.Default.Equals(default, value) ? default : new Maybe<T>(value);
         }
 


### PR DESCRIPTION
This PR fixes the remaining issue from [#422 Fix unessesary shadowing](https://github.com/vkhorikov/CSharpFunctionalExtensions/pull/422) where `implicit T: Maybe<T>` would not accept dynamic typed box of `T` as a parameter when used by the `DynamicBinder` at runtime.