### PR TITLE
Move ValueTask to own namespace

### DIFF
--- a/CSharpFunctionalExtensions.Tests/MaybeTests/Extensions/BindTests.ValueTask.Left.cs
+++ b/CSharpFunctionalExtensions.Tests/MaybeTests/Extensions/BindTests.ValueTask.Left.cs
@@ -1,4 +1,5 @@
 ﻿using System.Threading.Tasks;
+using CSharpFunctionalExtensions.ValueTasks;
 using FluentAssertions;
 using Xunit;
 

--- a/CSharpFunctionalExtensions.Tests/MaybeTests/Extensions/BindTests.ValueTask.Right.cs
+++ b/CSharpFunctionalExtensions.Tests/MaybeTests/Extensions/BindTests.ValueTask.Right.cs
@@ -1,4 +1,5 @@
 ﻿using System.Threading.Tasks;
+using CSharpFunctionalExtensions.ValueTasks;
 using FluentAssertions;
 using Xunit;
 

--- a/CSharpFunctionalExtensions.Tests/MaybeTests/Extensions/BindTests.ValueTask.cs
+++ b/CSharpFunctionalExtensions.Tests/MaybeTests/Extensions/BindTests.ValueTask.cs
@@ -1,4 +1,5 @@
 ﻿using System.Threading.Tasks;
+using CSharpFunctionalExtensions.ValueTasks;
 using FluentAssertions;
 using Xunit;
 

--- a/CSharpFunctionalExtensions.Tests/MaybeTests/Extensions/ExecuteNoValueTests.ValueTask.Left.cs
+++ b/CSharpFunctionalExtensions.Tests/MaybeTests/Extensions/ExecuteNoValueTests.ValueTask.Left.cs
@@ -1,4 +1,5 @@
 ﻿using System.Threading.Tasks;
+using CSharpFunctionalExtensions.ValueTasks;
 using FluentAssertions;
 using Xunit;
 

--- a/CSharpFunctionalExtensions.Tests/MaybeTests/Extensions/ExecuteNoValueTests.ValueTask.Right.cs
+++ b/CSharpFunctionalExtensions.Tests/MaybeTests/Extensions/ExecuteNoValueTests.ValueTask.Right.cs
@@ -1,4 +1,5 @@
 ﻿using System.Threading.Tasks;
+using CSharpFunctionalExtensions.ValueTasks;
 using FluentAssertions;
 using Xunit;
 

--- a/CSharpFunctionalExtensions.Tests/MaybeTests/Extensions/ExecuteNoValueTests.ValueTask.cs
+++ b/CSharpFunctionalExtensions.Tests/MaybeTests/Extensions/ExecuteNoValueTests.ValueTask.cs
@@ -1,4 +1,5 @@
 ﻿using System.Threading.Tasks;
+using CSharpFunctionalExtensions.ValueTasks;
 using FluentAssertions;
 using Xunit;
 

--- a/CSharpFunctionalExtensions.Tests/MaybeTests/Extensions/ExecuteTests.ValueTask.Left.cs
+++ b/CSharpFunctionalExtensions.Tests/MaybeTests/Extensions/ExecuteTests.ValueTask.Left.cs
@@ -1,4 +1,5 @@
 ﻿using System.Threading.Tasks;
+using CSharpFunctionalExtensions.ValueTasks;
 using FluentAssertions;
 using Xunit;
 

--- a/CSharpFunctionalExtensions.Tests/MaybeTests/Extensions/ExecuteTests.ValueTask.Right.cs
+++ b/CSharpFunctionalExtensions.Tests/MaybeTests/Extensions/ExecuteTests.ValueTask.Right.cs
@@ -1,4 +1,5 @@
 ﻿using System.Threading.Tasks;
+using CSharpFunctionalExtensions.ValueTasks;
 using FluentAssertions;
 using Xunit;
 

--- a/CSharpFunctionalExtensions.Tests/MaybeTests/Extensions/ExecuteTests.ValueTask.cs
+++ b/CSharpFunctionalExtensions.Tests/MaybeTests/Extensions/ExecuteTests.ValueTask.cs
@@ -1,4 +1,5 @@
 ﻿using System.Threading.Tasks;
+using CSharpFunctionalExtensions.ValueTasks;
 using FluentAssertions;
 using Xunit;
 

--- a/CSharpFunctionalExtensions.Tests/MaybeTests/Extensions/GetValueOrThrowTests.ValueTask.cs
+++ b/CSharpFunctionalExtensions.Tests/MaybeTests/Extensions/GetValueOrThrowTests.ValueTask.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Threading.Tasks;
+using CSharpFunctionalExtensions.ValueTasks;
 using FluentAssertions;
 using Xunit;
 

--- a/CSharpFunctionalExtensions.Tests/MaybeTests/Extensions/MapTests.ValueTask.Left.cs
+++ b/CSharpFunctionalExtensions.Tests/MaybeTests/Extensions/MapTests.ValueTask.Left.cs
@@ -1,4 +1,5 @@
 ﻿using System.Threading.Tasks;
+using CSharpFunctionalExtensions.ValueTasks;
 using FluentAssertions;
 using Xunit;
 

--- a/CSharpFunctionalExtensions.Tests/MaybeTests/Extensions/MapTests.ValueTask.Right.cs
+++ b/CSharpFunctionalExtensions.Tests/MaybeTests/Extensions/MapTests.ValueTask.Right.cs
@@ -1,5 +1,6 @@
 ﻿using System.Threading.Tasks;
 using FluentAssertions;
+using CSharpFunctionalExtensions.ValueTasks;
 using Xunit;
 
 namespace CSharpFunctionalExtensions.Tests.MaybeTests.Extensions
@@ -11,7 +12,7 @@ namespace CSharpFunctionalExtensions.Tests.MaybeTests.Extensions
         {
             Maybe<T> maybe = T.Value;
 
-            var maybe2 = await maybe.Map(ExpectAndReturn_ValueTask(T.Value, T.Value2));
+            var maybe2 = await maybe.Map(valueTask: ExpectAndReturn_ValueTask(T.Value, T.Value2));
 
             maybe2.HasValue.Should().BeTrue();
             maybe2.Value.Should().Be(T.Value2);
@@ -22,7 +23,7 @@ namespace CSharpFunctionalExtensions.Tests.MaybeTests.Extensions
         {
             Maybe<T> maybe = null;
 
-            var maybe2 = await maybe.Map(ExpectAndReturn_ValueTask(null, T.Value2));
+            var maybe2 = await maybe.Map(valueTask: ExpectAndReturn_ValueTask(null, T.Value2));
 
             maybe2.HasValue.Should().BeFalse();
         }

--- a/CSharpFunctionalExtensions.Tests/MaybeTests/Extensions/MapTests.ValueTask.cs
+++ b/CSharpFunctionalExtensions.Tests/MaybeTests/Extensions/MapTests.ValueTask.cs
@@ -1,4 +1,5 @@
 ﻿using System.Threading.Tasks;
+using CSharpFunctionalExtensions.ValueTasks;
 using FluentAssertions;
 using Xunit;
 

--- a/CSharpFunctionalExtensions.Tests/MaybeTests/Extensions/MaybeTestBase.cs
+++ b/CSharpFunctionalExtensions.Tests/MaybeTests/Extensions/MaybeTestBase.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Threading.Tasks;
 using CSharpFunctionalExtensions.Tests.ResultTests;
+using CSharpFunctionalExtensions.ValueTasks;
 using FluentAssertions;
 
 namespace CSharpFunctionalExtensions.Tests.MaybeTests.Extensions

--- a/CSharpFunctionalExtensions.Tests/MaybeTests/Extensions/OrTests.ValueTask.Left.cs
+++ b/CSharpFunctionalExtensions.Tests/MaybeTests/Extensions/OrTests.ValueTask.Left.cs
@@ -1,4 +1,5 @@
 ﻿using System.Threading.Tasks;
+using CSharpFunctionalExtensions.ValueTasks;
 using FluentAssertions;
 using Xunit;
 

--- a/CSharpFunctionalExtensions.Tests/MaybeTests/Extensions/OrTests.ValueTask.Right.cs
+++ b/CSharpFunctionalExtensions.Tests/MaybeTests/Extensions/OrTests.ValueTask.Right.cs
@@ -1,4 +1,5 @@
 ﻿using System.Threading.Tasks;
+using CSharpFunctionalExtensions.ValueTasks;
 using FluentAssertions;
 using Xunit;
 

--- a/CSharpFunctionalExtensions.Tests/MaybeTests/Extensions/OrTests.ValueTask.cs
+++ b/CSharpFunctionalExtensions.Tests/MaybeTests/Extensions/OrTests.ValueTask.cs
@@ -1,4 +1,5 @@
 ﻿using System.Threading.Tasks;
+using CSharpFunctionalExtensions.ValueTasks;
 using FluentAssertions;
 using Xunit;
 

--- a/CSharpFunctionalExtensions.Tests/MaybeTests/Extensions/ToResultTests.ValueTask.Left.cs
+++ b/CSharpFunctionalExtensions.Tests/MaybeTests/Extensions/ToResultTests.ValueTask.Left.cs
@@ -1,4 +1,5 @@
 ﻿using System.Threading.Tasks;
+using CSharpFunctionalExtensions.ValueTasks;
 using FluentAssertions;
 using Xunit;
 

--- a/CSharpFunctionalExtensions.Tests/MaybeTests/Extensions/ToResultTests.ValueTask.cs
+++ b/CSharpFunctionalExtensions.Tests/MaybeTests/Extensions/ToResultTests.ValueTask.cs
@@ -1,4 +1,5 @@
 ﻿using System.Threading.Tasks;
+using CSharpFunctionalExtensions.ValueTasks;
 using FluentAssertions;
 using Xunit;
 

--- a/CSharpFunctionalExtensions.Tests/MaybeTests/Extensions/WhereTests.ValueTask.Left.cs
+++ b/CSharpFunctionalExtensions.Tests/MaybeTests/Extensions/WhereTests.ValueTask.Left.cs
@@ -1,4 +1,5 @@
 ﻿using System.Threading.Tasks;
+using CSharpFunctionalExtensions.ValueTasks;
 using FluentAssertions;
 using Xunit;
 

--- a/CSharpFunctionalExtensions.Tests/MaybeTests/Extensions/WhereTests.ValueTask.Right.cs
+++ b/CSharpFunctionalExtensions.Tests/MaybeTests/Extensions/WhereTests.ValueTask.Right.cs
@@ -1,4 +1,5 @@
 ﻿using System.Threading.Tasks;
+using CSharpFunctionalExtensions.ValueTasks;
 using FluentAssertions;
 using Xunit;
 

--- a/CSharpFunctionalExtensions.Tests/MaybeTests/Extensions/WhereTests.ValueTask.cs
+++ b/CSharpFunctionalExtensions.Tests/MaybeTests/Extensions/WhereTests.ValueTask.cs
@@ -1,4 +1,5 @@
 ﻿using System.Threading.Tasks;
+using CSharpFunctionalExtensions.ValueTasks;
 using FluentAssertions;
 using Xunit;
 

--- a/CSharpFunctionalExtensions.Tests/ResultTests/AmbiguityTests.cs
+++ b/CSharpFunctionalExtensions.Tests/ResultTests/AmbiguityTests.cs
@@ -23,16 +23,16 @@ public class AmbiguityTests
             .Bind(async _ => await GetTask());
     }
 
-    private Task<Result<Profile>> GetProfileAsync() =>
-        Result.Try(async () =>
+    private ValueTask<Result<Profile>> GetProfileAsync() =>
+        Result.Try(valueTask: async () =>
         {
             await Task.Yield();
 
             return new Profile();
         });
 
-    private Task<Result<Profile, Error>> GetProfileWithErrorAsync() =>
-        Result.Try(async () =>
+    private ValueTask<Result<Profile, Error>> GetProfileWithErrorAsync() =>
+        Result.Try(valueTask: async () =>
         {
             await Task.Yield();
 

--- a/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/BindIfTests.Base.cs
+++ b/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/BindIfTests.Base.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Threading.Tasks;
+using CSharpFunctionalExtensions.ValueTasks;
 using FluentAssertions;
 
 namespace CSharpFunctionalExtensions.Tests.ResultTests.Extensions

--- a/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/BindIfTests.ValueTask.Left.cs
+++ b/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/BindIfTests.ValueTask.Left.cs
@@ -1,4 +1,5 @@
 using System.Threading.Tasks;
+using CSharpFunctionalExtensions.ValueTasks;
 using FluentAssertions;
 using Xunit;
 

--- a/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/BindIfTests.ValueTask.Right.cs
+++ b/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/BindIfTests.ValueTask.Right.cs
@@ -1,4 +1,5 @@
 using System.Threading.Tasks;
+using CSharpFunctionalExtensions.ValueTasks;
 using FluentAssertions;
 using Xunit;
 

--- a/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/BindIfTests.ValueTask.cs
+++ b/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/BindIfTests.ValueTask.cs
@@ -1,4 +1,5 @@
 using System.Threading.Tasks;
+using CSharpFunctionalExtensions.ValueTasks;
 using FluentAssertions;
 using Xunit;
 

--- a/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/BindTests.ValueTask.cs
+++ b/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/BindTests.ValueTask.cs
@@ -1,4 +1,5 @@
 ﻿using System.Threading.Tasks;
+using CSharpFunctionalExtensions.ValueTasks;
 using FluentAssertions;
 using Xunit;
 

--- a/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/BindsTests.ValueTask.Left.cs
+++ b/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/BindsTests.ValueTask.Left.cs
@@ -1,6 +1,7 @@
 ﻿using System.Threading.Tasks;
 using CSharpFunctionalExtensions.Tests;
 using CSharpFunctionalExtensions.Tests.ResultTests.Extensions;
+using CSharpFunctionalExtensions.ValueTasks;
 using FluentAssertions;
 using Xunit;
 

--- a/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/BindsTests.ValueTask.Right.cs
+++ b/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/BindsTests.ValueTask.Right.cs
@@ -1,4 +1,5 @@
 ﻿using System.Threading.Tasks;
+using CSharpFunctionalExtensions.ValueTasks;
 using FluentAssertions;
 using Xunit;
 

--- a/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/CheckIfTests.ValueTask.Left.cs
+++ b/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/CheckIfTests.ValueTask.Left.cs
@@ -1,4 +1,5 @@
 using System.Threading.Tasks;
+using CSharpFunctionalExtensions.ValueTasks;
 using FluentAssertions;
 using Xunit;
 

--- a/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/CheckIfTests.ValueTask.Right.cs
+++ b/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/CheckIfTests.ValueTask.Right.cs
@@ -1,4 +1,5 @@
 using System.Threading.Tasks;
+using CSharpFunctionalExtensions.ValueTasks;
 using FluentAssertions;
 using Xunit;
 

--- a/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/CheckIfTests.ValueTask.cs
+++ b/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/CheckIfTests.ValueTask.cs
@@ -1,4 +1,5 @@
 using System.Threading.Tasks;
+using CSharpFunctionalExtensions.ValueTasks;
 using FluentAssertions;
 using Xunit;
 

--- a/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/CheckTests.ValueTask.Right.cs
+++ b/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/CheckTests.ValueTask.Right.cs
@@ -1,4 +1,5 @@
 using System.Threading.Tasks;
+using CSharpFunctionalExtensions.ValueTasks;
 using FluentAssertions;
 using Xunit;
 

--- a/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/CheckTests.ValueTask.cs
+++ b/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/CheckTests.ValueTask.cs
@@ -1,4 +1,5 @@
 using System.Threading.Tasks;
+using CSharpFunctionalExtensions.ValueTasks;
 using FluentAssertions;
 using Xunit;
 

--- a/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/CompensateTests.ValueTask.Left.cs
+++ b/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/CompensateTests.ValueTask.Left.cs
@@ -1,4 +1,5 @@
 ﻿using System.Threading.Tasks;
+using CSharpFunctionalExtensions.ValueTasks;
 using Xunit;
 
 namespace CSharpFunctionalExtensions.Tests.ResultTests.Extensions

--- a/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/CompensateTests.ValueTask.cs
+++ b/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/CompensateTests.ValueTask.cs
@@ -1,4 +1,5 @@
 ﻿using System.Threading.Tasks;
+using CSharpFunctionalExtensions.ValueTasks;
 using Xunit;
 
 namespace CSharpFunctionalExtensions.Tests.ResultTests.Extensions

--- a/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/EnsureTests.ValueTask.Left.cs
+++ b/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/EnsureTests.ValueTask.Left.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Threading.Tasks;
+using CSharpFunctionalExtensions.ValueTasks;
 using FluentAssertions;
 using Xunit;
 

--- a/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/EnsureTests.ValueTask.Right.cs
+++ b/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/EnsureTests.ValueTask.Right.cs
@@ -1,4 +1,5 @@
 ﻿using System.Threading.Tasks;
+using CSharpFunctionalExtensions.ValueTasks;
 using FluentAssertions;
 using Xunit;
 

--- a/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/EnsureTests.ValueTask.cs
+++ b/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/EnsureTests.ValueTask.cs
@@ -1,4 +1,5 @@
 ﻿using System.Threading.Tasks;
+using CSharpFunctionalExtensions.ValueTasks;
 using FluentAssertions;
 using Xunit;
 

--- a/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/FinallyTests.ValueTask.Left.cs
+++ b/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/FinallyTests.ValueTask.Left.cs
@@ -1,4 +1,5 @@
 ﻿using System.Threading.Tasks;
+using CSharpFunctionalExtensions.ValueTasks;
 using Xunit;
 
 namespace CSharpFunctionalExtensions.Tests.ResultTests.Extensions

--- a/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/FinallyTests.ValueTask.cs
+++ b/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/FinallyTests.ValueTask.cs
@@ -1,4 +1,5 @@
 ﻿using System.Threading.Tasks;
+using CSharpFunctionalExtensions.ValueTasks;
 using Xunit;
 
 namespace CSharpFunctionalExtensions.Tests.ResultTests.Extensions

--- a/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/MapErrorTests.ValueTask.Left.cs
+++ b/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/MapErrorTests.ValueTask.Left.cs
@@ -1,4 +1,5 @@
 ﻿using System.Threading.Tasks;
+using CSharpFunctionalExtensions.ValueTasks;
 using FluentAssertions;
 using Xunit;
 

--- a/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/MapErrorTests.ValueTask.cs
+++ b/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/MapErrorTests.ValueTask.cs
@@ -1,4 +1,5 @@
 ﻿using System.Threading.Tasks;
+using CSharpFunctionalExtensions.ValueTasks;
 using FluentAssertions;
 using Xunit;
 

--- a/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/MapTests.ValueTask.Left.cs
+++ b/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/MapTests.ValueTask.Left.cs
@@ -1,5 +1,6 @@
 ﻿using FluentAssertions;
 using System.Threading.Tasks;
+using CSharpFunctionalExtensions.ValueTasks;
 using Xunit;
 
 namespace CSharpFunctionalExtensions.Tests.ResultTests.Extensions 

--- a/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/MapTests.ValueTask.Right.cs
+++ b/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/MapTests.ValueTask.Right.cs
@@ -1,5 +1,6 @@
 ﻿using FluentAssertions;
 using System.Threading.Tasks;
+using CSharpFunctionalExtensions.ValueTasks;
 using Xunit;
 
 namespace CSharpFunctionalExtensions.Tests.ResultTests.Extensions 
@@ -10,7 +11,7 @@ namespace CSharpFunctionalExtensions.Tests.ResultTests.Extensions
         public async Task Map_ValueTask_Right_executes_on_success_returns_new_success()
         {
             Result result = Result.Success();
-            Result<K> actual = await result.Map(ValueTask_Func_K);
+            Result<K> actual = await result.Map(valueTask: ValueTask_Func_K);
 
             actual.IsSuccess.Should().BeTrue();
             actual.Value.Should().Be(K.Value);
@@ -21,7 +22,7 @@ namespace CSharpFunctionalExtensions.Tests.ResultTests.Extensions
         public async Task Map_ValueTask_Right_executes_on_failure_returns_new_failure()
         {
             Result result = Result.Failure(ErrorMessage);
-            Result<K> actual = await result.Map(ValueTask_Func_K);
+            Result<K> actual = await result.Map(valueTask: ValueTask_Func_K);
 
             actual.IsSuccess.Should().BeFalse();
             FuncExecuted.Should().BeFalse();
@@ -31,7 +32,7 @@ namespace CSharpFunctionalExtensions.Tests.ResultTests.Extensions
         public async Task Map_ValueTask_Right_T_executes_on_success_returns_new_success()
         {
             Result<T> result = Result.Success(T.Value);
-            Result<K> actual = await result.Map(ValueTask_Func_T_K);
+            Result<K> actual = await result.Map(valueTask: ValueTask_Func_T_K);
 
             actual.IsSuccess.Should().BeTrue();
             actual.Value.Should().Be(K.Value);
@@ -42,7 +43,7 @@ namespace CSharpFunctionalExtensions.Tests.ResultTests.Extensions
         public async Task Map_ValueTask_Right_T_executes_on_failure_returns_new_failure()
         {
             Result<T> result = Result.Failure<T>(ErrorMessage);
-            Result<K> actual = await result.Map(ValueTask_Func_T_K);
+            Result<K> actual = await result.Map(valueTask: ValueTask_Func_T_K);
 
             actual.IsSuccess.Should().BeFalse();
             actual.Error.Should().Be(ErrorMessage);
@@ -53,7 +54,7 @@ namespace CSharpFunctionalExtensions.Tests.ResultTests.Extensions
         public async Task Map_ValueTask_Right_T_E_executes_on_success_returns_new_success()
         {
             Result<T, E> result = Result.Success<T, E>(T.Value);
-            Result<K, E> actual = await result.Map(ValueTask_Func_T_K);
+            Result<K, E> actual = await result.Map(valueTask: ValueTask_Func_T_K);
 
             actual.IsSuccess.Should().BeTrue();
             actual.Value.Should().Be(K.Value);
@@ -64,7 +65,7 @@ namespace CSharpFunctionalExtensions.Tests.ResultTests.Extensions
         public async Task Map_ValueTask_Right_T_E_executes_on_failure_returns_new_failure()
         {
             Result<T, E> result = Result.Failure<T, E>(E.Value);
-            Result<K, E> actual = await result.Map(ValueTask_Func_T_K);
+            Result<K, E> actual = await result.Map(valueTask: ValueTask_Func_T_K);
 
             actual.IsSuccess.Should().BeFalse();
             actual.Error.Should().Be(E.Value);
@@ -75,7 +76,7 @@ namespace CSharpFunctionalExtensions.Tests.ResultTests.Extensions
         public async Task Map_ValueTask_Right_UnitResult_E_executes_on_success_returns_success()
         {
             UnitResult<E> result = UnitResult.Success<E>();
-            Result<K, E> actual = await result.Map(ValueTask_Func_K);
+            Result<K, E> actual = await result.Map(valueTask: ValueTask_Func_K);
 
             actual.IsSuccess.Should().BeTrue();
             actual.Value.Should().Be(K.Value);
@@ -86,7 +87,7 @@ namespace CSharpFunctionalExtensions.Tests.ResultTests.Extensions
         public async Task Map_ValueTask_Right_UnitResult_E_executes_on_failure_returns_failure()
         {
             UnitResult<E> result = UnitResult.Failure(E.Value);
-            Result<K, E> actual = await result.Map(ValueTask_Func_K);
+            Result<K, E> actual = await result.Map(valueTask: ValueTask_Func_K);
 
             actual.IsSuccess.Should().BeFalse();
             actual.Error.Should().Be(E.Value);

--- a/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/MapTests.ValueTask.cs
+++ b/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/MapTests.ValueTask.cs
@@ -1,5 +1,6 @@
 ﻿using FluentAssertions;
 using System.Threading.Tasks;
+using CSharpFunctionalExtensions.ValueTasks;
 using Xunit;
 
 namespace CSharpFunctionalExtensions.Tests.ResultTests.Extensions 

--- a/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/MatchTests.ValueTask.Left.cs
+++ b/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/MatchTests.ValueTask.Left.cs
@@ -1,4 +1,5 @@
 ﻿using System.Threading.Tasks;
+using CSharpFunctionalExtensions.ValueTasks;
 using FluentAssertions;
 using Xunit;
 

--- a/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/MatchTests.ValueTask.Right.cs
+++ b/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/MatchTests.ValueTask.Right.cs
@@ -1,4 +1,5 @@
 ﻿using System.Threading.Tasks;
+using CSharpFunctionalExtensions.ValueTasks;
 using FluentAssertions;
 using Xunit;
 

--- a/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/MatchTests.ValueTask.cs
+++ b/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/MatchTests.ValueTask.cs
@@ -1,4 +1,5 @@
 ﻿using System.Threading.Tasks;
+using CSharpFunctionalExtensions.ValueTasks;
 using FluentAssertions;
 using Xunit;
 

--- a/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/OnFailureCompensateTests.ValueTask.Left.cs
+++ b/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/OnFailureCompensateTests.ValueTask.Left.cs
@@ -1,4 +1,5 @@
 ﻿using System.Threading.Tasks;
+using CSharpFunctionalExtensions.ValueTasks;
 using FluentAssertions;
 using Xunit;
 

--- a/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/OnFailureCompensateTests.ValueTask.Right.cs
+++ b/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/OnFailureCompensateTests.ValueTask.Right.cs
@@ -1,4 +1,5 @@
 ﻿using System.Threading.Tasks;
+using CSharpFunctionalExtensions.ValueTasks;
 using FluentAssertions;
 using Xunit;
 

--- a/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/OnFailureCompensateTests.ValueTask.cs
+++ b/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/OnFailureCompensateTests.ValueTask.cs
@@ -1,4 +1,5 @@
 ﻿using System.Threading.Tasks;
+using CSharpFunctionalExtensions.ValueTasks;
 using FluentAssertions;
 using Xunit;
 

--- a/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/OnFailureTests.ValueTask.Left.cs
+++ b/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/OnFailureTests.ValueTask.Left.cs
@@ -1,4 +1,5 @@
 ﻿using System.Threading.Tasks;
+using CSharpFunctionalExtensions.ValueTasks;
 using FluentAssertions;
 using Xunit;
 

--- a/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/OnFailureTests.ValueTask.Right.cs
+++ b/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/OnFailureTests.ValueTask.Right.cs
@@ -1,4 +1,5 @@
 ﻿using System.Threading.Tasks;
+using CSharpFunctionalExtensions.ValueTasks;
 using FluentAssertions;
 using Xunit;
 

--- a/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/OnFailureTests.ValueTask.cs
+++ b/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/OnFailureTests.ValueTask.cs
@@ -1,4 +1,5 @@
 ﻿using System.Threading.Tasks;
+using CSharpFunctionalExtensions.ValueTasks;
 using FluentAssertions;
 using Xunit;
 

--- a/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/OnSuccessTryTests.ValueTask.Left.cs
+++ b/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/OnSuccessTryTests.ValueTask.Left.cs
@@ -1,5 +1,6 @@
 ﻿using System.Threading.Tasks;
 using CSharpFunctionalExtensions.Tests.ResultTests.Methods.Try;
+using CSharpFunctionalExtensions.ValueTasks;
 using FluentAssertions;
 using Xunit;
 

--- a/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/OnSuccessTryTests.ValueTask.Right.cs
+++ b/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/OnSuccessTryTests.ValueTask.Right.cs
@@ -1,49 +1,19 @@
 ﻿using System.Threading.Tasks;
 using CSharpFunctionalExtensions.Tests.ResultTests.Methods.Try;
+using CSharpFunctionalExtensions.ValueTasks;
 using FluentAssertions;
-using FluentAssertions.CSharpFunctionalExtensions;
 using Xunit;
 
 namespace CSharpFunctionalExtensions.Tests.ResultTests.Extensions
 {
     public class OnSuccessTryTests_ValueTask_Right : TryTestBaseTask
     {
-       [Fact]
-        public async Task OnSuccess_ValueTask_Right_execute_action_success_without_error_handler_function_result_expected()
-        {
-            var success = Result.Success();
-            var result = await success.OnSuccessTry(Func_Task);
-
-            result.IsSuccess.Should().BeTrue();        
-        }
-
-        [Fact]
-        public async Task OnSuccess_ValueTask_Right_execute_action_failed_without_error_handler_failed_result_expected()
-        {
-            var success = Result.Success();
-            var result = await success.OnSuccessTry(Throwing_Func_Task);
-
-            result.Should()
-                .BeFailure()
-                .And.Subject.Error.Should()
-                .Be(ErrorMessage);
-        }
-
-        [Fact]
-        public async Task OnSuccess_ValueTask_Right_execute_action_failed_with_error_handler_failed_result_expected()
-        {
-            var success = Result.Success();
-            var result = await success.OnSuccessTry(Throwing_Func_Task, ErrorHandler);
-
-            result.IsFailure.Should().BeTrue();
-            result.Error.Should().Be(ErrorHandlerMessage);
-        }
 
         [Fact] 
         public async Task OnSuccess_ValueTask_Right_T_execute_function_success_without_error_handler_function_result_expected()
         {
             var success = Result.Success();
-            var result = await success.OnSuccessTry(Func_ValueTask_T);
+            var result = await success.OnSuccessTry(valueTask: Func_ValueTask_T);
 
             result.IsSuccess.Should().BeTrue();
             result.Value.Should().Be(T.Value);
@@ -53,7 +23,7 @@ namespace CSharpFunctionalExtensions.Tests.ResultTests.Extensions
         public async Task OnSuccess_ValueTask_Right_T_execute_function_failed_without_error_handler_failed_result_expected()
         {
             var success = Result.Success();
-            var result = await success.OnSuccessTry(Throwing_Func_ValueTask_T);
+            var result = await success.OnSuccessTry(valueTask: Throwing_Func_ValueTask_T);
 
             result.IsFailure.Should().BeTrue();
             result.Error.Should().Be(ErrorMessage);
@@ -63,36 +33,7 @@ namespace CSharpFunctionalExtensions.Tests.ResultTests.Extensions
         public async Task OnSuccess_ValueTask_Right_T_execute_function_failed_with_error_handler_failed_result_expected()
         {
             var success = Result.Success();
-            var result = await success.OnSuccessTry(Throwing_Func_ValueTask_T, ErrorHandler);
-
-            result.IsFailure.Should().BeTrue();
-            result.Error.Should().Be(ErrorHandlerMessage);
-        }
-
-        [Fact]
-        public async Task OnSuccess_ValueTask_Right_T_execute_action_success_without_error_handler_function_result_expected()
-        {
-            var success = Result.Success(T.Value);
-            var result = await success.OnSuccessTry(Func_T_Task);
-
-            result.IsSuccess.Should().BeTrue();
-        }
-        
-        [Fact]
-        public async Task OnSuccess_ValueTask_Right_T_execute_action_failed_without_error_handler_failed_result_expected()
-        {
-            var success = Result.Success(T.Value);
-            var result = await success.OnSuccessTry(Throwing_Func_T_Task);
-
-            result.IsFailure.Should().BeTrue();
-            result.Error.Should().Be(ErrorMessage);
-        }
-        
-        [Fact]
-        public async Task OnSuccess_ValueTask_Right_T_execute_action_failed_with_error_handler_failed_result_expected()
-        {
-            var success = Result.Success(T.Value);
-            var result = await success.OnSuccessTry(Throwing_Func_T_Task, ErrorHandler);
+            var result = await success.OnSuccessTry(valueTask: Throwing_Func_ValueTask_T, ErrorHandler);
 
             result.IsFailure.Should().BeTrue();
             result.Error.Should().Be(ErrorHandlerMessage);
@@ -102,7 +43,7 @@ namespace CSharpFunctionalExtensions.Tests.ResultTests.Extensions
         public async Task OnSuccess_ValueTask_Right_T_K_execute_function_success_without_error_handler_function_result_expected()
         {
             var success = Result.Success(T.Value);
-            var result = await success.OnSuccessTry(Func_T_ValueTask_K);
+            var result = await success.OnSuccessTry(valueTask: Func_T_ValueTask_K);
 
             result.IsSuccess.Should().BeTrue();
             result.Value.Should().Be(K.Value);
@@ -112,7 +53,7 @@ namespace CSharpFunctionalExtensions.Tests.ResultTests.Extensions
         public async Task OnSuccess_ValueTask_Right_T_K_execute_function_failed_without_error_handler_failed_result_expected()
         {
             var success = Result.Success(T.Value);
-            var result = await success.OnSuccessTry(Throwing_Func_T_ValueTask_K);
+            var result = await success.OnSuccessTry(valueTask: Throwing_Func_T_ValueTask_K);
 
             result.IsFailure.Should().BeTrue();
             result.Error.Should().Be(ErrorMessage);
@@ -122,7 +63,7 @@ namespace CSharpFunctionalExtensions.Tests.ResultTests.Extensions
         public async Task OnSuccess_ValueTask_Right_T_K_execute_function_failed_with_error_handler_failed_result_expected()
         {
             var success = Result.Success(T.Value);
-            var result = await success.OnSuccessTry(Throwing_Func_T_ValueTask_K, ErrorHandler);
+            var result = await success.OnSuccessTry(valueTask: Throwing_Func_T_ValueTask_K, ErrorHandler);
 
             result.IsFailure.Should().BeTrue();
             result.Error.Should().Be(ErrorHandlerMessage);
@@ -162,7 +103,7 @@ namespace CSharpFunctionalExtensions.Tests.ResultTests.Extensions
         public async Task OnSuccess_ValueTask_Right_T_K_E_execute_function_success_without_error_handler_function_result_expected()
         {
             var success = Result.Success<T, E>(T.Value);
-            var result = await success.OnSuccessTry(Func_T_ValueTask_K, ErrorHandler_E);
+            var result = await success.OnSuccessTry(valueTask: Func_T_ValueTask_K, ErrorHandler_E);
 
             result.IsSuccess.Should().BeTrue();
             result.Value.Should().Be(K.Value);
@@ -172,7 +113,7 @@ namespace CSharpFunctionalExtensions.Tests.ResultTests.Extensions
         public async Task OnSuccess_ValueTask_Right_T_K_E_execute_function_failed_without_error_handler_failed_result_expected()
         {
             var success = Result.Success<T, E>(T.Value);
-            var result = await success.OnSuccessTry(Throwing_Func_T_ValueTask_K, ErrorHandler_E);
+            var result = await success.OnSuccessTry(valueTask: Throwing_Func_T_ValueTask_K, ErrorHandler_E);
 
             result.IsFailure.Should().BeTrue();
             result.Error.Should().Be(E.Value);
@@ -182,7 +123,7 @@ namespace CSharpFunctionalExtensions.Tests.ResultTests.Extensions
         public async Task OnSuccess_ValueTask_Right_T_K_E_execute_function_failed_with_error_handler_failed_result_expected()
         {
             var success = Result.Success<T, E>(T.Value);
-            var result = await success.OnSuccessTry(Throwing_Func_T_ValueTask_K, ErrorHandler_E);
+            var result = await success.OnSuccessTry(valueTask: Throwing_Func_T_ValueTask_K, ErrorHandler_E);
 
             result.IsFailure.Should().BeTrue();
             result.Error.Should().Be(E.Value);

--- a/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/OnSuccessTryTests.ValueTask.cs
+++ b/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/OnSuccessTryTests.ValueTask.cs
@@ -1,5 +1,6 @@
 ﻿using System.Threading.Tasks;
 using CSharpFunctionalExtensions.Tests.ResultTests.Methods.Try;
+using CSharpFunctionalExtensions.ValueTasks;
 using FluentAssertions;
 using Xunit;
 
@@ -11,7 +12,7 @@ namespace CSharpFunctionalExtensions.Tests.ResultTests.Extensions
         public async Task OnSuccessTry_ValueTask_execute_action_success_without_error_handler_function_result_expected()
         {
             var success = Result.Success().AsValueTask();
-            var result = await success.OnSuccessTry(Func_Task);
+            var result = await success.OnSuccessTry(Func_ValueTask);
 
             result.IsSuccess.Should().BeTrue();        
         }
@@ -20,7 +21,7 @@ namespace CSharpFunctionalExtensions.Tests.ResultTests.Extensions
         public async Task OnSuccessTry_ValueTask_execute_action_failed_without_error_handler_failed_result_expected()
         {
             var success = Result.Success().AsValueTask();
-            var result = await success.OnSuccessTry(Throwing_Func_Task);
+            var result = await success.OnSuccessTry(Throwing_Func_ValueTask);
 
             result.IsFailure.Should().BeTrue();
             result.Error.Should().Be(ErrorMessage);
@@ -32,7 +33,7 @@ namespace CSharpFunctionalExtensions.Tests.ResultTests.Extensions
             var defaultTryErrorHandler = Result.Configuration.DefaultTryErrorHandler;
             Result.Configuration.DefaultTryErrorHandler = ErrorHandler;
             var success = Result.Success().AsValueTask();
-            var result = await success.OnSuccessTry(Throwing_Func_Task);
+            var result = await success.OnSuccessTry(Throwing_Func_ValueTask);
             Result.Configuration.DefaultTryErrorHandler = defaultTryErrorHandler;
 
             result.IsFailure.Should().BeTrue();
@@ -43,7 +44,7 @@ namespace CSharpFunctionalExtensions.Tests.ResultTests.Extensions
         public async Task OnSuccessTry_ValueTask_execute_action_failed_with_error_handler_failed_result_expected()
         {
             var success = Result.Success().AsValueTask();
-            var result = await success.OnSuccessTry(Throwing_Func_Task, ErrorHandler);
+            var result = await success.OnSuccessTry(Throwing_Func_ValueTask, ErrorHandler);
 
             result.IsFailure.Should().BeTrue();
             result.Error.Should().Be(ErrorHandlerMessage);
@@ -83,7 +84,7 @@ namespace CSharpFunctionalExtensions.Tests.ResultTests.Extensions
         public async Task OnSuccessTry_ValueTask_T_execute_action_success_without_error_handler_function_result_expected()
         {
             var success = Result.Success(T.Value).AsValueTask();
-            var result = await success.OnSuccessTry(Func_T_Task);
+            var result = await success.OnSuccessTry(Func_T_ValueTask);
 
             result.IsSuccess.Should().BeTrue();
         }

--- a/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/TapIfTests.Value.Task.Left.cs
+++ b/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/TapIfTests.Value.Task.Left.cs
@@ -1,4 +1,5 @@
 ﻿using FluentAssertions;
+using CSharpFunctionalExtensions.ValueTasks;
 using Xunit;
 
 namespace CSharpFunctionalExtensions.Tests.ResultTests.Extensions

--- a/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/TapIfTests.Value.Task.Right.cs
+++ b/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/TapIfTests.Value.Task.Right.cs
@@ -1,4 +1,5 @@
 ﻿using FluentAssertions;
+using CSharpFunctionalExtensions.ValueTasks;
 using Xunit;
 
 namespace CSharpFunctionalExtensions.Tests.ResultTests.Extensions

--- a/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/TapIfTests.Value.Task.cs
+++ b/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/TapIfTests.Value.Task.cs
@@ -1,4 +1,5 @@
 ﻿using FluentAssertions;
+using CSharpFunctionalExtensions.ValueTasks;
 using Xunit;
 
 namespace CSharpFunctionalExtensions.Tests.ResultTests.Extensions

--- a/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/TapTests.ValueTask.Left.cs
+++ b/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/TapTests.ValueTask.Left.cs
@@ -1,4 +1,5 @@
 ﻿using System.Threading.Tasks;
+using CSharpFunctionalExtensions.ValueTasks;
 using FluentAssertions;
 using Xunit;
 

--- a/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/TapTests.ValueTask.Right.cs
+++ b/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/TapTests.ValueTask.Right.cs
@@ -1,4 +1,5 @@
 ﻿using System.Threading.Tasks;
+using CSharpFunctionalExtensions.ValueTasks;
 using FluentAssertions;
 using Xunit;
 

--- a/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/TapTests.ValueTask.cs
+++ b/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/TapTests.ValueTask.cs
@@ -1,4 +1,5 @@
 ﻿using System.Threading.Tasks;
+using CSharpFunctionalExtensions.ValueTasks;
 using FluentAssertions;
 using Xunit;
 

--- a/CSharpFunctionalExtensions.Tests/ValueTaskExtensions.cs
+++ b/CSharpFunctionalExtensions.Tests/ValueTaskExtensions.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Threading.Tasks;
+using CSharpFunctionalExtensions.ValueTasks;
 
 namespace CSharpFunctionalExtensions.Tests
 {

--- a/CSharpFunctionalExtensions/CSharpFunctionalExtensions.csproj
+++ b/CSharpFunctionalExtensions/CSharpFunctionalExtensions.csproj
@@ -249,6 +249,15 @@
     <Compile Update="Result\Methods\Extensions\Map.ValueTask.Right.cs">
       <DependentUpon>Map.ValueTask.cs</DependentUpon>
     </Compile>
+    <Compile Update="Result\Methods\Extensions\TapIf.ValueTask.Right.cs">
+      <DependentUpon>TapIf.ValueTask.cs</DependentUpon>
+    </Compile>
+    <Compile Update="Result\Methods\Extensions\TapIf.ValueTask.Left.cs">
+      <DependentUpon>TapIf.ValueTask.cs</DependentUpon>
+    </Compile>
+    <Compile Update="Result\Methods\Extensions\TapIf.ValueTask.cs">
+      <DependentUpon>TapIf.cs</DependentUpon>
+    </Compile>
   </ItemGroup>
 
   <ItemGroup>
@@ -518,12 +527,6 @@
     </Compile>
     <Compile Update="Result\Methods\FailureIf.Task.cs">
       <DependentUpon>FailureIf.cs</DependentUpon>
-    </Compile>
-    <Compile Update="Result\Methods\SuccessIf.ValueTask.cs">
-      <DependentUpon>SuccessIf.cs</DependentUpon>
-    </Compile>
-    <Compile Update="Result\Methods\SuccessIf.Task.cs">
-      <DependentUpon>SuccessIf.cs</DependentUpon>
     </Compile>
     <Compile Update="Result\Methods\Try.ValueTask.cs">
       <DependentUpon>Try.cs</DependentUpon>

--- a/CSharpFunctionalExtensions/Maybe/Extensions/Bind.ValueTask.Left.cs
+++ b/CSharpFunctionalExtensions/Maybe/Extensions/Bind.ValueTask.Left.cs
@@ -2,7 +2,7 @@
 using System;
 using System.Threading.Tasks;
 
-namespace CSharpFunctionalExtensions
+namespace CSharpFunctionalExtensions.ValueTasks
 {
     public static partial class MaybeExtensions
     {

--- a/CSharpFunctionalExtensions/Maybe/Extensions/Bind.ValueTask.Right.cs
+++ b/CSharpFunctionalExtensions/Maybe/Extensions/Bind.ValueTask.Right.cs
@@ -2,7 +2,7 @@
 using System;
 using System.Threading.Tasks;
 
-namespace CSharpFunctionalExtensions
+namespace CSharpFunctionalExtensions.ValueTasks
 {
     public static partial class MaybeExtensions
     {

--- a/CSharpFunctionalExtensions/Maybe/Extensions/Bind.ValueTask.cs
+++ b/CSharpFunctionalExtensions/Maybe/Extensions/Bind.ValueTask.cs
@@ -2,7 +2,7 @@
 using System;
 using System.Threading.Tasks;
 
-namespace CSharpFunctionalExtensions
+namespace CSharpFunctionalExtensions.ValueTasks
 {
     public static partial class MaybeExtensions
     {

--- a/CSharpFunctionalExtensions/Maybe/Extensions/Execute.ValueTask.Left.cs
+++ b/CSharpFunctionalExtensions/Maybe/Extensions/Execute.ValueTask.Left.cs
@@ -2,7 +2,7 @@
 using System;
 using System.Threading.Tasks;
 
-namespace CSharpFunctionalExtensions
+namespace CSharpFunctionalExtensions.ValueTasks
 {
     public static partial class MaybeExtensions
     {

--- a/CSharpFunctionalExtensions/Maybe/Extensions/Execute.ValueTask.Right.cs
+++ b/CSharpFunctionalExtensions/Maybe/Extensions/Execute.ValueTask.Right.cs
@@ -2,22 +2,22 @@
 using System;
 using System.Threading.Tasks;
 
-namespace CSharpFunctionalExtensions
+namespace CSharpFunctionalExtensions.ValueTasks
 {
     public static partial class MaybeExtensions
     {
         /// <summary>
-        ///     Executes the given async <paramref name="action" /> if the <paramref name="maybe" /> has a value
+        ///     Executes the given async <paramref name="valueTask" /> if the <paramref name="maybe" /> has a value
         /// </summary>
         /// <param name="maybe"></param>
-        /// <param name="action"></param>
+        /// <param name="valueTask"></param>
         /// <typeparam name="T"></typeparam>
-        public static async Task Execute<T>(this Maybe<T> maybe, Func<T, ValueTask> action)
+        public static async Task Execute<T>(this Maybe<T> maybe, Func<T, ValueTask> valueTask)
         {
             if (maybe.HasNoValue)
                 return;
 
-            await action(maybe.GetValueOrThrow());
+            await valueTask(maybe.GetValueOrThrow());
         }
     }
 }

--- a/CSharpFunctionalExtensions/Maybe/Extensions/Execute.ValueTask.cs
+++ b/CSharpFunctionalExtensions/Maybe/Extensions/Execute.ValueTask.cs
@@ -2,25 +2,25 @@
 using System;
 using System.Threading.Tasks;
 
-namespace CSharpFunctionalExtensions
+namespace CSharpFunctionalExtensions.ValueTasks
 {
     public static partial class MaybeExtensions
     {
         /// <summary>
-        /// Executes the given <paramref name="asyncAction" /> if the <paramref name="maybeTask" /> produces a value
+        /// Executes the given <paramref name="valueTask" /> if the <paramref name="maybeTask" /> produces a value
         /// </summary>
         /// <param name="maybeTask"></param>
-        /// <param name="asyncAction"></param>
+        /// <param name="valueTask"></param>
         /// <typeparam name="T"></typeparam>
         /// <returns></returns>
-        public static async Task Execute<T>(this ValueTask<Maybe<T>> maybeTask, Func<T, ValueTask> asyncAction)
+        public static async Task Execute<T>(this ValueTask<Maybe<T>> maybeTask, Func<T, ValueTask> valueTask)
         {
             var maybe = await maybeTask;
 
             if (maybe.HasNoValue)
                 return;
 
-            await asyncAction(maybe.GetValueOrThrow());
+            await valueTask(maybe.GetValueOrThrow());
         }
     }
 }

--- a/CSharpFunctionalExtensions/Maybe/Extensions/ExecuteNoValue.ValueTask.Left.cs
+++ b/CSharpFunctionalExtensions/Maybe/Extensions/ExecuteNoValue.ValueTask.Left.cs
@@ -2,7 +2,7 @@
 using System;
 using System.Threading.Tasks;
 
-namespace CSharpFunctionalExtensions
+namespace CSharpFunctionalExtensions.ValueTasks
 {
     public static partial class MaybeExtensions
     {

--- a/CSharpFunctionalExtensions/Maybe/Extensions/ExecuteNoValue.ValueTask.Right.cs
+++ b/CSharpFunctionalExtensions/Maybe/Extensions/ExecuteNoValue.ValueTask.Right.cs
@@ -2,22 +2,22 @@
 using System;
 using System.Threading.Tasks;
 
-namespace CSharpFunctionalExtensions
+namespace CSharpFunctionalExtensions.ValueTasks
 {
     public static partial class MaybeExtensions
     {
         /// <summary>
-        ///     Executes the given async <paramref name="action" /> if the <paramref name="maybe" /> has no value
+        ///     Executes the given async <paramref name="valueTask" /> if the <paramref name="maybe" /> has no value
         /// </summary>
         /// <param name="maybe"></param>
-        /// <param name="action"></param>
+        /// <param name="valueTask"></param>
         /// <typeparam name="T"></typeparam>
-        public static async Task ExecuteNoValue<T>(this Maybe<T> maybe, Func<ValueTask> action)
+        public static async Task ExecuteNoValue<T>(this Maybe<T> maybe, Func<ValueTask> valueTask)
         {
             if (maybe.HasValue)
                 return;
 
-            await action();
+            await valueTask();
         }
     }
 }

--- a/CSharpFunctionalExtensions/Maybe/Extensions/ExecuteNoValue.ValueTask.cs
+++ b/CSharpFunctionalExtensions/Maybe/Extensions/ExecuteNoValue.ValueTask.cs
@@ -2,24 +2,24 @@
 using System;
 using System.Threading.Tasks;
 
-namespace CSharpFunctionalExtensions
+namespace CSharpFunctionalExtensions.ValueTasks
 {
     public static partial class MaybeExtensions
     {
         /// <summary>
-        /// Executes the given <paramref name="asyncAction" /> if the <paramref name="maybeTask" /> produces no value
+        /// Executes the given <paramref name="valueTask" /> if the <paramref name="maybeTask" /> produces no value
         /// </summary>
         /// <param name="maybeTask"></param>
-        /// <param name="asyncAction"></param>
+        /// <param name="valueTask"></param>
         /// <typeparam name="T"></typeparam>
-        public static async Task ExecuteNoValue<T>(this ValueTask<Maybe<T>> maybeTask, Func<ValueTask> asyncAction)
+        public static async Task ExecuteNoValue<T>(this ValueTask<Maybe<T>> maybeTask, Func<ValueTask> valueTask)
         {
             var maybe = await maybeTask;
 
             if (maybe.HasValue)
                 return;
 
-            await asyncAction();
+            await valueTask();
         }
 
     }

--- a/CSharpFunctionalExtensions/Maybe/Extensions/GetValueOrDefault.ValueTask.Left.cs
+++ b/CSharpFunctionalExtensions/Maybe/Extensions/GetValueOrDefault.ValueTask.Left.cs
@@ -2,7 +2,7 @@
 using System;
 using System.Threading.Tasks;
 
-namespace CSharpFunctionalExtensions
+namespace CSharpFunctionalExtensions.ValueTasks
 {
     public static partial class MaybeExtensions
     {

--- a/CSharpFunctionalExtensions/Maybe/Extensions/GetValueOrDefault.ValueTask.Right.cs
+++ b/CSharpFunctionalExtensions/Maybe/Extensions/GetValueOrDefault.ValueTask.Right.cs
@@ -2,43 +2,43 @@
 using System;
 using System.Threading.Tasks;
 
-namespace CSharpFunctionalExtensions
+namespace CSharpFunctionalExtensions.ValueTasks
 {
     public static partial class MaybeExtensions
     {
-        public static async ValueTask<T> GetValueOrDefault<T>(this Maybe<T> maybe, Func<ValueTask<T>> defaultValue)
+        public static async ValueTask<T> GetValueOrDefault<T>(this Maybe<T> maybe, Func<ValueTask<T>> valueTask)
         {
             if (maybe.HasNoValue)
-                return await defaultValue();
+                return await valueTask();
 
             return maybe.GetValueOrThrow();
         }
 
         public static async ValueTask<K> GetValueOrDefault<T, K>(this Maybe<T> maybe, Func<T, K> selector,
-            Func<ValueTask<K>> defaultValue)
+            Func<ValueTask<K>> valueTask)
         {
             if (maybe.HasNoValue)
-                return await defaultValue();
+                return await valueTask();
 
             return selector(maybe.GetValueOrThrow());
         }
 
-        public static async ValueTask<K> GetValueOrDefault<T, K>(this Maybe<T> maybe, Func<T, ValueTask<K>> selector,
+        public static async ValueTask<K> GetValueOrDefault<T, K>(this Maybe<T> maybe, Func<T, ValueTask<K>> valueTask,
             K defaultValue = default)
         {
             if (maybe.HasNoValue)
                 return defaultValue;
 
-            return await selector(maybe.GetValueOrThrow());
+            return await valueTask(maybe.GetValueOrThrow());
         }
 
-        public static async ValueTask<K> GetValueOrDefault<T, K>(this Maybe<T> maybe, Func<T, ValueTask<K>> selector,
+        public static async ValueTask<K> GetValueOrDefault<T, K>(this Maybe<T> maybe, Func<T, ValueTask<K>> valueTask,
             Func<ValueTask<K>> defaultValue)
         {
             if (maybe.HasNoValue)
                 return await defaultValue();
 
-            return await selector(maybe.GetValueOrThrow());
+            return await valueTask(maybe.GetValueOrThrow());
         }
     }
 }

--- a/CSharpFunctionalExtensions/Maybe/Extensions/GetValueOrDefault.ValueTask.cs
+++ b/CSharpFunctionalExtensions/Maybe/Extensions/GetValueOrDefault.ValueTask.cs
@@ -2,7 +2,7 @@
 using System;
 using System.Threading.Tasks;
 
-namespace CSharpFunctionalExtensions
+namespace CSharpFunctionalExtensions.ValueTasks
 {
     public static partial class MaybeExtensions
     {

--- a/CSharpFunctionalExtensions/Maybe/Extensions/GetValueOrThrow.ValueTask.cs
+++ b/CSharpFunctionalExtensions/Maybe/Extensions/GetValueOrThrow.ValueTask.cs
@@ -2,7 +2,7 @@
 using System;
 using System.Threading.Tasks;
 
-namespace CSharpFunctionalExtensions
+namespace CSharpFunctionalExtensions.ValueTasks
 {
     public static partial class MaybeExtensions
     {

--- a/CSharpFunctionalExtensions/Maybe/Extensions/Map.ValueTask.Left.cs
+++ b/CSharpFunctionalExtensions/Maybe/Extensions/Map.ValueTask.Left.cs
@@ -2,13 +2,13 @@
 using System;
 using System.Threading.Tasks;
 
-namespace CSharpFunctionalExtensions
+namespace CSharpFunctionalExtensions.ValueTasks
 {
     public static partial class MaybeExtensions
     {
-        public static async ValueTask<Maybe<K>> Map<T, K>(this ValueTask<Maybe<T>> maybeTask, Func<T, K> selector)
+        public static async ValueTask<Maybe<K>> Map<T, K>(this ValueTask<Maybe<T>> valueTask, Func<T, K> selector)
         {
-            Maybe<T> maybe = await maybeTask;
+            Maybe<T> maybe = await valueTask;
             return maybe.Map(selector);
         }
     }

--- a/CSharpFunctionalExtensions/Maybe/Extensions/Map.ValueTask.Right.cs
+++ b/CSharpFunctionalExtensions/Maybe/Extensions/Map.ValueTask.Right.cs
@@ -2,16 +2,16 @@
 using System;
 using System.Threading.Tasks;
 
-namespace CSharpFunctionalExtensions
+namespace CSharpFunctionalExtensions.ValueTasks
 {
     public static partial class MaybeExtensions
     {
-        public static async ValueTask<Maybe<K>> Map<T, K>(this Maybe<T> maybe, Func<T, ValueTask<K>> selector)
+        public static async ValueTask<Maybe<K>> Map<T, K>(this Maybe<T> maybe, Func<T, ValueTask<K>> valueTask)
         {
             if (maybe.HasNoValue)
                 return Maybe<K>.None;
 
-            return await selector(maybe.GetValueOrThrow());
+            return await valueTask(maybe.GetValueOrThrow());
         }
     }
 }

--- a/CSharpFunctionalExtensions/Maybe/Extensions/Map.ValueTask.cs
+++ b/CSharpFunctionalExtensions/Maybe/Extensions/Map.ValueTask.cs
@@ -2,14 +2,14 @@
 using System;
 using System.Threading.Tasks;
 
-namespace CSharpFunctionalExtensions
+namespace CSharpFunctionalExtensions.ValueTasks
 {
     public static partial class MaybeExtensions
     {
-        public static async ValueTask<Maybe<K>> Map<T, K>(this ValueTask<Maybe<T>> maybeTask, Func<T, ValueTask<K>> selector)
+        public static async ValueTask<Maybe<K>> Map<T, K>(this ValueTask<Maybe<T>> maybeTask, Func<T, ValueTask<K>> valueTask)
         {
             Maybe<T> maybe = await maybeTask;
-            return await maybe.Map(selector);
+            return await maybe.Map(valueTask);
         }
     }
 }

--- a/CSharpFunctionalExtensions/Maybe/Extensions/Or.ValueTask.Left.cs
+++ b/CSharpFunctionalExtensions/Maybe/Extensions/Or.ValueTask.Left.cs
@@ -2,7 +2,7 @@
 using System;
 using System.Threading.Tasks;
 
-namespace CSharpFunctionalExtensions
+namespace CSharpFunctionalExtensions.ValueTasks
 {
     public static partial class MaybeExtensions
     {

--- a/CSharpFunctionalExtensions/Maybe/Extensions/Or.ValueTask.Right.cs
+++ b/CSharpFunctionalExtensions/Maybe/Extensions/Or.ValueTask.Right.cs
@@ -2,51 +2,51 @@
 using System;
 using System.Threading.Tasks;
 
-namespace CSharpFunctionalExtensions
+namespace CSharpFunctionalExtensions.ValueTasks
 {
     public static partial class MaybeExtensions
     {
         /// <summary>
-        /// Creates a new <see cref="Maybe{T}" /> if <paramref name="maybe" /> is empty, using the result of the supplied <paramref name="fallbackOperation" />, otherwise it returns <paramref name="maybe" />
+        /// Creates a new <see cref="Maybe{T}" /> if <paramref name="maybe" /> is empty, using the result of the supplied <paramref name="valueTaskFallbackOperation" />, otherwise it returns <paramref name="maybe" />
         /// </summary>
         /// <param name="maybe"></param>
-        /// <param name="fallbackOperation"></param>
+        /// <param name="valueTaskFallbackOperation"></param>
         /// <typeparam name="T"></typeparam>
         /// <returns></returns>
-        public static async ValueTask<Maybe<T>> Or<T>(this Maybe<T> maybe, Func<ValueTask<T>> fallbackOperation)
+        public static async ValueTask<Maybe<T>> Or<T>(this Maybe<T> maybe, Func<ValueTask<T>> valueTaskFallbackOperation)
         {
             if (maybe.HasNoValue)
-                return await fallbackOperation();
+                return await valueTaskFallbackOperation();
 
             return maybe;
         }
 
         /// <summary>
-        /// Returns <paramref name="fallback" /> if <paramref name="maybe" /> is empty, otherwise it returns <paramref name="maybe" />
+        /// Returns <paramref name="valueTaskFallback" /> if <paramref name="maybe" /> is empty, otherwise it returns <paramref name="maybe" />
         /// </summary>
         /// <param name="maybe"></param>
-        /// <param name="fallback"></param>
+        /// <param name="valueTaskFallback"></param>
         /// <typeparam name="T"></typeparam>
         /// <returns></returns>
-        public static async ValueTask<Maybe<T>> Or<T>(this Maybe<T> maybe, ValueTask<Maybe<T>> fallback)
+        public static async ValueTask<Maybe<T>> Or<T>(this Maybe<T> maybe, ValueTask<Maybe<T>> valueTaskFallback)
         {
             if (maybe.HasNoValue)
-                return await fallback;
+                return await valueTaskFallback;
 
             return maybe;
         }
 
         /// <summary>
-        /// Returns the result of <paramref name="fallbackOperation" /> if <paramref name="maybe" /> is empty, otherwise it returns <paramref name="maybe" />
+        /// Returns the result of <paramref name="valueTaskFallbackOperation" /> if <paramref name="maybe" /> is empty, otherwise it returns <paramref name="maybe" />
         /// </summary>
         /// <param name="maybe"></param>
-        /// <param name="fallbackOperation"></param>
+        /// <param name="valueTaskFallbackOperation"></param>
         /// <typeparam name="T"></typeparam>
         /// <returns></returns>
-        public static async ValueTask<Maybe<T>> Or<T>(this Maybe<T> maybe, Func<ValueTask<Maybe<T>>> fallbackOperation)
+        public static async ValueTask<Maybe<T>> Or<T>(this Maybe<T> maybe, Func<ValueTask<Maybe<T>>> valueTaskFallbackOperation)
         {
             if (maybe.HasNoValue)
-                return await fallbackOperation();
+                return await valueTaskFallbackOperation();
 
             return maybe;
         }

--- a/CSharpFunctionalExtensions/Maybe/Extensions/Or.ValueTask.cs
+++ b/CSharpFunctionalExtensions/Maybe/Extensions/Or.ValueTask.cs
@@ -2,7 +2,7 @@
 using System;
 using System.Threading.Tasks;
 
-namespace CSharpFunctionalExtensions
+namespace CSharpFunctionalExtensions.ValueTasks
 {
     public static partial class MaybeExtensions
     {

--- a/CSharpFunctionalExtensions/Maybe/Extensions/ToResult.ValueTask.cs
+++ b/CSharpFunctionalExtensions/Maybe/Extensions/ToResult.ValueTask.cs
@@ -2,7 +2,7 @@
 using System;
 using System.Threading.Tasks;
 
-namespace CSharpFunctionalExtensions
+namespace CSharpFunctionalExtensions.ValueTasks
 {
     public static partial class MaybeExtensions
     {

--- a/CSharpFunctionalExtensions/Maybe/Extensions/Where.ValueTask.Left.cs
+++ b/CSharpFunctionalExtensions/Maybe/Extensions/Where.ValueTask.Left.cs
@@ -2,7 +2,7 @@
 using System;
 using System.Threading.Tasks;
 
-namespace CSharpFunctionalExtensions
+namespace CSharpFunctionalExtensions.ValueTasks
 {
     public static partial class MaybeExtensions
     {

--- a/CSharpFunctionalExtensions/Maybe/Extensions/Where.ValueTask.Right.cs
+++ b/CSharpFunctionalExtensions/Maybe/Extensions/Where.ValueTask.Right.cs
@@ -2,7 +2,7 @@
 using System;
 using System.Threading.Tasks;
 
-namespace CSharpFunctionalExtensions
+namespace CSharpFunctionalExtensions.ValueTasks
 {
     public static partial class MaybeExtensions
     {

--- a/CSharpFunctionalExtensions/Maybe/Extensions/Where.ValueTask.cs
+++ b/CSharpFunctionalExtensions/Maybe/Extensions/Where.ValueTask.cs
@@ -2,7 +2,7 @@
 using System;
 using System.Threading.Tasks;
 
-namespace CSharpFunctionalExtensions
+namespace CSharpFunctionalExtensions.ValueTasks
 {
     public static partial class MaybeExtensions
     {

--- a/CSharpFunctionalExtensions/Result/Internal/TaskExtensions.cs
+++ b/CSharpFunctionalExtensions/Result/Internal/TaskExtensions.cs
@@ -14,12 +14,10 @@ namespace CSharpFunctionalExtensions
     {
         public static Task<T> AsCompletedTask<T>(this T obj) => Task.FromResult(obj);
 
-        public static ConfiguredTaskAwaitable DefaultAwait(this System.Threading.Tasks.Task task) => task.ConfigureAwait(Result.Configuration.DefaultConfigureAwait);
+        public static ConfiguredTaskAwaitable DefaultAwait(this System.Threading.Tasks.Task task) =>
+            task.ConfigureAwait(Result.Configuration.DefaultConfigureAwait);
 
-        public static ConfiguredTaskAwaitable<T> DefaultAwait<T>(this Task<T> task) => task.ConfigureAwait(Result.Configuration.DefaultConfigureAwait);
-        
-        #if NET5_0_OR_GREATER
-        public static ValueTask<T> AsCompletedValueTask<T>(this T obj) => ValueTask.FromResult(obj);
-        #endif
+        public static ConfiguredTaskAwaitable<T> DefaultAwait<T>(this Task<T> task) =>
+            task.ConfigureAwait(Result.Configuration.DefaultConfigureAwait);
     }
 }

--- a/CSharpFunctionalExtensions/Result/Internal/ValueTaskExtensions.cs
+++ b/CSharpFunctionalExtensions/Result/Internal/ValueTaskExtensions.cs
@@ -1,0 +1,11 @@
+﻿#if NET5_0_OR_GREATER
+using System.Threading.Tasks;
+
+namespace CSharpFunctionalExtensions.ValueTasks
+{
+    internal static class ValueTaskExtensions
+    {
+        public static ValueTask<T> AsCompletedValueTask<T>(this T obj) => ValueTask.FromResult(obj);
+    }
+}
+#endif

--- a/CSharpFunctionalExtensions/Result/Methods/Extensions/Bind.ValueTask.Left.cs
+++ b/CSharpFunctionalExtensions/Result/Methods/Extensions/Bind.ValueTask.Left.cs
@@ -2,80 +2,80 @@
 using System;
 using System.Threading.Tasks;
 
-namespace CSharpFunctionalExtensions
+namespace CSharpFunctionalExtensions.ValueTasks
 {
     public static partial class AsyncResultExtensionsLeftOperand
     {
         /// <summary>
-        ///     Selects result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.
+        ///     Selects result from the return value of a given valueTask action. If the calling Result is a failure, a new failure result is returned instead.
         /// </summary>
-        public static async ValueTask<Result<K, E>> Bind<T, K, E>(this ValueTask<Result<T, E>> resultTask, Func<T, Result<K, E>> func)
+        public static async ValueTask<Result<K, E>> Bind<T, K, E>(this ValueTask<Result<T, E>> resultTask, Func<T, Result<K, E>> valueTask)
         {
             Result<T, E> result = await resultTask;
-            return result.Bind(func);
+            return result.Bind(valueTask);
         }
 
         /// <summary>
-        ///     Selects result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.
+        ///     Selects result from the return value of a given valueTask action. If the calling Result is a failure, a new failure result is returned instead.
         /// </summary>
-        public static async ValueTask<Result<K>> Bind<T, K>(this ValueTask<Result<T>> resultTask, Func<T, Result<K>> func)
+        public static async ValueTask<Result<K>> Bind<T, K>(this ValueTask<Result<T>> resultTask, Func<T, Result<K>> valueTask)
         {
             Result<T> result = await resultTask;
-            return result.Bind(func);
+            return result.Bind(valueTask);
         }
 
         /// <summary>
-        ///     Selects result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.
+        ///     Selects result from the return value of a given valueTask action. If the calling Result is a failure, a new failure result is returned instead.
         /// </summary>
-        public static async ValueTask<Result<K>> Bind<K>(this ValueTask<Result> resultTask, Func<Result<K>> func)
+        public static async ValueTask<Result<K>> Bind<K>(this ValueTask<Result> resultTask, Func<Result<K>> valueTask)
         {
             Result result = await resultTask;
-            return result.Bind(func);
+            return result.Bind(valueTask);
         }
 
         /// <summary>
-        ///     Selects result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.
+        ///     Selects result from the return value of a given valueTask action. If the calling Result is a failure, a new failure result is returned instead.
         /// </summary>
-        public static async ValueTask<Result> Bind<T>(this ValueTask<Result<T>> resultTask, Func<T, Result> func)
+        public static async ValueTask<Result> Bind<T>(this ValueTask<Result<T>> resultTask, Func<T, Result> valueTask)
         {
             Result<T> result = await resultTask;
-            return result.Bind(func);
+            return result.Bind(valueTask);
         }
 
         /// <summary>
-        ///     Selects result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.
+        ///     Selects result from the return value of a given valueTask action. If the calling Result is a failure, a new failure result is returned instead.
         /// </summary>
-        public static async ValueTask<Result> Bind(this ValueTask<Result> resultTask, Func<Result> func)
+        public static async ValueTask<Result> Bind(this ValueTask<Result> resultTask, Func<Result> valueTask)
         {
             Result result = await resultTask;
-            return result.Bind(func);
+            return result.Bind(valueTask);
         }
 
         /// <summary>
-        ///     Selects result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.
+        ///     Selects result from the return value of a given valueTask action. If the calling Result is a failure, a new failure result is returned instead.
         /// </summary>
-        public static async ValueTask<Result<T, E>> Bind<T, E>(this ValueTask<UnitResult<E>> resultTask, Func<Result<T, E>> func)
+        public static async ValueTask<Result<T, E>> Bind<T, E>(this ValueTask<UnitResult<E>> resultTask, Func<Result<T, E>> valueTask)
         {
             UnitResult<E> result = await resultTask;
-            return result.Bind(func);
+            return result.Bind(valueTask);
         }
 
         /// <summary>
-        ///     Selects result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.
+        ///     Selects result from the return value of a given valueTask action. If the calling Result is a failure, a new failure result is returned instead.
         /// </summary>
-        public static async ValueTask<UnitResult<E>> Bind<T, E>(this ValueTask<Result<T, E>> resultTask, Func<T, UnitResult<E>> func)
+        public static async ValueTask<UnitResult<E>> Bind<T, E>(this ValueTask<Result<T, E>> resultTask, Func<T, UnitResult<E>> valueTask)
         {
             Result<T, E> result = await resultTask;
-            return result.Bind(func);
+            return result.Bind(valueTask);
         }
         
         /// <summary>
-        ///     Selects result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.
+        ///     Selects result from the return value of a given valueTask action. If the calling Result is a failure, a new failure result is returned instead.
         /// </summary>
-        public static async ValueTask<UnitResult<E>> Bind<E>(this ValueTask<UnitResult<E>> resultTask, Func<UnitResult<E>> func)
+        public static async ValueTask<UnitResult<E>> Bind<E>(this ValueTask<UnitResult<E>> resultTask, Func<UnitResult<E>> valueTask)
         {
             UnitResult<E> result = await resultTask;
-            return result.Bind(func);
+            return result.Bind(valueTask);
         }
     }
 }

--- a/CSharpFunctionalExtensions/Result/Methods/Extensions/Bind.ValueTask.Right.cs
+++ b/CSharpFunctionalExtensions/Result/Methods/Extensions/Bind.ValueTask.Right.cs
@@ -2,96 +2,96 @@
 using System;
 using System.Threading.Tasks;
 
-namespace CSharpFunctionalExtensions
+namespace CSharpFunctionalExtensions.ValueTasks
 {
     public static partial class AsyncResultExtensionsRightOperand
     {
         /// <summary>
-        ///     Selects result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.
+        ///     Selects result from the return value of a given valueTask action. If the calling Result is a failure, a new failure result is returned instead.
         /// </summary>
-        public static ValueTask<Result<K, E>> Bind<T, K, E>(this Result<T, E> result, Func<T, ValueTask<Result<K, E>>> func)
+        public static ValueTask<Result<K, E>> Bind<T, K, E>(this Result<T, E> result, Func<T, ValueTask<Result<K, E>>> valueTask)
         {
             if (result.IsFailure)
                 return Result.Failure<K, E>(result.Error).AsCompletedValueTask();
 
-            return func(result.Value);
+            return valueTask(result.Value);
         }
 
         /// <summary>
-        ///     Selects result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.
+        ///     Selects result from the return value of a given valueTask action. If the calling Result is a failure, a new failure result is returned instead.
         /// </summary>
-        public static ValueTask<Result<K>> Bind<T, K>(this Result<T> result, Func<T, ValueTask<Result<K>>> func)
+        public static ValueTask<Result<K>> Bind<T, K>(this Result<T> result, Func<T, ValueTask<Result<K>>> valueTask)
         {
             if (result.IsFailure)
                 return Result.Failure<K>(result.Error).AsCompletedValueTask();
 
-            return func(result.Value);
+            return valueTask(result.Value);
         }
 
         /// <summary>
-        ///     Selects result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.
+        ///     Selects result from the return value of a given valueTask action. If the calling Result is a failure, a new failure result is returned instead.
         /// </summary>
-        public static ValueTask<Result<K>> Bind<K>(this Result result, Func<ValueTask<Result<K>>> func)
+        public static ValueTask<Result<K>> Bind<K>(this Result result, Func<ValueTask<Result<K>>> valueTask)
         {
             if (result.IsFailure)
                 return Result.Failure<K>(result.Error).AsCompletedValueTask();
 
-            return func();
+            return valueTask();
         }
 
         /// <summary>
-        ///     Selects result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.
+        ///     Selects result from the return value of a given valueTask action. If the calling Result is a failure, a new failure result is returned instead.
         /// </summary>
-        public static ValueTask<Result> Bind<T>(this Result<T> result, Func<T, ValueTask<Result>> func)
+        public static ValueTask<Result> Bind<T>(this Result<T> result, Func<T, ValueTask<Result>> valueTask)
         {
             if (result.IsFailure)
                 return Result.Failure(result.Error).AsCompletedValueTask();
 
-            return func(result.Value);
+            return valueTask(result.Value);
         }
 
         /// <summary>
-        ///     Selects result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.
+        ///     Selects result from the return value of a given valueTask action. If the calling Result is a failure, a new failure result is returned instead.
         /// </summary>
-        public static ValueTask<Result> Bind(this Result result, Func<ValueTask<Result>> func)
+        public static ValueTask<Result> Bind(this Result result, Func<ValueTask<Result>> valueTask)
         {
             if (result.IsFailure)
                 return result.AsCompletedValueTask();
 
-            return func();
+            return valueTask();
         }
 
         /// <summary>
-        ///     Selects result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.
+        ///     Selects result from the return value of a given valueTask action. If the calling Result is a failure, a new failure result is returned instead.
         /// </summary>
-        public static ValueTask<UnitResult<E>> Bind<E>(this UnitResult<E> result, Func<ValueTask<UnitResult<E>>> func)
+        public static ValueTask<UnitResult<E>> Bind<E>(this UnitResult<E> result, Func<ValueTask<UnitResult<E>>> valueTask)
         {
             if (result.IsFailure)
                 return UnitResult.Failure(result.Error).AsCompletedValueTask();
 
-            return func();
+            return valueTask();
         }
         
         /// <summary>
-        ///     Selects result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.
+        ///     Selects result from the return value of a given valueTask action. If the calling Result is a failure, a new failure result is returned instead.
         /// </summary>
-        public static ValueTask<Result<T, E>> Bind<T, E>(this UnitResult<E> result, Func<ValueTask<Result<T, E>>> func)
+        public static ValueTask<Result<T, E>> Bind<T, E>(this UnitResult<E> result, Func<ValueTask<Result<T, E>>> valueTask)
         {
             if (result.IsFailure)
                 return Result.Failure<T, E>(result.Error).AsCompletedValueTask();
 
-            return func();
+            return valueTask();
         }
 
         /// <summary>
-        ///     Selects result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.
+        ///     Selects result from the return value of a given valueTask action. If the calling Result is a failure, a new failure result is returned instead.
         /// </summary>
-        public static ValueTask<UnitResult<E>> Bind<T, E>(this Result<T, E> result, Func<T, ValueTask<UnitResult<E>>> func)
+        public static ValueTask<UnitResult<E>> Bind<T, E>(this Result<T, E> result, Func<T, ValueTask<UnitResult<E>>> valueTask)
         {
             if (result.IsFailure)
                 return UnitResult.Failure(result.Error).AsCompletedValueTask();
 
-            return func(result.Value);
+            return valueTask(result.Value);
         }
     }
 }

--- a/CSharpFunctionalExtensions/Result/Methods/Extensions/Bind.ValueTask.cs
+++ b/CSharpFunctionalExtensions/Result/Methods/Extensions/Bind.ValueTask.cs
@@ -2,80 +2,80 @@
 using System;
 using System.Threading.Tasks;
 
-namespace CSharpFunctionalExtensions
+namespace CSharpFunctionalExtensions.ValueTasks
 {
     public static partial class AsyncResultExtensionsBothOperands
     {
         /// <summary>
-        ///     Selects result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.
+        ///     Selects result from the return value of a given valueTask action. If the calling Result is a failure, a new failure result is returned instead.
         /// </summary>
-        public static async ValueTask<Result<K, E>> Bind<T, K, E>(this ValueTask<Result<T, E>> resultTask, Func<T, ValueTask<Result<K, E>>> func)
+        public static async ValueTask<Result<K, E>> Bind<T, K, E>(this ValueTask<Result<T, E>> resultTask, Func<T, ValueTask<Result<K, E>>> valueTask)
         {
             Result<T, E> result = await resultTask;
-            return await result.Bind(func);
+            return await result.Bind(valueTask);
         }
 
         /// <summary>
-        ///     Selects result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.
+        ///     Selects result from the return value of a given valueTask action. If the calling Result is a failure, a new failure result is returned instead.
         /// </summary>
-        public static async ValueTask<Result<K>> Bind<T, K>(this ValueTask<Result<T>> resultTask, Func<T, ValueTask<Result<K>>> func)
+        public static async ValueTask<Result<K>> Bind<T, K>(this ValueTask<Result<T>> resultTask, Func<T, ValueTask<Result<K>>> valueTask)
         {
             Result<T> result = await resultTask;
-            return await result.Bind(func);
+            return await result.Bind(valueTask);
         }
 
         /// <summary>
-        ///     Selects result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.
+        ///     Selects result from the return value of a given valueTask action. If the calling Result is a failure, a new failure result is returned instead.
         /// </summary>
-        public static async ValueTask<Result<K>> Bind<K>(this ValueTask<Result> resultTask, Func<ValueTask<Result<K>>> func)
+        public static async ValueTask<Result<K>> Bind<K>(this ValueTask<Result> resultTask, Func<ValueTask<Result<K>>> valueTask)
         {
             Result result = await resultTask;
-            return await result.Bind(func);
+            return await result.Bind(valueTask);
         }
 
         /// <summary>
-        ///     Selects result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.
+        ///     Selects result from the return value of a given valueTask action. If the calling Result is a failure, a new failure result is returned instead.
         /// </summary>
-        public static async ValueTask<Result> Bind<T>(this ValueTask<Result<T>> resultTask, Func<T, ValueTask<Result>> func)
+        public static async ValueTask<Result> Bind<T>(this ValueTask<Result<T>> resultTask, Func<T, ValueTask<Result>> valueTask)
         {
             Result<T> result = await resultTask;
-            return await result.Bind(func);
+            return await result.Bind(valueTask);
         }
 
         /// <summary>
-        ///     Selects result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.
+        ///     Selects result from the return value of a given valueTask action. If the calling Result is a failure, a new failure result is returned instead.
         /// </summary>
-        public static async ValueTask<Result> Bind(this ValueTask<Result> resultTask, Func<ValueTask<Result>> func)
+        public static async ValueTask<Result> Bind(this ValueTask<Result> resultTask, Func<ValueTask<Result>> valueTask)
         {
             Result result = await resultTask;
-            return await result.Bind(func);
+            return await result.Bind(valueTask);
         }
 
         /// <summary>
-        ///     Selects result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.
+        ///     Selects result from the return value of a given valueTask action. If the calling Result is a failure, a new failure result is returned instead.
         /// </summary>
-        public static async ValueTask<Result<T, E>> Bind<T, E>(this ValueTask<UnitResult<E>> resultTask, Func<ValueTask<Result<T, E>>> func)
+        public static async ValueTask<Result<T, E>> Bind<T, E>(this ValueTask<UnitResult<E>> resultTask, Func<ValueTask<Result<T, E>>> valueTask)
         {
             UnitResult<E> result = await resultTask;
-            return await result.Bind(func);
+            return await result.Bind(valueTask);
         }
 
         /// <summary>
-        ///     Selects result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.
+        ///     Selects result from the return value of a given valueTask action. If the calling Result is a failure, a new failure result is returned instead.
         /// </summary>
-        public static async ValueTask<UnitResult<E>> Bind<T, E>(this ValueTask<Result<T, E>> resultTask, Func<T, ValueTask<UnitResult<E>>> func)
+        public static async ValueTask<UnitResult<E>> Bind<T, E>(this ValueTask<Result<T, E>> resultTask, Func<T, ValueTask<UnitResult<E>>> valueTask)
         {
             Result<T, E> result = await resultTask;
-            return await result.Bind(func);
+            return await result.Bind(valueTask);
         }
         
         /// <summary>
-        ///     Selects result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.
+        ///     Selects result from the return value of a given valueTask action. If the calling Result is a failure, a new failure result is returned instead.
         /// </summary>
-        public static async ValueTask<UnitResult<E>> Bind<E>(this ValueTask<UnitResult<E>> resultTask, Func<ValueTask<UnitResult<E>>> func)
+        public static async ValueTask<UnitResult<E>> Bind<E>(this ValueTask<UnitResult<E>> resultTask, Func<ValueTask<UnitResult<E>>> valueTask)
         {
             UnitResult<E> result = await resultTask;
-            return await result.Bind(func);
+            return await result.Bind(valueTask);
         }
     }
 }

--- a/CSharpFunctionalExtensions/Result/Methods/Extensions/BindIf.ValueTask.Left.cs
+++ b/CSharpFunctionalExtensions/Result/Methods/Extensions/BindIf.ValueTask.Left.cs
@@ -2,56 +2,56 @@
 using System;
 using System.Threading.Tasks;
 
-namespace CSharpFunctionalExtensions
+namespace CSharpFunctionalExtensions.ValueTasks
 {
     public static partial class ResultExtensions
     {
-        public static async ValueTask<Result> BindIf(this ValueTask<Result> resultTask, bool condition, Func<Result> func)
+        public static async ValueTask<Result> BindIf(this ValueTask<Result> resultTask, bool condition, Func<Result> valueTask)
         {
             var result = await resultTask;
-            return result.BindIf(condition, func);
+            return result.BindIf(condition, valueTask);
         }
 
-        public static async ValueTask<Result<T>> BindIf<T>(this ValueTask<Result<T>> resultTask, bool condition, Func<T, Result<T>> func)
+        public static async ValueTask<Result<T>> BindIf<T>(this ValueTask<Result<T>> resultTask, bool condition, Func<T, Result<T>> valueTask)
         {
             var result = await resultTask;
-            return result.BindIf(condition, func);
+            return result.BindIf(condition, valueTask);
         }
 
-        public static async ValueTask<UnitResult<E>> BindIf<E>(this ValueTask<UnitResult<E>> resultTask, bool condition, Func<UnitResult<E>> func)
+        public static async ValueTask<UnitResult<E>> BindIf<E>(this ValueTask<UnitResult<E>> resultTask, bool condition, Func<UnitResult<E>> valueTask)
         {
             var result = await resultTask;
-            return result.BindIf(condition, func);
+            return result.BindIf(condition, valueTask);
         }
 
-        public static async ValueTask<Result<T, E>> BindIf<T, E>(this ValueTask<Result<T, E>> resultTask, bool condition, Func<T, Result<T, E>> func)
+        public static async ValueTask<Result<T, E>> BindIf<T, E>(this ValueTask<Result<T, E>> resultTask, bool condition, Func<T, Result<T, E>> valueTask)
         {
             var result = await resultTask;
-            return result.BindIf(condition, func);
+            return result.BindIf(condition, valueTask);
         }
 
-        public static async ValueTask<Result> BindIf(this ValueTask<Result> resultTask, Func<bool> predicate, Func<Result> func)
+        public static async ValueTask<Result> BindIf(this ValueTask<Result> resultTask, Func<bool> predicate, Func<Result> valueTask)
         {
             var result = await resultTask;
-            return result.BindIf(predicate, func);
+            return result.BindIf(predicate, valueTask);
         }
 
-        public static async ValueTask<Result<T>> BindIf<T>(this ValueTask<Result<T>> resultTask, Func<T, bool> predicate, Func<T, Result<T>> func)
+        public static async ValueTask<Result<T>> BindIf<T>(this ValueTask<Result<T>> resultTask, Func<T, bool> predicate, Func<T, Result<T>> valueTask)
         {
             var result = await resultTask;
-            return result.BindIf(predicate, func);
+            return result.BindIf(predicate, valueTask);
         }
 
-        public static async ValueTask<UnitResult<E>> BindIf<E>(this ValueTask<UnitResult<E>> resultTask, Func<bool> predicate, Func<UnitResult<E>> func)
+        public static async ValueTask<UnitResult<E>> BindIf<E>(this ValueTask<UnitResult<E>> resultTask, Func<bool> predicate, Func<UnitResult<E>> valueTask)
         {
             var result = await resultTask;
-            return result.BindIf(predicate, func);
+            return result.BindIf(predicate, valueTask);
         }
 
-        public static async ValueTask<Result<T, E>> BindIf<T, E>(this ValueTask<Result<T, E>> resultTask, Func<T, bool> predicate, Func<T, Result<T, E>> func)
+        public static async ValueTask<Result<T, E>> BindIf<T, E>(this ValueTask<Result<T, E>> resultTask, Func<T, bool> predicate, Func<T, Result<T, E>> valueTask)
         {
             var result = await resultTask;
-            return result.BindIf(predicate, func);
+            return result.BindIf(predicate, valueTask);
         }
     }
 }

--- a/CSharpFunctionalExtensions/Result/Methods/Extensions/BindIf.ValueTask.Right.cs
+++ b/CSharpFunctionalExtensions/Result/Methods/Extensions/BindIf.ValueTask.Right.cs
@@ -2,88 +2,88 @@
 using System;
 using System.Threading.Tasks;
 
-namespace CSharpFunctionalExtensions
+namespace CSharpFunctionalExtensions.ValueTasks
 {
     public static partial class ResultExtensions
     {
-        public static ValueTask<Result> BindIf(this Result result, bool condition, Func<ValueTask<Result>> func)
+        public static ValueTask<Result> BindIf(this Result result, bool condition, Func<ValueTask<Result>> valueTask)
         {
             if (!condition)
             {
                 return result.AsCompletedValueTask();
             }
 
-            return result.Bind(func);
+            return result.Bind(valueTask);
         }
 
-        public static ValueTask<Result<T>> BindIf<T>(this Result<T> result, bool condition, Func<T, ValueTask<Result<T>>> func)
+        public static ValueTask<Result<T>> BindIf<T>(this Result<T> result, bool condition, Func<T, ValueTask<Result<T>>> valueTask)
         {
             if (!condition)
             {
                 return result.AsCompletedValueTask();
             }
 
-            return result.Bind(func);
+            return result.Bind(valueTask);
         }
 
-        public static ValueTask<UnitResult<E>> BindIf<E>(this UnitResult<E> result, bool condition, Func<ValueTask<UnitResult<E>>> func)
+        public static ValueTask<UnitResult<E>> BindIf<E>(this UnitResult<E> result, bool condition, Func<ValueTask<UnitResult<E>>> valueTask)
         {
             if (!condition)
             {
                 return result.AsCompletedValueTask();
             }
 
-            return result.Bind(func);
+            return result.Bind(valueTask);
         }
 
-        public static ValueTask<Result<T, E>> BindIf<T, E>(this Result<T, E> result, bool condition, Func<T, ValueTask<Result<T, E>>> func)
+        public static ValueTask<Result<T, E>> BindIf<T, E>(this Result<T, E> result, bool condition, Func<T, ValueTask<Result<T, E>>> valueTask)
         {
             if (!condition)
             {
                 return result.AsCompletedValueTask();
             }
 
-            return result.Bind(func);
+            return result.Bind(valueTask);
         }
 
-        public static ValueTask<Result> BindIf(this Result result, Func<bool> predicate, Func<ValueTask<Result>> func)
+        public static ValueTask<Result> BindIf(this Result result, Func<bool> predicate, Func<ValueTask<Result>> valueTask)
         {
             if (!result.IsSuccess || !predicate())
             {
                 return result.AsCompletedValueTask();
             }
 
-            return result.Bind(func);
+            return result.Bind(valueTask);
         }
 
-        public static ValueTask<Result<T>> BindIf<T>(this Result<T> result, Func<T, bool> predicate, Func<T, ValueTask<Result<T>>> func)
+        public static ValueTask<Result<T>> BindIf<T>(this Result<T> result, Func<T, bool> predicate, Func<T, ValueTask<Result<T>>> valueTask)
         {
             if (!result.IsSuccess || !predicate(result.Value))
             {
                 return result.AsCompletedValueTask();
             }
 
-            return result.Bind(func);
+            return result.Bind(valueTask);
         }
 
-        public static ValueTask<UnitResult<E>> BindIf<E>(this UnitResult<E> result, Func<bool> predicate, Func<ValueTask<UnitResult<E>>> func)
+        public static ValueTask<UnitResult<E>> BindIf<E>(this UnitResult<E> result, Func<bool> predicate, Func<ValueTask<UnitResult<E>>> valueTask)
         {
             if (!result.IsSuccess || !predicate())
             {
                 return result.AsCompletedValueTask();
             }
 
-            return result.Bind(func);
+            return result.Bind(valueTask);
         }
 
-        public static ValueTask<Result<T, E>> BindIf<T, E>(this Result<T, E> result, Func<T, bool> predicate, Func<T, ValueTask<Result<T, E>>> func)
+        public static ValueTask<Result<T, E>> BindIf<T, E>(this Result<T, E> result, Func<T, bool> predicate, Func<T, ValueTask<Result<T, E>>> valueTask)
         {
             if (!result.IsSuccess || !predicate(result.Value))
             {
                 return result.AsCompletedValueTask();
             }
 
-            return result.Bind(func);
+            return result.Bind(valueTask);
         }
     }
 }

--- a/CSharpFunctionalExtensions/Result/Methods/Extensions/BindIf.ValueTask.cs
+++ b/CSharpFunctionalExtensions/Result/Methods/Extensions/BindIf.ValueTask.cs
@@ -2,57 +2,57 @@
 using System;
 using System.Threading.Tasks;
 
-namespace CSharpFunctionalExtensions
+namespace CSharpFunctionalExtensions.ValueTasks
 {
     public static partial class ResultExtensions
     {
-        public static async ValueTask<Result> BindIf(this ValueTask<Result> resultTask, bool condition, Func<ValueTask<Result>> func)
+        public static async ValueTask<Result> BindIf(this ValueTask<Result> resultTask, bool condition, Func<ValueTask<Result>> valueTask)
         {
             var result = await resultTask;
-            return await result.BindIf(condition, func);
+            return await result.BindIf(condition, valueTask);
         }
 
-        public static async ValueTask<Result<T>> BindIf<T>(this ValueTask<Result<T>> resultTask, bool condition, Func<T, ValueTask<Result<T>>> func)
+        public static async ValueTask<Result<T>> BindIf<T>(this ValueTask<Result<T>> resultTask, bool condition, Func<T, ValueTask<Result<T>>> valueTask)
         {
             var result = await resultTask;
-            return await result.BindIf(condition, func);
+            return await result.BindIf(condition, valueTask);
         }
 
-        public static async ValueTask<UnitResult<E>> BindIf<E>(this ValueTask<UnitResult<E>> resultTask, bool condition, Func<ValueTask<UnitResult<E>>> func)
+        public static async ValueTask<UnitResult<E>> BindIf<E>(this ValueTask<UnitResult<E>> resultTask, bool condition, Func<ValueTask<UnitResult<E>>> valueTask)
         {
             var result = await resultTask;
-            return await result.BindIf(condition, func);
+            return await result.BindIf(condition, valueTask);
         }
 
-        public static async ValueTask<Result<T, E>> BindIf<T, E>(this ValueTask<Result<T, E>> resultTask, bool condition, Func<T, ValueTask<Result<T, E>>> func)
+        public static async ValueTask<Result<T, E>> BindIf<T, E>(this ValueTask<Result<T, E>> resultTask, bool condition, Func<T, ValueTask<Result<T, E>>> valueTask)
         {
             var result = await resultTask;
-            return await result.BindIf(condition, func);
+            return await result.BindIf(condition, valueTask);
         }
 
-        public static async ValueTask<Result> BindIf(this ValueTask<Result> resultTask, Func<bool> predicate, Func<ValueTask<Result>> func)
+        public static async ValueTask<Result> BindIf(this ValueTask<Result> resultTask, Func<bool> predicate, Func<ValueTask<Result>> valueTask)
         {
             var result = await resultTask;
-            return await result.BindIf(predicate, func);
+            return await result.BindIf(predicate, valueTask);
         }
 
-        public static async ValueTask<Result<T>> BindIf<T>(this ValueTask<Result<T>> resultTask, Func<T, bool> predicate, Func<T, ValueTask<Result<T>>> func)
+        public static async ValueTask<Result<T>> BindIf<T>(this ValueTask<Result<T>> resultTask, Func<T, bool> predicate, Func<T, ValueTask<Result<T>>> valueTask)
         {
             var result = await resultTask;
-            return await result.BindIf(predicate, func);
+            return await result.BindIf(predicate, valueTask);
         }
 
-        public static async ValueTask<UnitResult<E>> BindIf<E>(this ValueTask<UnitResult<E>> resultTask, Func<bool> predicate, Func<ValueTask<UnitResult<E>>> func)
+        public static async ValueTask<UnitResult<E>> BindIf<E>(this ValueTask<UnitResult<E>> resultTask, Func<bool> predicate, Func<ValueTask<UnitResult<E>>> valueTask)
         {
             
             var result = await resultTask;
-            return await result.BindIf(predicate, func);
+            return await result.BindIf(predicate, valueTask);
         }
 
-        public static async ValueTask<Result<T, E>> BindIf<T, E>(this ValueTask<Result<T, E>> resultTask, Func<T, bool> predicate, Func<T, ValueTask<Result<T, E>>> func)
+        public static async ValueTask<Result<T, E>> BindIf<T, E>(this ValueTask<Result<T, E>> resultTask, Func<T, bool> predicate, Func<T, ValueTask<Result<T, E>>> valueTask)
         {
             var result = await resultTask;
-            return await result.BindIf(predicate, func);
+            return await result.BindIf(predicate, valueTask);
         }
     }
 }

--- a/CSharpFunctionalExtensions/Result/Methods/Extensions/BindWithTransactionScope.ValueTask.Left.cs
+++ b/CSharpFunctionalExtensions/Result/Methods/Extensions/BindWithTransactionScope.ValueTask.Left.cs
@@ -2,7 +2,7 @@
 using System;
 using System.Threading.Tasks;
 
-namespace CSharpFunctionalExtensions
+namespace CSharpFunctionalExtensions.ValueTasks
 {
     public static partial class ResultExtensions
     {

--- a/CSharpFunctionalExtensions/Result/Methods/Extensions/BindWithTransactionScope.ValueTask.Right.cs
+++ b/CSharpFunctionalExtensions/Result/Methods/Extensions/BindWithTransactionScope.ValueTask.Right.cs
@@ -2,7 +2,7 @@
 using System;
 using System.Threading.Tasks;
 
-namespace CSharpFunctionalExtensions
+namespace CSharpFunctionalExtensions.ValueTasks
 {
     public static partial class ResultExtensions
     {

--- a/CSharpFunctionalExtensions/Result/Methods/Extensions/BindWithTransactionScope.ValueTask.cs
+++ b/CSharpFunctionalExtensions/Result/Methods/Extensions/BindWithTransactionScope.ValueTask.cs
@@ -2,7 +2,7 @@
 using System;
 using System.Threading.Tasks;
 
-namespace CSharpFunctionalExtensions
+namespace CSharpFunctionalExtensions.ValueTasks
 {
     public static partial class ResultExtensions
     {

--- a/CSharpFunctionalExtensions/Result/Methods/Extensions/Check.ValueTask.Left.cs
+++ b/CSharpFunctionalExtensions/Result/Methods/Extensions/Check.ValueTask.Left.cs
@@ -2,57 +2,57 @@
 using System;
 using System.Threading.Tasks;
 
-namespace CSharpFunctionalExtensions
+namespace CSharpFunctionalExtensions.ValueTasks
 {
     public static partial class AsyncResultExtensionsLeftOperand
     {
         /// <summary>
-        ///     If the calling result is a success, the given function is executed and its Result is checked. If this Result is a failure, it is returned. Otherwise, the calling result is returned.
+        ///     If the calling result is a success, the given valueTask action is executed and its Result is checked. If this Result is a failure, it is returned. Otherwise, the calling result is returned.
         /// </summary>
-        public static async ValueTask<Result<T>> Check<T>(this ValueTask<Result<T>> resultTask, Func<T, Result> func)
+        public static async ValueTask<Result<T>> Check<T>(this ValueTask<Result<T>> resultTask, Func<T, Result> valueTask)
         {
             Result<T> result = await resultTask;
-            return result.Check(func);
+            return result.Check(valueTask);
         }
 
         /// <summary>
-        ///     If the calling result is a success, the given function is executed and its Result is checked. If this Result is a failure, it is returned. Otherwise, the calling result is returned.
+        ///     If the calling result is a success, the given valueTask action is executed and its Result is checked. If this Result is a failure, it is returned. Otherwise, the calling result is returned.
         /// </summary>
         public static async ValueTask<Result<T>> Check<T, K>(this ValueTask<Result<T>> resultTask,
-            Func<T, Result<K>> func)
+            Func<T, Result<K>> valueTask)
         {
             Result<T> result = await resultTask;
-            return result.Check(func);
+            return result.Check(valueTask);
         }
 
         /// <summary>
-        ///     If the calling result is a success, the given function is executed and its Result is checked. If this Result is a failure, it is returned. Otherwise, the calling result is returned.
+        ///     If the calling result is a success, the given valueTask action is executed and its Result is checked. If this Result is a failure, it is returned. Otherwise, the calling result is returned.
         /// </summary>
         public static async ValueTask<Result<T, E>> Check<T, K, E>(this ValueTask<Result<T, E>> resultTask,
-            Func<T, Result<K, E>> func)
+            Func<T, Result<K, E>> valueTask)
         {
             Result<T, E> result = await resultTask;
-            return result.Check(func);
+            return result.Check(valueTask);
         }
 
         /// <summary>
-        ///     If the calling result is a success, the given function is executed and its Result is checked. If this Result is a failure, it is returned. Otherwise, the calling result is returned.
+        ///     If the calling result is a success, the given valueTask action is executed and its Result is checked. If this Result is a failure, it is returned. Otherwise, the calling result is returned.
         /// </summary>
         public static async ValueTask<Result<T, E>> Check<T, E>(this ValueTask<Result<T, E>> resultTask,
-            Func<T, UnitResult<E>> func)
+            Func<T, UnitResult<E>> valueTask)
         {
             Result<T, E> result = await resultTask;
-            return result.Check(func);
+            return result.Check(valueTask);
         }
 
         /// <summary>
-        ///     If the calling result is a success, the given function is executed and its Result is checked. If this Result is a failure, it is returned. Otherwise, the calling result is returned.
+        ///     If the calling result is a success, the given valueTask action is executed and its Result is checked. If this Result is a failure, it is returned. Otherwise, the calling result is returned.
         /// </summary>
         public static async ValueTask<UnitResult<E>> Check<E>(this ValueTask<UnitResult<E>> resultTask,
-            Func<UnitResult<E>> func)
+            Func<UnitResult<E>> valueTask)
         {
             UnitResult<E> result = await resultTask;
-            return result.Check(func);
+            return result.Check(valueTask);
         }
     }
 }

--- a/CSharpFunctionalExtensions/Result/Methods/Extensions/Check.ValueTask.Right.cs
+++ b/CSharpFunctionalExtensions/Result/Methods/Extensions/Check.ValueTask.Right.cs
@@ -2,48 +2,48 @@
 using System;
 using System.Threading.Tasks;
 
-namespace CSharpFunctionalExtensions
+namespace CSharpFunctionalExtensions.ValueTasks
 {
    public static partial class AsyncResultExtensionsRightOperand
     {
         /// <summary>
-        ///     If the calling result is a success, the given function is executed and its Result is checked. If this Result is a failure, it is returned. Otherwise, the calling result is returned.
+        ///     If the calling result is a success, the given valueTask action is executed and its Result is checked. If this Result is a failure, it is returned. Otherwise, the calling result is returned.
         /// </summary>
-        public static async ValueTask<Result<T>> Check<T>(this Result<T> result, Func<T, ValueTask<Result>> func)
+        public static async ValueTask<Result<T>> Check<T>(this Result<T> result, Func<T, ValueTask<Result>> valueTask)
         {
-            return await result.Bind(func).Map(() => result.Value);
+            return await result.Bind(valueTask).Map(() => result.Value);
         }
 
         /// <summary>
-        ///     If the calling result is a success, the given function is executed and its Result is checked. If this Result is a failure, it is returned. Otherwise, the calling result is returned.
+        ///     If the calling result is a success, the given valueTask action is executed and its Result is checked. If this Result is a failure, it is returned. Otherwise, the calling result is returned.
         /// </summary>
-        public static async ValueTask<Result<T>> Check<T, K>(this Result<T> result, Func<T, ValueTask<Result<K>>> func)
+        public static async ValueTask<Result<T>> Check<T, K>(this Result<T> result, Func<T, ValueTask<Result<K>>> valueTask)
         {
-            return await result.Bind(func).Map(_ => result.Value);
+            return await result.Bind(valueTask).Map(_ => result.Value);
         }
 
         /// <summary>
-        ///     If the calling result is a success, the given function is executed and its Result is checked. If this Result is a failure, it is returned. Otherwise, the calling result is returned.
+        ///     If the calling result is a success, the given valueTask action is executed and its Result is checked. If this Result is a failure, it is returned. Otherwise, the calling result is returned.
         /// </summary>
-        public static async ValueTask<Result<T, E>> Check<T, K, E>(this Result<T, E> result, Func<T, ValueTask<Result<K, E>>> func)
+        public static async ValueTask<Result<T, E>> Check<T, K, E>(this Result<T, E> result, Func<T, ValueTask<Result<K, E>>> valueTask)
         {
-            return await result.Bind(func).Map(_ => result.Value);
+            return await result.Bind(valueTask).Map(_ => result.Value);
         }
 
         /// <summary>
-        ///     If the calling result is a success, the given function is executed and its Result is checked. If this Result is a failure, it is returned. Otherwise, the calling result is returned.
+        ///     If the calling result is a success, the given valueTask action is executed and its Result is checked. If this Result is a failure, it is returned. Otherwise, the calling result is returned.
         /// </summary>
-        public static async ValueTask<Result<T, E>> Check<T, E>(this Result<T, E> result, Func<T, ValueTask<UnitResult<E>>> func)
+        public static async ValueTask<Result<T, E>> Check<T, E>(this Result<T, E> result, Func<T, ValueTask<UnitResult<E>>> valueTask)
         {
-            return await result.Bind(func).Map(() => result.Value);
+            return await result.Bind(valueTask).Map(() => result.Value);
         }
 
         /// <summary>
-        ///     If the calling result is a success, the given function is executed and its Result is checked. If this Result is a failure, it is returned. Otherwise, the calling result is returned.
+        ///     If the calling result is a success, the given valueTask action is executed and its Result is checked. If this Result is a failure, it is returned. Otherwise, the calling result is returned.
         /// </summary>
-        public static async ValueTask<UnitResult<E>> Check<E>(this UnitResult<E> result, Func<ValueTask<UnitResult<E>>> func)
+        public static async ValueTask<UnitResult<E>> Check<E>(this UnitResult<E> result, Func<ValueTask<UnitResult<E>>> valueTask)
         {
-            return await result.Bind(func).Map(() => result);
+            return await result.Bind(valueTask).Map(() => result);
         }
     }
 }

--- a/CSharpFunctionalExtensions/Result/Methods/Extensions/Check.ValueTask.cs
+++ b/CSharpFunctionalExtensions/Result/Methods/Extensions/Check.ValueTask.cs
@@ -2,58 +2,58 @@
 using System;
 using System.Threading.Tasks;
 
-namespace CSharpFunctionalExtensions
+namespace CSharpFunctionalExtensions.ValueTasks
 {
     public static partial class AsyncResultExtensionsBothOperands
     {
         /// <summary>
-        ///     If the calling result is a success, the given function is executed and its Result is checked. If this Result is a failure, it is returned. Otherwise, the calling result is returned.
+        ///     If the calling result is a success, the given valueTask action is executed and its Result is checked. If this Result is a failure, it is returned. Otherwise, the calling result is returned.
         /// </summary>
         public static async ValueTask<Result<T>> Check<T>(this ValueTask<Result<T>> resultTask,
-            Func<T, ValueTask<Result>> func)
+            Func<T, ValueTask<Result>> valueTask)
         {
             Result<T> result = await resultTask;
-            return await result.Bind(func).Map(() => result.Value);
+            return await result.Bind(valueTask).Map(() => result.Value);
         }
 
         /// <summary>
-        ///     If the calling result is a success, the given function is executed and its Result is checked. If this Result is a failure, it is returned. Otherwise, the calling result is returned.
+        ///     If the calling result is a success, the given valueTask action is executed and its Result is checked. If this Result is a failure, it is returned. Otherwise, the calling result is returned.
         /// </summary>
         public static async ValueTask<Result<T>> Check<T, K>(this ValueTask<Result<T>> resultTask,
-            Func<T, ValueTask<Result<K>>> func)
+            Func<T, ValueTask<Result<K>>> valueTask)
         {
             Result<T> result = await resultTask;
-            return await result.Bind(func).Map(_ => result.Value);
+            return await result.Bind(valueTask).Map(_ => result.Value);
         }
 
         /// <summary>
-        ///     If the calling result is a success, the given function is executed and its Result is checked. If this Result is a failure, it is returned. Otherwise, the calling result is returned.
+        ///     If the calling result is a success, the given valueTask action is executed and its Result is checked. If this Result is a failure, it is returned. Otherwise, the calling result is returned.
         /// </summary>
         public static async ValueTask<Result<T, E>> Check<T, K, E>(this ValueTask<Result<T, E>> resultTask,
-            Func<T, ValueTask<Result<K, E>>> func)
+            Func<T, ValueTask<Result<K, E>>> valueTask)
         {
             Result<T, E> result = await resultTask;
-            return await result.Bind(func).Map(_ => result.Value);
+            return await result.Bind(valueTask).Map(_ => result.Value);
         }
 
         /// <summary>
-        ///     If the calling result is a success, the given function is executed and its Result is checked. If this Result is a failure, it is returned. Otherwise, the calling result is returned.
+        ///     If the calling result is a success, the given valueTask action is executed and its Result is checked. If this Result is a failure, it is returned. Otherwise, the calling result is returned.
         /// </summary>
         public static async ValueTask<Result<T, E>> Check<T, E>(this ValueTask<Result<T, E>> resultTask,
-            Func<T, ValueTask<UnitResult<E>>> func)
+            Func<T, ValueTask<UnitResult<E>>> valueTask)
         {
             Result<T, E> result = await resultTask;
-            return await result.Bind(func).Map(() => result.Value);
+            return await result.Bind(valueTask).Map(() => result.Value);
         }
 
         /// <summary>
-        ///     If the calling result is a success, the given function is executed and its Result is checked. If this Result is a failure, it is returned. Otherwise, the calling result is returned.
+        ///     If the calling result is a success, the given valueTask action is executed and its Result is checked. If this Result is a failure, it is returned. Otherwise, the calling result is returned.
         /// </summary>
         public static async ValueTask<UnitResult<E>> Check<E>(this ValueTask<UnitResult<E>> resultTask,
-            Func<ValueTask<UnitResult<E>>> func)
+            Func<ValueTask<UnitResult<E>>> valueTask)
         {
             UnitResult<E> result = await resultTask;
-            return await result.Bind(func).Map(() => result);
+            return await result.Bind(valueTask).Map(() => result);
         }
     }
 }

--- a/CSharpFunctionalExtensions/Result/Methods/Extensions/CheckIf.ValueTask.Left.cs
+++ b/CSharpFunctionalExtensions/Result/Methods/Extensions/CheckIf.ValueTask.Left.cs
@@ -2,96 +2,96 @@
 using System;
 using System.Threading.Tasks;
 
-namespace CSharpFunctionalExtensions
+namespace CSharpFunctionalExtensions.ValueTasks
 {
    public static partial class AsyncResultExtensionsLeftOperand
     {
-        public static ValueTask<Result<T>> CheckIf<T>(this ValueTask<Result<T>> resultTask, bool condition, Func<T, Result> func)
+        public static ValueTask<Result<T>> CheckIf<T>(this ValueTask<Result<T>> resultTask, bool condition, Func<T, Result> valueTask)
         {
             if (condition)
-                return resultTask.Check(func);
+                return resultTask.Check(valueTask);
             else
                 return resultTask;
         }
 
-        public static ValueTask<Result<T>> CheckIf<T, K>(this ValueTask<Result<T>> resultTask, bool condition, Func<T, Result<K>> func)
+        public static ValueTask<Result<T>> CheckIf<T, K>(this ValueTask<Result<T>> resultTask, bool condition, Func<T, Result<K>> valueTask)
         {
             if (condition)
-                return resultTask.Check(func);
+                return resultTask.Check(valueTask);
             else
                 return resultTask;
         }
 
-        public static ValueTask<Result<T, E>> CheckIf<T, K, E>(this ValueTask<Result<T, E>> resultTask, bool condition, Func<T, Result<K, E>> func)
+        public static ValueTask<Result<T, E>> CheckIf<T, K, E>(this ValueTask<Result<T, E>> resultTask, bool condition, Func<T, Result<K, E>> valueTask)
         {
             if (condition)
-                return resultTask.Check(func);
+                return resultTask.Check(valueTask);
             else
                 return resultTask;
         }
 
-        public static ValueTask<Result<T, E>> CheckIf<T, E>(this ValueTask<Result<T, E>> resultTask, bool condition, Func<T, UnitResult<E>> func)
+        public static ValueTask<Result<T, E>> CheckIf<T, E>(this ValueTask<Result<T, E>> resultTask, bool condition, Func<T, UnitResult<E>> valueTask)
         {
             if (condition)
-                return resultTask.Check(func);
+                return resultTask.Check(valueTask);
             else
                 return resultTask;
         }
 
-        public static ValueTask<UnitResult<E>> CheckIf<E>(this ValueTask<UnitResult<E>> resultTask, bool condition, Func<UnitResult<E>> func)
+        public static ValueTask<UnitResult<E>> CheckIf<E>(this ValueTask<UnitResult<E>> resultTask, bool condition, Func<UnitResult<E>> valueTask)
         {
             if (condition)
-                return resultTask.Check(func);
+                return resultTask.Check(valueTask);
             else
                 return resultTask;
         }
 
-        public static async ValueTask<Result<T>> CheckIf<T>(this ValueTask<Result<T>> resultTask, Func<T, bool> predicate, Func<T, Result> func)
+        public static async ValueTask<Result<T>> CheckIf<T>(this ValueTask<Result<T>> resultTask, Func<T, bool> predicate, Func<T, Result> valueTask)
         {
             Result<T> result = await resultTask;
 
             if (result.IsSuccess && predicate(result.Value))
-                return result.Check(func);
+                return result.Check(valueTask);
             else
                 return result;
         }
 
-        public static async ValueTask<Result<T>> CheckIf<T, K>(this ValueTask<Result<T>> resultTask, Func<T, bool> predicate, Func<T, Result<K>> func)
+        public static async ValueTask<Result<T>> CheckIf<T, K>(this ValueTask<Result<T>> resultTask, Func<T, bool> predicate, Func<T, Result<K>> valueTask)
         {
             Result<T> result = await resultTask;
 
             if (result.IsSuccess && predicate(result.Value))
-                return result.Check(func);
+                return result.Check(valueTask);
             else
                 return result;
         }
 
-        public static async ValueTask<Result<T, E>> CheckIf<T, K, E>(this ValueTask<Result<T, E>> resultTask, Func<T, bool> predicate, Func<T, Result<K, E>> func)
+        public static async ValueTask<Result<T, E>> CheckIf<T, K, E>(this ValueTask<Result<T, E>> resultTask, Func<T, bool> predicate, Func<T, Result<K, E>> valueTask)
         {
             Result<T, E> result = await resultTask;
 
             if (result.IsSuccess && predicate(result.Value))
-                return result.Check(func);
+                return result.Check(valueTask);
             else
                 return result;
         }
 
-        public static async ValueTask<Result<T, E>> CheckIf<T, E>(this ValueTask<Result<T, E>> resultTask, Func<T, bool> predicate, Func<T, UnitResult<E>> func)
+        public static async ValueTask<Result<T, E>> CheckIf<T, E>(this ValueTask<Result<T, E>> resultTask, Func<T, bool> predicate, Func<T, UnitResult<E>> valueTask)
         {
             Result<T, E> result = await resultTask;
 
             if (result.IsSuccess && predicate(result.Value))
-                return result.Check(func);
+                return result.Check(valueTask);
             else
                 return result;
         }
 
-        public static async ValueTask<UnitResult<E>> CheckIf<E>(this ValueTask<UnitResult<E>> resultTask, Func<bool> predicate, Func<UnitResult<E>> func)
+        public static async ValueTask<UnitResult<E>> CheckIf<E>(this ValueTask<UnitResult<E>> resultTask, Func<bool> predicate, Func<UnitResult<E>> valueTask)
         {
             UnitResult<E> result = await resultTask;
 
             if (result.IsSuccess && predicate())
-                return result.Check(func);
+                return result.Check(valueTask);
             else
                 return result;
         }

--- a/CSharpFunctionalExtensions/Result/Methods/Extensions/CheckIf.ValueTask.Right.cs
+++ b/CSharpFunctionalExtensions/Result/Methods/Extensions/CheckIf.ValueTask.Right.cs
@@ -2,86 +2,86 @@
 using System;
 using System.Threading.Tasks;
 
-namespace CSharpFunctionalExtensions
+namespace CSharpFunctionalExtensions.ValueTasks
 {
     public static partial class AsyncResultExtensionsRightOperand
     {
-        public static ValueTask<Result<T>> CheckIf<T>(this Result<T> result, bool condition, Func<T, ValueTask<Result>> func)
+        public static ValueTask<Result<T>> CheckIf<T>(this Result<T> result, bool condition, Func<T, ValueTask<Result>> valueTask)
         {
             if (condition)
-                return result.Check(func);
+                return result.Check(valueTask);
             else
                 return result.AsCompletedValueTask();
         }
 
-        public static ValueTask<Result<T>> CheckIf<T, K>(this Result<T> result, bool condition, Func<T, ValueTask<Result<K>>> func)
+        public static ValueTask<Result<T>> CheckIf<T, K>(this Result<T> result, bool condition, Func<T, ValueTask<Result<K>>> valueTask)
         {
             if (condition)
-                return result.Check(func);
+                return result.Check(valueTask);
             else
                 return result.AsCompletedValueTask();
         }
 
-        public static ValueTask<Result<T, E>> CheckIf<T, K, E>(this Result<T, E> result, bool condition, Func<T, ValueTask<Result<K, E>>> func)
+        public static ValueTask<Result<T, E>> CheckIf<T, K, E>(this Result<T, E> result, bool condition, Func<T, ValueTask<Result<K, E>>> valueTask)
         {
             if (condition)
-                return result.Check(func);
+                return result.Check(valueTask);
             else
                 return result.AsCompletedValueTask();
         }
 
-        public static ValueTask<Result<T, E>> CheckIf<T, E>(this Result<T, E> result, bool condition, Func<T, ValueTask<UnitResult<E>>> func)
+        public static ValueTask<Result<T, E>> CheckIf<T, E>(this Result<T, E> result, bool condition, Func<T, ValueTask<UnitResult<E>>> valueTask)
         {
             if (condition)
-                return result.Check(func);
+                return result.Check(valueTask);
             else
                 return result.AsCompletedValueTask();
         }
 
-        public static ValueTask<UnitResult<E>> CheckIf<E>(this UnitResult<E> result, bool condition, Func<ValueTask<UnitResult<E>>> func)
+        public static ValueTask<UnitResult<E>> CheckIf<E>(this UnitResult<E> result, bool condition, Func<ValueTask<UnitResult<E>>> valueTask)
         {
             if (condition)
-                return result.Check(func);
+                return result.Check(valueTask);
             else
                 return result.AsCompletedValueTask();
         }
 
-        public static ValueTask<Result<T>> CheckIf<T>(this Result<T> result, Func<T, bool> predicate, Func<T, ValueTask<Result>> func)
+        public static ValueTask<Result<T>> CheckIf<T>(this Result<T> result, Func<T, bool> predicate, Func<T, ValueTask<Result>> valueTask)
         {
             if (result.IsSuccess && predicate(result.Value))
-                return result.Check(func);
+                return result.Check(valueTask);
             else
                 return result.AsCompletedValueTask();
         }
 
-        public static ValueTask<Result<T>> CheckIf<T, K>(this Result<T> result, Func<T, bool> predicate, Func<T, ValueTask<Result<K>>> func)
+        public static ValueTask<Result<T>> CheckIf<T, K>(this Result<T> result, Func<T, bool> predicate, Func<T, ValueTask<Result<K>>> valueTask)
         {
             if (result.IsSuccess && predicate(result.Value))
-                return result.Check(func);
+                return result.Check(valueTask);
             else
                 return result.AsCompletedValueTask();
         }
 
-        public static ValueTask<Result<T, E>> CheckIf<T, K, E>(this Result<T, E> result, Func<T, bool> predicate, Func<T, ValueTask<Result<K, E>>> func)
+        public static ValueTask<Result<T, E>> CheckIf<T, K, E>(this Result<T, E> result, Func<T, bool> predicate, Func<T, ValueTask<Result<K, E>>> valueTask)
         {
             if (result.IsSuccess && predicate(result.Value))
-                return result.Check(func);
+                return result.Check(valueTask);
             else
                 return result.AsCompletedValueTask();
         }
 
-        public static ValueTask<Result<T, E>> CheckIf<T, E>(this Result<T, E> result, Func<T, bool> predicate, Func<T, ValueTask<UnitResult<E>>> func)
+        public static ValueTask<Result<T, E>> CheckIf<T, E>(this Result<T, E> result, Func<T, bool> predicate, Func<T, ValueTask<UnitResult<E>>> valueTask)
         {
             if (result.IsSuccess && predicate(result.Value))
-                return result.Check(func);
+                return result.Check(valueTask);
             else
                 return result.AsCompletedValueTask();
         }
 
-        public static async ValueTask<UnitResult<E>> CheckIf<E>(this UnitResult<E> result, Func<bool> predicate, Func<ValueTask<UnitResult<E>>> func)
+        public static async ValueTask<UnitResult<E>> CheckIf<E>(this UnitResult<E> result, Func<bool> predicate, Func<ValueTask<UnitResult<E>>> valueTask)
         {
             if (result.IsSuccess && predicate())
-                return await result.Check(func);
+                return await result.Check(valueTask);
             else
                 return result;
         }

--- a/CSharpFunctionalExtensions/Result/Methods/Extensions/CheckIf.ValueTask.cs
+++ b/CSharpFunctionalExtensions/Result/Methods/Extensions/CheckIf.ValueTask.cs
@@ -2,106 +2,106 @@
 using System;
 using System.Threading.Tasks;
 
-namespace CSharpFunctionalExtensions
+namespace CSharpFunctionalExtensions.ValueTasks
 {
     public static partial class AsyncResultExtensionsBothOperands
     {
         public static ValueTask<Result<T>> CheckIf<T>(this ValueTask<Result<T>> resultTask, bool condition,
-            Func<T, ValueTask<Result>> func)
+            Func<T, ValueTask<Result>> valueTask)
         {
             if (condition)
-                return resultTask.Check(func);
+                return resultTask.Check(valueTask);
             else
                 return resultTask;
         }
 
         public static ValueTask<Result<T>> CheckIf<T, K>(this ValueTask<Result<T>> resultTask, bool condition,
-            Func<T, ValueTask<Result<K>>> func)
+            Func<T, ValueTask<Result<K>>> valueTask)
         {
             if (condition)
-                return resultTask.Check(func);
+                return resultTask.Check(valueTask);
             else
                 return resultTask;
         }
 
         public static ValueTask<Result<T, E>> CheckIf<T, K, E>(this ValueTask<Result<T, E>> resultTask, bool condition,
-            Func<T, ValueTask<Result<K, E>>> func)
+            Func<T, ValueTask<Result<K, E>>> valueTask)
         {
             if (condition)
-                return resultTask.Check(func);
+                return resultTask.Check(valueTask);
             else
                 return resultTask;
         }
 
         public static ValueTask<Result<T, E>> CheckIf<T, E>(this ValueTask<Result<T, E>> resultTask, bool condition,
-            Func<T, ValueTask<UnitResult<E>>> func)
+            Func<T, ValueTask<UnitResult<E>>> valueTask)
         {
             if (condition)
-                return resultTask.Check(func);
+                return resultTask.Check(valueTask);
             else
                 return resultTask;
         }
 
         public static ValueTask<UnitResult<E>> CheckIf<E>(this ValueTask<UnitResult<E>> resultTask, bool condition,
-            Func<ValueTask<UnitResult<E>>> func)
+            Func<ValueTask<UnitResult<E>>> valueTask)
         {
             if (condition)
-                return resultTask.Check(func);
+                return resultTask.Check(valueTask);
             else
                 return resultTask;
         }
 
         public static async ValueTask<Result<T>> CheckIf<T>(this ValueTask<Result<T>> resultTask,
-            Func<T, bool> predicate, Func<T, ValueTask<Result>> func)
+            Func<T, bool> predicate, Func<T, ValueTask<Result>> valueTask)
         {
             Result<T> result = await resultTask;
 
             if (result.IsSuccess && predicate(result.Value))
-                return await result.Check(func);
+                return await result.Check(valueTask);
             else
                 return result;
         }
 
         public static async ValueTask<Result<T>> CheckIf<T, K>(this ValueTask<Result<T>> resultTask,
-            Func<T, bool> predicate, Func<T, ValueTask<Result<K>>> func)
+            Func<T, bool> predicate, Func<T, ValueTask<Result<K>>> valueTask)
         {
             Result<T> result = await resultTask;
 
             if (result.IsSuccess && predicate(result.Value))
-                return await result.Check(func);
+                return await result.Check(valueTask);
             else
                 return result;
         }
 
         public static async ValueTask<Result<T, E>> CheckIf<T, K, E>(this ValueTask<Result<T, E>> resultTask,
-            Func<T, bool> predicate, Func<T, ValueTask<Result<K, E>>> func)
+            Func<T, bool> predicate, Func<T, ValueTask<Result<K, E>>> valueTask)
         {
             Result<T, E> result = await resultTask;
 
             if (result.IsSuccess && predicate(result.Value))
-                return await result.Check(func);
+                return await result.Check(valueTask);
             else
                 return result;
         }
 
         public static async ValueTask<Result<T, E>> CheckIf<T, E>(this ValueTask<Result<T, E>> resultTask,
-            Func<T, bool> predicate, Func<T, ValueTask<UnitResult<E>>> func)
+            Func<T, bool> predicate, Func<T, ValueTask<UnitResult<E>>> valueTask)
         {
             Result<T, E> result = await resultTask;
 
             if (result.IsSuccess && predicate(result.Value))
-                return await result.Check(func);
+                return await result.Check(valueTask);
             else
                 return result;
         }
 
         public static async ValueTask<UnitResult<E>> CheckIf<E>(this ValueTask<UnitResult<E>> resultTask,
-            Func<bool> predicate, Func<ValueTask<UnitResult<E>>> func)
+            Func<bool> predicate, Func<ValueTask<UnitResult<E>>> valueTask)
         {
             UnitResult<E> result = await resultTask;
 
             if (result.IsSuccess && predicate())
-                return await result.Check(func);
+                return await result.Check(valueTask);
             else
                 return result;
         }

--- a/CSharpFunctionalExtensions/Result/Methods/Extensions/Combine.ValueTask.cs
+++ b/CSharpFunctionalExtensions/Result/Methods/Extensions/Combine.ValueTask.cs
@@ -4,7 +4,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 
-namespace CSharpFunctionalExtensions
+namespace CSharpFunctionalExtensions.ValueTasks
 {
     public static partial class AsyncResultExtensionsLeftOperand
     {

--- a/CSharpFunctionalExtensions/Result/Methods/Extensions/CombineInOrder.ValueTask.cs
+++ b/CSharpFunctionalExtensions/Result/Methods/Extensions/CombineInOrder.ValueTask.cs
@@ -3,7 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 
-namespace CSharpFunctionalExtensions
+namespace CSharpFunctionalExtensions.ValueTasks
 {
     public static partial class AsyncResultExtensionsLeftOperand
     {

--- a/CSharpFunctionalExtensions/Result/Methods/Extensions/Compensate.ValueTask.Left.cs
+++ b/CSharpFunctionalExtensions/Result/Methods/Extensions/Compensate.ValueTask.Left.cs
@@ -2,68 +2,68 @@
 using System;
 using System.Threading.Tasks;
 
-namespace CSharpFunctionalExtensions
+namespace CSharpFunctionalExtensions.ValueTasks
 {
     public static partial class ResultExtensions
     {
-        public static async ValueTask<Result> Compensate(this ValueTask<Result> resultTask, Func<string, Result> func)
+        public static async ValueTask<Result> Compensate(this ValueTask<Result> resultTask, Func<string, Result> valueTask)
         {
             var result = await resultTask;
-            return result.Compensate(func);
+            return result.Compensate(valueTask);
         }
 
-        public static async ValueTask<UnitResult<E>> Compensate<E>(this ValueTask<Result> resultTask, Func<string, UnitResult<E>> func)
+        public static async ValueTask<UnitResult<E>> Compensate<E>(this ValueTask<Result> resultTask, Func<string, UnitResult<E>> valueTask)
         {
             var result = await resultTask;
-            return result.Compensate(func);
+            return result.Compensate(valueTask);
         }
 
-        public static async ValueTask<Result> Compensate<T>(this ValueTask<Result<T>> resultTask, Func<string, Result> func)
+        public static async ValueTask<Result> Compensate<T>(this ValueTask<Result<T>> resultTask, Func<string, Result> valueTask)
         {
             var result = await resultTask;
-            return result.Compensate(func);
+            return result.Compensate(valueTask);
         }
 
-        public static async ValueTask<Result<T>> Compensate<T>(this ValueTask<Result<T>> resultTask, Func<string, Result<T>> func)
+        public static async ValueTask<Result<T>> Compensate<T>(this ValueTask<Result<T>> resultTask, Func<string, Result<T>> valueTask)
         {
             var result = await resultTask;
-            return result.Compensate(func);
+            return result.Compensate(valueTask);
         }
 
-        public static async ValueTask<Result<T, E>> Compensate<T, E>(this ValueTask<Result<T>> resultTask, Func<string, Result<T, E>> func)
+        public static async ValueTask<Result<T, E>> Compensate<T, E>(this ValueTask<Result<T>> resultTask, Func<string, Result<T, E>> valueTask)
         {
             var result = await resultTask;
-            return result.Compensate(func);
+            return result.Compensate(valueTask);
         }
 
-        public static async ValueTask<Result> Compensate<E>(this ValueTask<UnitResult<E>> resultTask, Func<E, Result> func)
+        public static async ValueTask<Result> Compensate<E>(this ValueTask<UnitResult<E>> resultTask, Func<E, Result> valueTask)
         {
             var result = await resultTask;
-            return result.Compensate(func);
+            return result.Compensate(valueTask);
         }
 
-        public static async ValueTask<UnitResult<E2>> Compensate<E, E2>(this ValueTask<UnitResult<E>> resultTask, Func<E, UnitResult<E2>> func)
+        public static async ValueTask<UnitResult<E2>> Compensate<E, E2>(this ValueTask<UnitResult<E>> resultTask, Func<E, UnitResult<E2>> valueTask)
         {
             var result = await resultTask;
-            return result.Compensate(func);
+            return result.Compensate(valueTask);
         }
 
-        public static async ValueTask<Result> Compensate<T, E>(this ValueTask<Result<T, E>> resultTask, Func<E, Result> func)
+        public static async ValueTask<Result> Compensate<T, E>(this ValueTask<Result<T, E>> resultTask, Func<E, Result> valueTask)
         {
             var result = await resultTask;
-            return result.Compensate(func);
+            return result.Compensate(valueTask);
         }
 
-        public static async ValueTask<UnitResult<E2>> Compensate<T, E, E2>(this ValueTask<Result<T, E>> resultTask, Func<E, UnitResult<E2>> func)
+        public static async ValueTask<UnitResult<E2>> Compensate<T, E, E2>(this ValueTask<Result<T, E>> resultTask, Func<E, UnitResult<E2>> valueTask)
         {
             var result = await resultTask;
-            return result.Compensate(func);
+            return result.Compensate(valueTask);
         }
 
-        public static async ValueTask<Result<T, E2>> Compensate<T, E, E2>(this ValueTask<Result<T, E>> resultTask, Func<E, Result<T, E2>> func)
+        public static async ValueTask<Result<T, E2>> Compensate<T, E, E2>(this ValueTask<Result<T, E>> resultTask, Func<E, Result<T, E2>> valueTask)
         {
             var result = await resultTask;
-            return result.Compensate(func);
+            return result.Compensate(valueTask);
         }
     }
 }

--- a/CSharpFunctionalExtensions/Result/Methods/Extensions/Compensate.ValueTask.Right.cs
+++ b/CSharpFunctionalExtensions/Result/Methods/Extensions/Compensate.ValueTask.Right.cs
@@ -2,108 +2,108 @@
 using System;
 using System.Threading.Tasks;
 
-namespace CSharpFunctionalExtensions
+namespace CSharpFunctionalExtensions.ValueTasks
 {
     public static partial class ResultExtensions
     {
-        public static ValueTask<Result> Compensate(this Result result, Func<string, ValueTask<Result>> func)
+        public static ValueTask<Result> Compensate(this Result result, Func<string, ValueTask<Result>> valueTask)
         {
             if (result.IsSuccess)
             {
                 return Result.Success().AsCompletedValueTask();
             }
 
-            return func(result.Error);
+            return valueTask(result.Error);
         }
 
-        public static ValueTask<UnitResult<E>> Compensate<E>(this Result result, Func<string, ValueTask<UnitResult<E>>> func)
+        public static ValueTask<UnitResult<E>> Compensate<E>(this Result result, Func<string, ValueTask<UnitResult<E>>> valueTask)
         {
             if (result.IsSuccess)
             {
                 return UnitResult.Success<E>().AsCompletedValueTask();
             }
 
-            return func(result.Error);
+            return valueTask(result.Error);
         }
 
-        public static ValueTask<Result> Compensate<T>(this Result<T> result, Func<string, ValueTask<Result>> func)
+        public static ValueTask<Result> Compensate<T>(this Result<T> result, Func<string, ValueTask<Result>> valueTask)
         {
             if (result.IsSuccess)
             {
                 return Result.Success().AsCompletedValueTask();
             }
 
-            return func(result.Error);
+            return valueTask(result.Error);
         }
 
-        public static ValueTask<Result<T>> Compensate<T>(this Result<T> result, Func<string, ValueTask<Result<T>>> func)
+        public static ValueTask<Result<T>> Compensate<T>(this Result<T> result, Func<string, ValueTask<Result<T>>> valueTask)
         {
             if (result.IsSuccess)
             {
                 return Result.Success(result.Value).AsCompletedValueTask();
             }
 
-            return func(result.Error);
+            return valueTask(result.Error);
         }
 
-        public static ValueTask<Result<T, E>> Compensate<T, E>(this Result<T> result, Func<string, ValueTask<Result<T, E>>> func)
+        public static ValueTask<Result<T, E>> Compensate<T, E>(this Result<T> result, Func<string, ValueTask<Result<T, E>>> valueTask)
         {
             if (result.IsSuccess)
             {
                 return Result.Success<T, E>(result.Value).AsCompletedValueTask();
             }
 
-            return func(result.Error);
+            return valueTask(result.Error);
         }
 
-        public static ValueTask<Result> Compensate<E>(this UnitResult<E> result, Func<E, ValueTask<Result>> func)
+        public static ValueTask<Result> Compensate<E>(this UnitResult<E> result, Func<E, ValueTask<Result>> valueTask)
         {
             if (result.IsSuccess)
             {
                 return Result.Success().AsCompletedValueTask();
             }
 
-            return func(result.Error);
+            return valueTask(result.Error);
         }
 
-        public static ValueTask<UnitResult<E2>> Compensate<E, E2>(this UnitResult<E> result, Func<E, ValueTask<UnitResult<E2>>> func)
+        public static ValueTask<UnitResult<E2>> Compensate<E, E2>(this UnitResult<E> result, Func<E, ValueTask<UnitResult<E2>>> valueTask)
         {
             if (result.IsSuccess)
             {
                 return UnitResult.Success<E2>().AsCompletedValueTask();
             }
 
-            return func(result.Error);
+            return valueTask(result.Error);
         }
 
-        public static ValueTask<Result> Compensate<T, E>(this Result<T, E> result, Func<E, ValueTask<Result>> func)
+        public static ValueTask<Result> Compensate<T, E>(this Result<T, E> result, Func<E, ValueTask<Result>> valueTask)
         {
             if (result.IsSuccess)
             {
                 return Result.Success().AsCompletedValueTask();
             }
 
-            return func(result.Error);
+            return valueTask(result.Error);
         }
 
-        public static ValueTask<UnitResult<E2>> Compensate<T, E, E2>(this Result<T, E> result, Func<E, ValueTask<UnitResult<E2>>> func)
+        public static ValueTask<UnitResult<E2>> Compensate<T, E, E2>(this Result<T, E> result, Func<E, ValueTask<UnitResult<E2>>> valueTask)
         {
             if (result.IsSuccess)
             {
                 return UnitResult.Success<E2>().AsCompletedValueTask();
             }
 
-            return func(result.Error);
+            return valueTask(result.Error);
         }
 
-        public static ValueTask<Result<T, E2>> Compensate<T, E, E2>(this Result<T, E> result, Func<E, ValueTask<Result<T, E2>>> func)
+        public static ValueTask<Result<T, E2>> Compensate<T, E, E2>(this Result<T, E> result, Func<E, ValueTask<Result<T, E2>>> valueTask)
         {
             if (result.IsSuccess)
             {
                 return Result.Success<T, E2>(result.Value).AsCompletedValueTask();
             }
 
-            return func(result.Error);
+            return valueTask(result.Error);
         }
     }
 }

--- a/CSharpFunctionalExtensions/Result/Methods/Extensions/Compensate.ValueTask.cs
+++ b/CSharpFunctionalExtensions/Result/Methods/Extensions/Compensate.ValueTask.cs
@@ -2,68 +2,68 @@
 using System;
 using System.Threading.Tasks;
 
-namespace CSharpFunctionalExtensions
+namespace CSharpFunctionalExtensions.ValueTasks
 {
     public static partial class ResultExtensions
     {
-        public static async ValueTask<Result> Compensate(this ValueTask<Result> resultTask, Func<string, ValueTask<Result>> func)
+        public static async ValueTask<Result> Compensate(this ValueTask<Result> resultTask, Func<string, ValueTask<Result>> valueTask)
         {
             var result = await resultTask;
-            return await result.Compensate(func);
+            return await result.Compensate(valueTask);
         }
 
-        public static async ValueTask<UnitResult<E>> Compensate<E>(this ValueTask<Result> resultTask, Func<string, ValueTask<UnitResult<E>>> func)
+        public static async ValueTask<UnitResult<E>> Compensate<E>(this ValueTask<Result> resultTask, Func<string, ValueTask<UnitResult<E>>> valueTask)
         {
             var result = await resultTask;
-            return await result.Compensate(func);
+            return await result.Compensate(valueTask);
         }
 
-        public static async ValueTask<Result> Compensate<T>(this ValueTask<Result<T>> resultTask, Func<string, ValueTask<Result>> func)
+        public static async ValueTask<Result> Compensate<T>(this ValueTask<Result<T>> resultTask, Func<string, ValueTask<Result>> valueTask)
         {
             var result = await resultTask;
-            return await result.Compensate(func);
+            return await result.Compensate(valueTask);
         }
 
-        public static async ValueTask<Result<T>> Compensate<T>(this ValueTask<Result<T>> resultTask, Func<string, ValueTask<Result<T>>> func)
+        public static async ValueTask<Result<T>> Compensate<T>(this ValueTask<Result<T>> resultTask, Func<string, ValueTask<Result<T>>> valueTask)
         {
             var result = await resultTask;
-            return await result.Compensate(func);
+            return await result.Compensate(valueTask);
         }
 
-        public static async ValueTask<Result<T, E>> Compensate<T, E>(this ValueTask<Result<T>> resultTask, Func<string, ValueTask<Result<T, E>>> func)
+        public static async ValueTask<Result<T, E>> Compensate<T, E>(this ValueTask<Result<T>> resultTask, Func<string, ValueTask<Result<T, E>>> valueTask)
         {
             var result = await resultTask;
-            return await result.Compensate(func);
+            return await result.Compensate(valueTask);
         }
 
-        public static async ValueTask<Result> Compensate<E>(this ValueTask<UnitResult<E>> resultTask, Func<E, ValueTask<Result>> func)
+        public static async ValueTask<Result> Compensate<E>(this ValueTask<UnitResult<E>> resultTask, Func<E, ValueTask<Result>> valueTask)
         {
             var result = await resultTask;
-            return await result.Compensate(func);
+            return await result.Compensate(valueTask);
         }
 
-        public static async ValueTask<UnitResult<E2>> Compensate<E, E2>(this ValueTask<UnitResult<E>> resultTask, Func<E, ValueTask<UnitResult<E2>>> func)
+        public static async ValueTask<UnitResult<E2>> Compensate<E, E2>(this ValueTask<UnitResult<E>> resultTask, Func<E, ValueTask<UnitResult<E2>>> valueTask)
         {
             var result = await resultTask;
-            return await result.Compensate(func);
+            return await result.Compensate(valueTask);
         }
 
-        public static async ValueTask<Result> Compensate<T, E>(this ValueTask<Result<T, E>> resultTask, Func<E, ValueTask<Result>> func)
+        public static async ValueTask<Result> Compensate<T, E>(this ValueTask<Result<T, E>> resultTask, Func<E, ValueTask<Result>> valueTask)
         {
             var result = await resultTask;
-            return await result.Compensate(func);
+            return await result.Compensate(valueTask);
         }
 
-        public static async ValueTask<UnitResult<E2>> Compensate<T, E, E2>(this ValueTask<Result<T, E>> resultTask, Func<E, ValueTask<UnitResult<E2>>> func)
+        public static async ValueTask<UnitResult<E2>> Compensate<T, E, E2>(this ValueTask<Result<T, E>> resultTask, Func<E, ValueTask<UnitResult<E2>>> valueTask)
         {
             var result = await resultTask;
-            return await result.Compensate(func);
+            return await result.Compensate(valueTask);
         }
 
-        public static async ValueTask<Result<T, E2>> Compensate<T, E, E2>(this ValueTask<Result<T, E>> resultTask, Func<E, ValueTask<Result<T, E2>>> func)
+        public static async ValueTask<Result<T, E2>> Compensate<T, E, E2>(this ValueTask<Result<T, E>> resultTask, Func<E, ValueTask<Result<T, E2>>> valueTask)
         {
             var result = await resultTask;
-            return await result.Compensate(func);
+            return await result.Compensate(valueTask);
         }
     }
 }

--- a/CSharpFunctionalExtensions/Result/Methods/Extensions/Ensure.ValueTask.Left.cs
+++ b/CSharpFunctionalExtensions/Result/Methods/Extensions/Ensure.ValueTask.Left.cs
@@ -2,7 +2,7 @@
 using System;
 using System.Threading.Tasks;
 
-namespace CSharpFunctionalExtensions
+namespace CSharpFunctionalExtensions.ValueTasks
 {
     public static partial class AsyncResultExtensionsLeftOperand
     {

--- a/CSharpFunctionalExtensions/Result/Methods/Extensions/Ensure.ValueTask.Right.cs
+++ b/CSharpFunctionalExtensions/Result/Methods/Extensions/Ensure.ValueTask.Right.cs
@@ -2,7 +2,7 @@
 using System;
 using System.Threading.Tasks;
 
-namespace CSharpFunctionalExtensions
+namespace CSharpFunctionalExtensions.ValueTasks
 {
     public static partial class AsyncResultExtensionsRightOperand
     {

--- a/CSharpFunctionalExtensions/Result/Methods/Extensions/Ensure.ValueTask.cs
+++ b/CSharpFunctionalExtensions/Result/Methods/Extensions/Ensure.ValueTask.cs
@@ -2,21 +2,21 @@
 using System;
 using System.Threading.Tasks;
 
-namespace CSharpFunctionalExtensions
+namespace CSharpFunctionalExtensions.ValueTasks
 {
     public static partial class AsyncResultExtensionsBothOperands
     {
         /// <summary>
         ///     Returns a new failure result if the predicate is false. Otherwise returns the starting result.
         /// </summary>
-        public static async ValueTask<Result<T>> Ensure<T>(this ValueTask<Result<T>> resultTask, Func<T, ValueTask<bool>> predicate, string errorMessage)
+        public static async ValueTask<Result<T>> Ensure<T>(this ValueTask<Result<T>> resultTask, Func<T, ValueTask<bool>> valueTaskPredicate, string errorMessage)
         {
             Result<T> result = await resultTask;
 
             if (result.IsFailure)
                 return result;
 
-            if (!await predicate(result.Value))
+            if (!await valueTaskPredicate(result.Value))
                 return Result.Failure<T>(errorMessage);
 
             return result;
@@ -25,14 +25,14 @@ namespace CSharpFunctionalExtensions
         /// <summary>
         ///     Returns a new failure result if the predicate is false. Otherwise returns the starting result.
         /// </summary>
-        public static async ValueTask<Result<T, E>> Ensure<T, E>(this ValueTask<Result<T, E>> resultTask, Func<T, ValueTask<bool>> predicate, E error)
+        public static async ValueTask<Result<T, E>> Ensure<T, E>(this ValueTask<Result<T, E>> resultTask, Func<T, ValueTask<bool>> valueTaskPredicate, E error)
         {
             Result<T, E> result = await resultTask;
 
             if (result.IsFailure)
                 return result;
 
-            if (!await predicate(result.Value))
+            if (!await valueTaskPredicate(result.Value))
                 return Result.Failure<T, E>(error);
 
             return result;
@@ -41,15 +41,15 @@ namespace CSharpFunctionalExtensions
         /// <summary>
         ///     Returns a new failure result if the predicate is false. Otherwise returns the starting result.
         /// </summary>
-        public static async ValueTask<Result<T, E>> Ensure<T, E>(this ValueTask<Result<T, E>> resultTask, Func<T, ValueTask<bool>> predicate, Func<T, E> errorPredicate)
+        public static async ValueTask<Result<T, E>> Ensure<T, E>(this ValueTask<Result<T, E>> resultTask, Func<T, ValueTask<bool>> valueTaskPredicate, Func<T, E> valueTaskErrorPredicate)
         {
             Result<T, E> result = await resultTask;
 
             if (result.IsFailure)
                 return result;
 
-            if (!await predicate(result.Value))
-                return Result.Failure<T, E>(errorPredicate(result.Value));
+            if (!await valueTaskPredicate(result.Value))
+                return Result.Failure<T, E>(valueTaskErrorPredicate(result.Value));
 
             return result;
         }
@@ -57,15 +57,15 @@ namespace CSharpFunctionalExtensions
         /// <summary>
         ///     Returns a new failure result if the predicate is false. Otherwise returns the starting result.
         /// </summary>
-        public static async ValueTask<Result<T, E>> Ensure<T, E>(this ValueTask<Result<T, E>> resultTask, Func<T, ValueTask<bool>> predicate, Func<T, ValueTask<E>> errorPredicate)
+        public static async ValueTask<Result<T, E>> Ensure<T, E>(this ValueTask<Result<T, E>> resultTask, Func<T, ValueTask<bool>> valueTaskPredicate, Func<T, ValueTask<E>> valueTaskErrorPredicate)
         {
             Result<T, E> result = await resultTask;
 
             if (result.IsFailure)
                 return result;
 
-            if (!await predicate(result.Value))
-                return Result.Failure<T, E>(await errorPredicate(result.Value));
+            if (!await valueTaskPredicate(result.Value))
+                return Result.Failure<T, E>(await valueTaskErrorPredicate(result.Value));
 
             return result;
         }
@@ -73,15 +73,15 @@ namespace CSharpFunctionalExtensions
         /// <summary>
         ///     Returns a new failure result if the predicate is false. Otherwise returns the starting result.
         /// </summary>
-        public static async ValueTask<Result<T>> Ensure<T>(this ValueTask<Result<T>> resultTask, Func<T, ValueTask<bool>> predicate, Func<T, string> errorPredicate)
+        public static async ValueTask<Result<T>> Ensure<T>(this ValueTask<Result<T>> resultTask, Func<T, ValueTask<bool>> predicateValueTask, Func<T, string> valueTaskErrorPredicate)
         {
             Result<T> result = await resultTask;
 
             if (result.IsFailure)
                 return result;
 
-            if (!await predicate(result.Value))
-                return Result.Failure<T>(errorPredicate(result.Value));
+            if (!await predicateValueTask(result.Value))
+                return Result.Failure<T>(valueTaskErrorPredicate(result.Value));
 
             return result;
         }
@@ -89,15 +89,15 @@ namespace CSharpFunctionalExtensions
         /// <summary>
         ///     Returns a new failure result if the predicate is false. Otherwise returns the starting result.
         /// </summary>
-        public static async ValueTask<Result<T>> Ensure<T>(this ValueTask<Result<T>> resultTask, Func<T, ValueTask<bool>> predicate, Func<T, ValueTask<string>> errorPredicate)
+        public static async ValueTask<Result<T>> Ensure<T>(this ValueTask<Result<T>> resultTask, Func<T, ValueTask<bool>> valueTaskPredicate, Func<T, ValueTask<string>> valueTaskErrorPredicate)
         {
             Result<T> result = await resultTask;
 
             if (result.IsFailure)
                 return result;
 
-            if (!await predicate(result.Value))
-                return Result.Failure<T>(await errorPredicate(result.Value));
+            if (!await valueTaskPredicate(result.Value))
+                return Result.Failure<T>(await valueTaskErrorPredicate(result.Value));
 
             return result;
         }
@@ -105,14 +105,14 @@ namespace CSharpFunctionalExtensions
         /// <summary>
         ///     Returns a new failure result if the predicate is false. Otherwise returns the starting result.
         /// </summary>
-        public static async ValueTask<Result> Ensure(this ValueTask<Result> resultTask, Func<ValueTask<bool>> predicate, string errorMessage)
+        public static async ValueTask<Result> Ensure(this ValueTask<Result> resultTask, Func<ValueTask<bool>> valueTaskPredicate, string errorMessage)
         {
             Result result = await resultTask;
 
             if (result.IsFailure)
                 return result;
 
-            if (!await predicate())
+            if (!await valueTaskPredicate())
                 return Result.Failure(errorMessage);
 
             return result;
@@ -121,14 +121,14 @@ namespace CSharpFunctionalExtensions
         /// <summary>
         ///     Returns a new failure result if the predicate is a failure result. Otherwise returns the starting result.
         /// </summary>
-        public static async ValueTask<Result> Ensure(this ValueTask<Result> resultTask, Func<ValueTask<Result>> predicate)
+        public static async ValueTask<Result> Ensure(this ValueTask<Result> resultTask, Func<ValueTask<Result>> valueTaskPredicate)
         {
           Result result = await resultTask;
           
           if (result.IsFailure)
             return result;
 
-          var predicateResult = await predicate();
+          var predicateResult = await valueTaskPredicate();
           
           if (predicateResult.IsFailure)
             return Result.Failure(predicateResult.Error);
@@ -139,14 +139,14 @@ namespace CSharpFunctionalExtensions
         /// <summary>
         ///     Returns a new failure result if the predicate is a failure result. Otherwise returns the starting result.
         /// </summary>
-        public static async ValueTask<Result<T>> Ensure<T>(this ValueTask<Result<T>> resultTask, Func<ValueTask<Result>> predicate)
+        public static async ValueTask<Result<T>> Ensure<T>(this ValueTask<Result<T>> resultTask, Func<ValueTask<Result>> valueTaskPredicate)
         {
           Result<T> result = await resultTask;
           
           if (result.IsFailure)
             return result;
 
-          var predicateResult = await predicate();
+          var predicateResult = await valueTaskPredicate();
           
           if (predicateResult.IsFailure)
             return Result.Failure<T>(predicateResult.Error);
@@ -157,14 +157,14 @@ namespace CSharpFunctionalExtensions
         /// <summary>
         ///     Returns a new failure result if the predicate is a failure result. Otherwise returns the starting result.
         /// </summary>
-        public static async ValueTask<Result> Ensure<T>(this ValueTask<Result> resultTask, Func<ValueTask<Result<T>>> predicate)
+        public static async ValueTask<Result> Ensure<T>(this ValueTask<Result> resultTask, Func<ValueTask<Result<T>>> valueTaskPredicate)
         {
           Result result = await resultTask;
           
           if (result.IsFailure)
             return result;
 
-          var predicateResult = await predicate();
+          var predicateResult = await valueTaskPredicate();
           
           if (predicateResult.IsFailure)
             return Result.Failure<T>(predicateResult.Error);
@@ -175,14 +175,14 @@ namespace CSharpFunctionalExtensions
         /// <summary>
         ///     Returns a new failure result if the predicate is a failure result. Otherwise returns the starting result.
         /// </summary>
-        public static async ValueTask<Result<T>> Ensure<T>(this ValueTask<Result<T>> resultTask, Func<ValueTask<Result<T>>> predicate)
+        public static async ValueTask<Result<T>> Ensure<T>(this ValueTask<Result<T>> resultTask, Func<ValueTask<Result<T>>> valueTaskPredicate)
         {
           Result<T> result = await resultTask;
           
           if (result.IsFailure)
             return result;
         
-          var predicateResult = await predicate();
+          var predicateResult = await valueTaskPredicate();
           
           if (predicateResult.IsFailure)
             return Result.Failure<T>(predicateResult.Error);
@@ -193,14 +193,14 @@ namespace CSharpFunctionalExtensions
         /// <summary>
         ///     Returns a new failure result if the predicate is a failure result. Otherwise returns the starting result.
         /// </summary>
-        public static async ValueTask<Result<T>> Ensure<T>(this ValueTask<Result<T>> resultTask, Func<T,ValueTask<Result>> predicate)
+        public static async ValueTask<Result<T>> Ensure<T>(this ValueTask<Result<T>> resultTask, Func<T,ValueTask<Result>> valueTaskPredicate)
         {
           Result<T> result = await resultTask;
           
           if (result.IsFailure)
             return result;
 
-          var predicateResult = await predicate(result.Value);
+          var predicateResult = await valueTaskPredicate(result.Value);
           
           if (predicateResult.IsFailure)
             return Result.Failure<T>(predicateResult.Error);
@@ -211,14 +211,14 @@ namespace CSharpFunctionalExtensions
         /// <summary>
         ///     Returns a new failure result if the predicate is a failure result. Otherwise returns the starting result.
         /// </summary>
-        public static async ValueTask<Result<T>> Ensure<T>(this ValueTask<Result<T>> resultTask, Func<T,ValueTask<Result<T>>> predicate)
+        public static async ValueTask<Result<T>> Ensure<T>(this ValueTask<Result<T>> resultTask, Func<T,ValueTask<Result<T>>> valueTaskPredicate)
         {
           Result<T> result = await resultTask;
           
           if (result.IsFailure)
             return result;
 
-          var predicateResult = await predicate(result.Value);
+          var predicateResult = await valueTaskPredicate(result.Value);
           
           if (predicateResult.IsFailure)
             return Result.Failure<T>(predicateResult.Error);

--- a/CSharpFunctionalExtensions/Result/Methods/Extensions/Finally.ValueTask.Left.cs
+++ b/CSharpFunctionalExtensions/Result/Methods/Extensions/Finally.ValueTask.Left.cs
@@ -2,45 +2,45 @@
 using System;
 using System.Threading.Tasks;
 
-namespace CSharpFunctionalExtensions
+namespace CSharpFunctionalExtensions.ValueTasks
 {
     public static partial class AsyncResultExtensionsLeftOperand
     {
         /// <summary>
-        ///     Passes the result to the given function (regardless of success/failure state) to yield a final output value.
+        ///     Passes the result to the given valueTask action (regardless of success/failure state) to yield a final output value.
         /// </summary>
-        public static async ValueTask<T> Finally<T>(this ValueTask<Result> resultTask, Func<Result, T> func)
+        public static async ValueTask<T> Finally<T>(this ValueTask<Result> resultTask, Func<Result, T> valueTask)
         {
             Result result = await resultTask;
-            return result.Finally(func);
+            return result.Finally(valueTask);
         }
 
         /// <summary>
-        ///     Passes the result to the given function (regardless of success/failure state) to yield a final output value.
+        ///     Passes the result to the given valueTask action (regardless of success/failure state) to yield a final output value.
         /// </summary>
-        public static async ValueTask<K> Finally<T, K>(this ValueTask<Result<T>> resultTask, Func<Result<T>, K> func)
+        public static async ValueTask<K> Finally<T, K>(this ValueTask<Result<T>> resultTask, Func<Result<T>, K> valueTask)
         {
             Result<T> result = await resultTask;
-            return result.Finally(func);
+            return result.Finally(valueTask);
         }
 
         /// <summary>
-        ///     Passes the result to the given function (regardless of success/failure state) to yield a final output value.
+        ///     Passes the result to the given valueTask action (regardless of success/failure state) to yield a final output value.
         /// </summary>
-        public static async ValueTask<K> Finally<K, E>(this ValueTask<UnitResult<E>> resultTask, Func<UnitResult<E>, K> func)
+        public static async ValueTask<K> Finally<K, E>(this ValueTask<UnitResult<E>> resultTask, Func<UnitResult<E>, K> valueTask)
         {
             UnitResult<E> result = await resultTask;
-            return result.Finally(func);
+            return result.Finally(valueTask);
         }
 
         /// <summary>
-        ///     Passes the result to the given function (regardless of success/failure state) to yield a final output value.
+        ///     Passes the result to the given valueTask action (regardless of success/failure state) to yield a final output value.
         /// </summary>
         public static async ValueTask<K> Finally<T, K, E>(this ValueTask<Result<T, E>> resultTask,
-            Func<Result<T, E>, K> func)
+            Func<Result<T, E>, K> valueTask)
         {
             Result<T, E> result = await resultTask;
-            return result.Finally(func);
+            return result.Finally(valueTask);
         }
     }
 }

--- a/CSharpFunctionalExtensions/Result/Methods/Extensions/Finally.ValueTask.Right.cs
+++ b/CSharpFunctionalExtensions/Result/Methods/Extensions/Finally.ValueTask.Right.cs
@@ -2,40 +2,40 @@
 using System;
 using System.Threading.Tasks;
 
-namespace CSharpFunctionalExtensions
+namespace CSharpFunctionalExtensions.ValueTasks
 {
     public static partial class AsyncResultExtensionsRightOperand
     {
         /// <summary>
-        ///     Passes the result to the given function (regardless of success/failure state) to yield a final output value.
+        ///     Passes the result to the given valueTask action (regardless of success/failure state) to yield a final output value.
         /// </summary>
-        public static async ValueTask<T> Finally<T>(this Result result, Func<Result, ValueTask<T>> func)
+        public static async ValueTask<T> Finally<T>(this Result result, Func<Result, ValueTask<T>> valueTask)
         {
-            return await func(result);
+            return await valueTask(result);
         }
 
         /// <summary>
-        ///     Passes the result to the given function (regardless of success/failure state) to yield a final output value.
+        ///     Passes the result to the given valueTask action (regardless of success/failure state) to yield a final output value.
         /// </summary>
-        public static async ValueTask<K> Finally<T, K>(this Result<T> result, Func<Result<T>, ValueTask<K>> func)
+        public static async ValueTask<K> Finally<T, K>(this Result<T> result, Func<Result<T>, ValueTask<K>> valueTask)
         {
-            return await func(result);
+            return await valueTask(result);
         }
 
         /// <summary>
-        ///     Passes the result to the given function (regardless of success/failure state) to yield a final output value.
+        ///     Passes the result to the given valueTask action (regardless of success/failure state) to yield a final output value.
         /// </summary>
-        public static async ValueTask<K> Finally<K, E>(this UnitResult<E> result, Func<UnitResult<E>, ValueTask<K>> func)
+        public static async ValueTask<K> Finally<K, E>(this UnitResult<E> result, Func<UnitResult<E>, ValueTask<K>> valueTask)
         {
-            return await func(result);
+            return await valueTask(result);
         }
 
         /// <summary>
-        ///     Passes the result to the given function (regardless of success/failure state) to yield a final output value.
+        ///     Passes the result to the given valueTask action (regardless of success/failure state) to yield a final output value.
         /// </summary>
-        public static async ValueTask<K> Finally<T, K, E>(this Result<T, E> result, Func<Result<T, E>, ValueTask<K>> func)
+        public static async ValueTask<K> Finally<T, K, E>(this Result<T, E> result, Func<Result<T, E>, ValueTask<K>> valueTask)
         {
-            return await func(result);
+            return await valueTask(result);
         }
     }
 }

--- a/CSharpFunctionalExtensions/Result/Methods/Extensions/Finally.ValueTask.cs
+++ b/CSharpFunctionalExtensions/Result/Methods/Extensions/Finally.ValueTask.cs
@@ -2,45 +2,45 @@
 using System;
 using System.Threading.Tasks;
 
-namespace CSharpFunctionalExtensions
+namespace CSharpFunctionalExtensions.ValueTasks
 {
     public static partial class AsyncResultExtensionsBothOperands
     {
         /// <summary>
-        ///     Passes the result to the given function (regardless of success/failure state) to yield a final output value.
+        ///     Passes the result to the given valueTask action (regardless of success/failure state) to yield a final output value.
         /// </summary>
-        public static async ValueTask<T> Finally<T>(this ValueTask<Result> resultTask, Func<Result, ValueTask<T>> func)
+        public static async ValueTask<T> Finally<T>(this ValueTask<Result> resultTask, Func<Result, ValueTask<T>> valueTask)
         {
             Result result = await resultTask;
-            return await func(result);
+            return await valueTask(result);
         }
 
         /// <summary>
-        ///     Passes the result to the given function (regardless of success/failure state) to yield a final output value.
+        ///     Passes the result to the given valueTask action (regardless of success/failure state) to yield a final output value.
         /// </summary>
-        public static async ValueTask<K> Finally<T, K>(this ValueTask<Result<T>> resultTask, Func<Result<T>, ValueTask<K>> func)
+        public static async ValueTask<K> Finally<T, K>(this ValueTask<Result<T>> resultTask, Func<Result<T>, ValueTask<K>> valueTask)
         {
             Result<T> result = await resultTask;
-            return await func(result);
+            return await valueTask(result);
         }
 
         /// <summary>
-        ///     Passes the result to the given function (regardless of success/failure state) to yield a final output value.
+        ///     Passes the result to the given valueTask action (regardless of success/failure state) to yield a final output value.
         /// </summary>
-        public static async ValueTask<K> Finally<K, E>(this ValueTask<UnitResult<E>> resultTask, Func<UnitResult<E>, ValueTask<K>> func) 
+        public static async ValueTask<K> Finally<K, E>(this ValueTask<UnitResult<E>> resultTask, Func<UnitResult<E>, ValueTask<K>> valueTask) 
         {
             UnitResult<E> result = await resultTask;
-            return await func(result);
+            return await valueTask(result);
         }
 
         /// <summary>
-        ///     Passes the result to the given function (regardless of success/failure state) to yield a final output value.
+        ///     Passes the result to the given valueTask action (regardless of success/failure state) to yield a final output value.
         /// </summary>
         public static async ValueTask<K> Finally<T, K, E>(this ValueTask<Result<T, E>> resultTask,
-            Func<Result<T, E>, ValueTask<K>> func)
+            Func<Result<T, E>, ValueTask<K>> valueTask)
         {
             Result<T, E> result = await resultTask;
-            return await func(result);
+            return await valueTask(result);
         }
     }
 }

--- a/CSharpFunctionalExtensions/Result/Methods/Extensions/Map.ValueTask.Left.cs
+++ b/CSharpFunctionalExtensions/Result/Methods/Extensions/Map.ValueTask.Left.cs
@@ -2,44 +2,44 @@
 using System;
 using System.Threading.Tasks;
 
-namespace CSharpFunctionalExtensions
+namespace CSharpFunctionalExtensions.ValueTasks
 {
     public static partial class AsyncResultExtensionsLeftOperand
     {
         /// <summary>
-        ///     Creates a new result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.
+        ///     Creates a new result from the return value of a given valueTask action. If the calling Result is a failure, a new failure result is returned instead.
         /// </summary>
-        public static async ValueTask<Result<K, E>> Map<T, K, E>(this ValueTask<Result<T, E>> resultTask, Func<T, K> func)
+        public static async ValueTask<Result<K, E>> Map<T, K, E>(this ValueTask<Result<T, E>> resultTask, Func<T, K> valueTask)
         {
             Result<T, E> result = await resultTask;
-            return result.Map(func);
+            return result.Map(valueTask);
         }
 
         /// <summary>
-        ///     Creates a new result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.
+        ///     Creates a new result from the return value of a given valueTask action. If the calling Result is a failure, a new failure result is returned instead.
         /// </summary>
-        public static async ValueTask<Result<K, E>> Map<K, E>(this ValueTask<UnitResult<E>> resultTask, Func<K> func) 
+        public static async ValueTask<Result<K, E>> Map<K, E>(this ValueTask<UnitResult<E>> resultTask, Func<K> valueTask) 
         {
             UnitResult<E> result = await resultTask;
-            return result.Map(func);
+            return result.Map(valueTask);
         }
 
         /// <summary>
-        ///     Creates a new result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.
+        ///     Creates a new result from the return value of a given valueTask action. If the calling Result is a failure, a new failure result is returned instead.
         /// </summary>
-        public static async ValueTask<Result<K>> Map<T, K>(this ValueTask<Result<T>> resultTask, Func<T, K> func)
+        public static async ValueTask<Result<K>> Map<T, K>(this ValueTask<Result<T>> resultTask, Func<T, K> valueTask)
         {
             Result<T> result = await resultTask;
-            return result.Map(func);
+            return result.Map(valueTask);
         }
 
         /// <summary>
-        ///     Creates a new result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.
+        ///     Creates a new result from the return value of a given valueTask action. If the calling Result is a failure, a new failure result is returned instead.
         /// </summary>
-        public static async ValueTask<Result<K>> Map<K>(this ValueTask<Result> resultTask, Func<K> func)
+        public static async ValueTask<Result<K>> Map<K>(this ValueTask<Result> resultTask, Func<K> valueTask)
         {
             Result result = await resultTask;
-            return result.Map(func);
+            return result.Map(valueTask);
         }
     }
 }

--- a/CSharpFunctionalExtensions/Result/Methods/Extensions/Map.ValueTask.Right.cs
+++ b/CSharpFunctionalExtensions/Result/Methods/Extensions/Map.ValueTask.Right.cs
@@ -2,70 +2,70 @@
 using System;
 using System.Threading.Tasks;
 
-namespace CSharpFunctionalExtensions
+namespace CSharpFunctionalExtensions.ValueTasks
 {
     public static partial class AsyncResultExtensionsRightOperand
     {
         /// <summary>
-        ///     Creates a new result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.
+        ///     Creates a new result from the return value of a given valueTask action. If the calling Result is a failure, a new failure result is returned instead.
         /// </summary>
-        public static async ValueTask<Result<K, E>> Map<T, K, E>(this Result<T, E> result, Func<T, ValueTask<K>> func)
+        public static async ValueTask<Result<K, E>> Map<T, K, E>(this Result<T, E> result, Func<T, ValueTask<K>> valueTask)
         {
             if (result.IsFailure)
                 return Result.Failure<K, E>(result.Error);
 
-            K value = await func(result.Value);
+            K value = await valueTask(result.Value);
 
             return Result.Success<K, E>(value);
         }
 
         /// <summary>
-        ///     Creates a new result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.
+        ///     Creates a new result from the return value of a given valueTask action. If the calling Result is a failure, a new failure result is returned instead.
         /// </summary>
-        public static async ValueTask<Result<K, E>> Map<K, E>(this UnitResult<E> result, Func<ValueTask<K>> func) 
+        public static async ValueTask<Result<K, E>> Map<K, E>(this UnitResult<E> result, Func<ValueTask<K>> valueTask) 
         {
             if (result.IsFailure)
                 return Result.Failure<K, E>(result.Error);
 
-            K value = await func();
+            K value = await valueTask();
 
             return Result.Success<K, E>(value);
         }
 
         /// <summary>
-        ///     Creates a new result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.
+        ///     Creates a new result from the return value of a given valueTask action. If the calling Result is a failure, a new failure result is returned instead.
         /// </summary>
-        public static async ValueTask<Result<K>> Map<T, K>(this Result<T> result, Func<T, ValueTask<K>> func)
+        public static async ValueTask<Result<K>> Map<T, K>(this Result<T> result, Func<T, ValueTask<K>> valueTask)
         {
             if (result.IsFailure)
                 return Result.Failure<K>(result.Error);
 
-            K value = await func(result.Value);
+            K value = await valueTask(result.Value);
 
             return Result.Success(value);
         }
 
         /// <summary>
-        ///     Creates a new result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.
+        ///     Creates a new result from the return value of a given valueTask action. If the calling Result is a failure, a new failure result is returned instead.
         /// </summary>
-        public static async ValueTask<Result<K>> Map<T, K>(this Result<T> result, Func<T, ValueTask<Result<K>>> func)
+        public static async ValueTask<Result<K>> Map<T, K>(this Result<T> result, Func<T, ValueTask<Result<K>>> valueTask)
         {
             if (result.IsFailure)
                 return Result.Failure<K>(result.Error);
 
-            Result<K> value = await func(result.Value);
+            Result<K> value = await valueTask(result.Value);
             return value;
         }
 
         /// <summary>
-        ///     Creates a new result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.
+        ///     Creates a new result from the return value of a given valueTask action. If the calling Result is a failure, a new failure result is returned instead.
         /// </summary>
-        public static async ValueTask<Result<K>> Map<K>(this Result result, Func<ValueTask<K>> func)
+        public static async ValueTask<Result<K>> Map<K>(this Result result, Func<ValueTask<K>> valueTask)
         {
             if (result.IsFailure)
                 return Result.Failure<K>(result.Error);
 
-            K value = await func();
+            K value = await valueTask();
 
             return Result.Success(value);
         }

--- a/CSharpFunctionalExtensions/Result/Methods/Extensions/Map.ValueTask.cs
+++ b/CSharpFunctionalExtensions/Result/Methods/Extensions/Map.ValueTask.cs
@@ -2,66 +2,66 @@
 using System;
 using System.Threading.Tasks;
 
-namespace CSharpFunctionalExtensions
+namespace CSharpFunctionalExtensions.ValueTasks
 {
     public static partial class AsyncResultExtensionsBothOperands
     {
         /// <summary>
-        ///     Creates a new result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.
+        ///     Creates a new result from the return value of a given valueTask action. If the calling Result is a failure, a new failure result is returned instead.
         /// </summary>
-        public static async ValueTask<Result<K, E>> Map<T, K, E>(this ValueTask<Result<T, E>> resultTask, Func<T, ValueTask<K>> func)
+        public static async ValueTask<Result<K, E>> Map<T, K, E>(this ValueTask<Result<T, E>> resultTask, Func<T, ValueTask<K>> valueTask)
         {
             Result<T, E> result = await resultTask;
 
             if (result.IsFailure)
                 return Result.Failure<K, E>(result.Error);
 
-            K value = await func(result.Value);
+            K value = await valueTask(result.Value);
 
             return Result.Success<K, E>(value);
         }
 
         /// <summary>
-        ///     Creates a new result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.
+        ///     Creates a new result from the return value of a given valueTask action. If the calling Result is a failure, a new failure result is returned instead.
         /// </summary>
-        public static async ValueTask<Result<K, E>> Map<K, E>(this ValueTask<UnitResult<E>> resultTask, Func<ValueTask<K>> func) 
+        public static async ValueTask<Result<K, E>> Map<K, E>(this ValueTask<UnitResult<E>> resultTask, Func<ValueTask<K>> valueTask) 
         {
             UnitResult<E> result = await resultTask;
 
             if (result.IsFailure)
                 return Result.Failure<K, E>(result.Error);
 
-            K value = await func();
+            K value = await valueTask();
 
             return Result.Success<K, E>(value);
         }
 
         /// <summary>
-        ///     Creates a new result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.
+        ///     Creates a new result from the return value of a given valueTask action. If the calling Result is a failure, a new failure result is returned instead.
         /// </summary>
-        public static async ValueTask<Result<K>> Map<T, K>(this ValueTask<Result<T>> resultTask, Func<T, ValueTask<K>> func)
+        public static async ValueTask<Result<K>> Map<T, K>(this ValueTask<Result<T>> resultTask, Func<T, ValueTask<K>> valueTask)
         {
             Result<T> result = await resultTask;
 
             if (result.IsFailure)
                 return Result.Failure<K>(result.Error);
 
-            K value = await func(result.Value);
+            K value = await valueTask(result.Value);
 
             return Result.Success(value);
         }
 
         /// <summary>
-        ///     Creates a new result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.
+        ///     Creates a new result from the return value of a given valueTask action. If the calling Result is a failure, a new failure result is returned instead.
         /// </summary>
-        public static async ValueTask<Result<K>> Map<K>(this ValueTask<Result> resultTask, Func<ValueTask<K>> func)
+        public static async ValueTask<Result<K>> Map<K>(this ValueTask<Result> resultTask, Func<ValueTask<K>> valueTask)
         {
             Result result = await resultTask;
 
             if (result.IsFailure)
                 return Result.Failure<K>(result.Error);
 
-            K value = await func();
+            K value = await valueTask();
 
             return Result.Success(value);
         }

--- a/CSharpFunctionalExtensions/Result/Methods/Extensions/MapError.ValueTask.Left.cs
+++ b/CSharpFunctionalExtensions/Result/Methods/Extensions/MapError.ValueTask.Left.cs
@@ -2,12 +2,12 @@
 using System;
 using System.Threading.Tasks;
 
-namespace CSharpFunctionalExtensions
+namespace CSharpFunctionalExtensions.ValueTasks
 {
     public static partial class ResultExtensions
     {
         /// <summary>
-        ///     If the calling Result is a success, a new success result is returned. Otherwise, creates a new failure result from the return value of a given function.
+        ///     If the calling Result is a success, a new success result is returned. Otherwise, creates a new failure result from the return value of a given valueTask action.
         /// </summary>
         public static async ValueTask<Result> MapError(this ValueTask<Result> resultTask, Func<string, string> errorFactory)
         {
@@ -22,7 +22,7 @@ namespace CSharpFunctionalExtensions
         }
 
         /// <summary>
-        ///     If the calling Result is a success, a new success result is returned. Otherwise, creates a new failure result from the return value of a given function.
+        ///     If the calling Result is a success, a new success result is returned. Otherwise, creates a new failure result from the return value of a given valueTask action.
         /// </summary>
         public static async ValueTask<UnitResult<E>> MapError<E>(this ValueTask<Result> resultTask, Func<string, E> errorFactory)
         {
@@ -37,7 +37,7 @@ namespace CSharpFunctionalExtensions
         }
 
         /// <summary>
-        ///     If the calling Result is a success, a new success result is returned. Otherwise, creates a new failure result from the return value of a given function.
+        ///     If the calling Result is a success, a new success result is returned. Otherwise, creates a new failure result from the return value of a given valueTask action.
         /// </summary>
         public static async ValueTask<Result<T>> MapError<T>(this ValueTask<Result<T>> resultTask, Func<string, string> errorFactory)
         {
@@ -52,7 +52,7 @@ namespace CSharpFunctionalExtensions
         }
 
         /// <summary>
-        ///     If the calling Result is a success, a new success result is returned. Otherwise, creates a new failure result from the return value of a given function.
+        ///     If the calling Result is a success, a new success result is returned. Otherwise, creates a new failure result from the return value of a given valueTask action.
         /// </summary>
         public static async ValueTask<Result<T, E>> MapError<T, E>(this ValueTask<Result<T>> resultTask, Func<string, E> errorFactory)
         {
@@ -67,7 +67,7 @@ namespace CSharpFunctionalExtensions
         }
 
         /// <summary>
-        ///     If the calling Result is a success, a new success result is returned. Otherwise, creates a new failure result from the return value of a given function.
+        ///     If the calling Result is a success, a new success result is returned. Otherwise, creates a new failure result from the return value of a given valueTask action.
         /// </summary>
         public static async ValueTask<Result> MapError<E>(this ValueTask<UnitResult<E>> resultTask, Func<E, string> errorFactory)
         {
@@ -82,7 +82,7 @@ namespace CSharpFunctionalExtensions
         }
 
         /// <summary>
-        ///     If the calling Result is a success, a new success result is returned. Otherwise, creates a new failure result from the return value of a given function.
+        ///     If the calling Result is a success, a new success result is returned. Otherwise, creates a new failure result from the return value of a given valueTask action.
         /// </summary>
         public static async ValueTask<UnitResult<E2>> MapError<E, E2>(this ValueTask<UnitResult<E>> resultTask, Func<E, E2> errorFactory)
         {
@@ -97,7 +97,7 @@ namespace CSharpFunctionalExtensions
         }
 
         /// <summary>
-        ///     If the calling Result is a success, a new success result is returned. Otherwise, creates a new failure result from the return value of a given function.
+        ///     If the calling Result is a success, a new success result is returned. Otherwise, creates a new failure result from the return value of a given valueTask action.
         /// </summary>
         public static async ValueTask<Result<T>> MapError<T, E>(this ValueTask<Result<T, E>> resultTask, Func<E, string> errorFactory)
         {
@@ -112,7 +112,7 @@ namespace CSharpFunctionalExtensions
         }
 
         /// <summary>
-        ///     If the calling Result is a success, a new success result is returned. Otherwise, creates a new failure result from the return value of a given function.
+        ///     If the calling Result is a success, a new success result is returned. Otherwise, creates a new failure result from the return value of a given valueTask action.
         /// </summary>
         public static async ValueTask<Result<T, E2>> MapError<T, E, E2>(this ValueTask<Result<T, E>> resultTask, Func<E, E2> errorFactory)
         {

--- a/CSharpFunctionalExtensions/Result/Methods/Extensions/MapError.ValueTask.Right.cs
+++ b/CSharpFunctionalExtensions/Result/Methods/Extensions/MapError.ValueTask.Right.cs
@@ -2,12 +2,12 @@
 using System;
 using System.Threading.Tasks;
 
-namespace CSharpFunctionalExtensions
+namespace CSharpFunctionalExtensions.ValueTasks
 {
     public static partial class ResultExtensions
     {
         /// <summary>
-        ///     If the calling Result is a success, a new success result is returned. Otherwise, creates a new failure result from the return value of a given function.
+        ///     If the calling Result is a success, a new success result is returned. Otherwise, creates a new failure result from the return value of a given valueTask action.
         /// </summary>
         public static async ValueTask<Result> MapError(this Result result, Func<string, ValueTask<string>> errorFactory)
         {
@@ -21,7 +21,7 @@ namespace CSharpFunctionalExtensions
         }
 
         /// <summary>
-        ///     If the calling Result is a success, a new success result is returned. Otherwise, creates a new failure result from the return value of a given function.
+        ///     If the calling Result is a success, a new success result is returned. Otherwise, creates a new failure result from the return value of a given valueTask action.
         /// </summary>
         public static async ValueTask<UnitResult<E>> MapError<E>(this Result result, Func<string, ValueTask<E>> errorFactory)
         {
@@ -35,7 +35,7 @@ namespace CSharpFunctionalExtensions
         }
 
         /// <summary>
-        ///     If the calling Result is a success, a new success result is returned. Otherwise, creates a new failure result from the return value of a given function.
+        ///     If the calling Result is a success, a new success result is returned. Otherwise, creates a new failure result from the return value of a given valueTask action.
         /// </summary>
         public static async ValueTask<Result<T>> MapError<T>(this Result<T> result, Func<string, ValueTask<string>> errorFactory)
         {
@@ -49,7 +49,7 @@ namespace CSharpFunctionalExtensions
         }
 
         /// <summary>
-        ///     If the calling Result is a success, a new success result is returned. Otherwise, creates a new failure result from the return value of a given function.
+        ///     If the calling Result is a success, a new success result is returned. Otherwise, creates a new failure result from the return value of a given valueTask action.
         /// </summary>
         public static async ValueTask<Result<T, E>> MapError<T, E>(this Result<T> result, Func<string, ValueTask<E>> errorFactory)
         {
@@ -63,7 +63,7 @@ namespace CSharpFunctionalExtensions
         }
 
         /// <summary>
-        ///     If the calling Result is a success, a new success result is returned. Otherwise, creates a new failure result from the return value of a given function.
+        ///     If the calling Result is a success, a new success result is returned. Otherwise, creates a new failure result from the return value of a given valueTask action.
         /// </summary>
         public static async ValueTask<Result> MapError<E>(this UnitResult<E> result, Func<E, ValueTask<string>> errorFactory)
         {
@@ -77,7 +77,7 @@ namespace CSharpFunctionalExtensions
         }
 
         /// <summary>
-        ///     If the calling Result is a success, a new success result is returned. Otherwise, creates a new failure result from the return value of a given function.
+        ///     If the calling Result is a success, a new success result is returned. Otherwise, creates a new failure result from the return value of a given valueTask action.
         /// </summary>
         public static async ValueTask<UnitResult<E2>> MapError<E, E2>(this UnitResult<E> result, Func<E, ValueTask<E2>> errorFactory)
         {
@@ -91,7 +91,7 @@ namespace CSharpFunctionalExtensions
         }
 
         /// <summary>
-        ///     If the calling Result is a success, a new success result is returned. Otherwise, creates a new failure result from the return value of a given function.
+        ///     If the calling Result is a success, a new success result is returned. Otherwise, creates a new failure result from the return value of a given valueTask action.
         /// </summary>
         public static async ValueTask<Result<T>> MapError<T, E>(this Result<T, E> result, Func<E, ValueTask<string>> errorFactory)
         {
@@ -105,7 +105,7 @@ namespace CSharpFunctionalExtensions
         }
 
         /// <summary>
-        ///     If the calling Result is a success, a new success result is returned. Otherwise, creates a new failure result from the return value of a given function.
+        ///     If the calling Result is a success, a new success result is returned. Otherwise, creates a new failure result from the return value of a given valueTask action.
         /// </summary>
         public static async ValueTask<Result<T, E2>> MapError<T, E, E2>(this Result<T, E> result, Func<E, ValueTask<E2>> errorFactory)
         {

--- a/CSharpFunctionalExtensions/Result/Methods/Extensions/MapError.ValueTask.cs
+++ b/CSharpFunctionalExtensions/Result/Methods/Extensions/MapError.ValueTask.cs
@@ -2,12 +2,12 @@
 using System;
 using System.Threading.Tasks;
 
-namespace CSharpFunctionalExtensions
+namespace CSharpFunctionalExtensions.ValueTasks
 {
     public static partial class ResultExtensions
     {
         /// <summary>
-        ///     If the calling Result is a success, a new success result is returned. Otherwise, creates a new failure result from the return value of a given function.
+        ///     If the calling Result is a success, a new success result is returned. Otherwise, creates a new failure result from the return value of a given valueTask action.
         /// </summary>
         public static async ValueTask<Result> MapError(this ValueTask<Result> resultTask, Func<string, ValueTask<string>> errorFactory)
         {
@@ -16,7 +16,7 @@ namespace CSharpFunctionalExtensions
         }
 
         /// <summary>
-        ///     If the calling Result is a success, a new success result is returned. Otherwise, creates a new failure result from the return value of a given function.
+        ///     If the calling Result is a success, a new success result is returned. Otherwise, creates a new failure result from the return value of a given valueTask action.
         /// </summary>
         public static async ValueTask<UnitResult<E>> MapError<E>(this ValueTask<Result> resultTask, Func<string, ValueTask<E>> errorFactory)
         {
@@ -25,7 +25,7 @@ namespace CSharpFunctionalExtensions
         }
 
         /// <summary>
-        ///     If the calling Result is a success, a new success result is returned. Otherwise, creates a new failure result from the return value of a given function.
+        ///     If the calling Result is a success, a new success result is returned. Otherwise, creates a new failure result from the return value of a given valueTask action.
         /// </summary>
         public static async ValueTask<Result<T>> MapError<T>(this ValueTask<Result<T>> resultTask, Func<string, ValueTask<string>> errorFactory)
         {
@@ -34,7 +34,7 @@ namespace CSharpFunctionalExtensions
         }
 
         /// <summary>
-        ///     If the calling Result is a success, a new success result is returned. Otherwise, creates a new failure result from the return value of a given function.
+        ///     If the calling Result is a success, a new success result is returned. Otherwise, creates a new failure result from the return value of a given valueTask action.
         /// </summary>
         public static async ValueTask<Result<T, E>> MapError<T, E>(this ValueTask<Result<T>> resultTask, Func<string, ValueTask<E>> errorFactory)
         {
@@ -43,7 +43,7 @@ namespace CSharpFunctionalExtensions
         }
 
         /// <summary>
-        ///     If the calling Result is a success, a new success result is returned. Otherwise, creates a new failure result from the return value of a given function.
+        ///     If the calling Result is a success, a new success result is returned. Otherwise, creates a new failure result from the return value of a given valueTask action.
         /// </summary>
         public static async ValueTask<Result> MapError<E>(this ValueTask<UnitResult<E>> resultTask, Func<E, ValueTask<string>> errorFactory)
         {
@@ -52,7 +52,7 @@ namespace CSharpFunctionalExtensions
         }
 
         /// <summary>
-        ///     If the calling Result is a success, a new success result is returned. Otherwise, creates a new failure result from the return value of a given function.
+        ///     If the calling Result is a success, a new success result is returned. Otherwise, creates a new failure result from the return value of a given valueTask action.
         /// </summary>
         public static async ValueTask<UnitResult<E2>> MapError<E, E2>(this ValueTask<UnitResult<E>> resultTask, Func<E, ValueTask<E2>> errorFactory)
         {
@@ -61,7 +61,7 @@ namespace CSharpFunctionalExtensions
         }
 
         /// <summary>
-        ///     If the calling Result is a success, a new success result is returned. Otherwise, creates a new failure result from the return value of a given function.
+        ///     If the calling Result is a success, a new success result is returned. Otherwise, creates a new failure result from the return value of a given valueTask action.
         /// </summary>
         public static async ValueTask<Result<T>> MapError<T, E>(this ValueTask<Result<T, E>> resultTask, Func<E, ValueTask<string>> errorFactory)
         {
@@ -70,7 +70,7 @@ namespace CSharpFunctionalExtensions
         }
 
         /// <summary>
-        ///     If the calling Result is a success, a new success result is returned. Otherwise, creates a new failure result from the return value of a given function.
+        ///     If the calling Result is a success, a new success result is returned. Otherwise, creates a new failure result from the return value of a given valueTask action.
         /// </summary>
         public static async ValueTask<Result<T, E2>> MapError<T, E, E2>(this ValueTask<Result<T, E>> resultTask, Func<E, ValueTask<E2>> errorFactory)
         {

--- a/CSharpFunctionalExtensions/Result/Methods/Extensions/MapWithTransactionScope.ValueTask.Left.cs
+++ b/CSharpFunctionalExtensions/Result/Methods/Extensions/MapWithTransactionScope.ValueTask.Left.cs
@@ -2,7 +2,7 @@
 using System;
 using System.Threading.Tasks;
 
-namespace CSharpFunctionalExtensions
+namespace CSharpFunctionalExtensions.ValueTasks
 {
     public static partial class ResultExtensions
     {

--- a/CSharpFunctionalExtensions/Result/Methods/Extensions/MapWithTransactionScope.ValueTask.Right.cs
+++ b/CSharpFunctionalExtensions/Result/Methods/Extensions/MapWithTransactionScope.ValueTask.Right.cs
@@ -2,7 +2,7 @@
 using System;
 using System.Threading.Tasks;
 
-namespace CSharpFunctionalExtensions
+namespace CSharpFunctionalExtensions.ValueTasks
 {
     public static partial class ResultExtensions
     {

--- a/CSharpFunctionalExtensions/Result/Methods/Extensions/MapWithTransactionScope.ValueTask.cs
+++ b/CSharpFunctionalExtensions/Result/Methods/Extensions/MapWithTransactionScope.ValueTask.cs
@@ -2,7 +2,7 @@
 using System;
 using System.Threading.Tasks;
 
-namespace CSharpFunctionalExtensions
+namespace CSharpFunctionalExtensions.ValueTasks
 {
     public static partial class ResultExtensions
     {

--- a/CSharpFunctionalExtensions/Result/Methods/Extensions/Match.ValueTask.Left.cs
+++ b/CSharpFunctionalExtensions/Result/Methods/Extensions/Match.ValueTask.Left.cs
@@ -2,12 +2,12 @@
 using System;
 using System.Threading.Tasks;
 
-namespace CSharpFunctionalExtensions
+namespace CSharpFunctionalExtensions.ValueTasks
 {
     public static partial class AsyncResultExtensionsLeftOperand
     {
         /// <summary>
-        ///     Returns the result of the given <paramref name="onSuccess"/> function if the calling Result is a success. Otherwise, it returns the result of the given <paramref name="onFailure"/> function.
+        ///     Returns the result of the given <paramref name="onSuccess"/> valueTask action if the calling Result is a success. Otherwise, it returns the result of the given <paramref name="onFailure"/> valueTask action.
         /// </summary>
         public static async ValueTask<K> Match<T, K, E>(this ValueTask<Result<T, E>> resultTask, Func<T, K> onSuccess, Func<E, K> onFailure)
         {
@@ -15,7 +15,7 @@ namespace CSharpFunctionalExtensions
         }
 
         /// <summary>
-        ///     Returns the result of the given <paramref name="onSuccess"/> function if the calling Result is a success. Otherwise, it returns the result of the given <paramref name="onFailure"/> function.
+        ///     Returns the result of the given <paramref name="onSuccess"/> valueTask action if the calling Result is a success. Otherwise, it returns the result of the given <paramref name="onFailure"/> valueTask action.
         /// </summary>
         public static async ValueTask<K> Match<K, T>(this ValueTask<Result<T>> resultTask, Func<T, K> onSuccess, Func<string, K> onFailure)
         {
@@ -23,7 +23,7 @@ namespace CSharpFunctionalExtensions
         }
 
         /// <summary>
-        ///     Returns the result of the given <paramref name="onSuccess"/> function if the calling Result is a success. Otherwise, it returns the result of the given <paramref name="onFailure"/> function.
+        ///     Returns the result of the given <paramref name="onSuccess"/> valueTask action if the calling Result is a success. Otherwise, it returns the result of the given <paramref name="onFailure"/> valueTask action.
         /// </summary>
         public static async ValueTask<T> Match<T>(this ValueTask<Result> resultTask, Func<T> onSuccess, Func<string, T> onFailure)
         {

--- a/CSharpFunctionalExtensions/Result/Methods/Extensions/Match.ValueTask.Right.cs
+++ b/CSharpFunctionalExtensions/Result/Methods/Extensions/Match.ValueTask.Right.cs
@@ -2,78 +2,78 @@
 using System;
 using System.Threading.Tasks;
 
-namespace CSharpFunctionalExtensions
+namespace CSharpFunctionalExtensions.ValueTasks
 {
     public static partial class AsyncResultExtensionsLeftOperand
     {
         /// <summary>
-        ///     Returns the result of the given <paramref name="onSuccess"/> function if the calling Result is a success. Otherwise, it returns the result of the given <paramref name="onFailure"/> function.
+        ///     Returns the result of the given <paramref name="onSuccessValueTask"/> valueTask action if the calling Result is a success. Otherwise, it returns the result of the given <paramref name="onFailureValueTask"/> valueTask action.
         /// </summary>
-        public static ValueTask<K> Match<T, K, E>(this Result<T, E> result, Func<T, ValueTask<K>> onSuccess, Func<E, ValueTask<K>> onFailure)
+        public static ValueTask<K> Match<T, K, E>(this Result<T, E> result, Func<T, ValueTask<K>> onSuccessValueTask, Func<E, ValueTask<K>> onFailureValueTask)
         {
             return result.IsSuccess
-                ? onSuccess(result.Value)
-                : onFailure(result.Error);
+                ? onSuccessValueTask(result.Value)
+                : onFailureValueTask(result.Error);
         }
 
         /// <summary>
-        ///     Returns the result of the given <paramref name="onSuccess"/> function if the calling Result is a success. Otherwise, it returns the result of the given <paramref name="onFailure"/> function.
+        ///     Returns the result of the given <paramref name="onSuccessValueTask"/> valueTask action if the calling Result is a success. Otherwise, it returns the result of the given <paramref name="onFailureValueTask"/> valueTask action.
         /// </summary>
-        public static ValueTask<K> Match<K, T>(this Result<T> result, Func<T, ValueTask<K>> onSuccess, Func<string, ValueTask<K>> onFailure)
+        public static ValueTask<K> Match<K, T>(this Result<T> result, Func<T, ValueTask<K>> onSuccessValueTask, Func<string, ValueTask<K>> onFailureValueTask)
         {
             return result.IsSuccess
-                ? onSuccess(result.Value)
-                : onFailure(result.Error);
+                ? onSuccessValueTask(result.Value)
+                : onFailureValueTask(result.Error);
         }
 
         /// <summary>
-        ///     Returns the result of the given <paramref name="onSuccess"/> function if the calling Result is a success. Otherwise, it returns the result of the given <paramref name="onFailure"/> function.
+        ///     Returns the result of the given <paramref name="onSuccessValueTask"/> valueTask action if the calling Result is a success. Otherwise, it returns the result of the given <paramref name="onFailureValueTask"/> valueTask action.
         /// </summary>
-        public static ValueTask<T> Match<T>(this Result result, Func<ValueTask<T>> onSuccess, Func<string, ValueTask<T>> onFailure)
+        public static ValueTask<T> Match<T>(this Result result, Func<ValueTask<T>> onSuccessValueTask, Func<string, ValueTask<T>> onFailureValueTask)
         {
             return result.IsSuccess
-                ? onSuccess()
-                : onFailure(result.Error);
+                ? onSuccessValueTask()
+                : onFailureValueTask(result.Error);
         }
 
         /// <summary>
-        ///     Invokes the given <paramref name="onSuccess"/> action if the calling Result is a success. Otherwise, it invokes the given <paramref name="onFailure"/> action.
+        ///     Invokes the given <paramref name="onSuccessValueTask"/> action if the calling Result is a success. Otherwise, it invokes the given <paramref name="onFailureValueTask"/> action.
         /// </summary>
-        public static ValueTask Match<T, E>(this Result<T, E> result, Func<T, ValueTask> onSuccess, Func<E, ValueTask> onFailure)
+        public static ValueTask Match<T, E>(this Result<T, E> result, Func<T, ValueTask> onSuccessValueTask, Func<E, ValueTask> onFailureValueTask)
         {
             return result.IsSuccess
-                ? onSuccess(result.Value)
-                : onFailure(result.Error);
+                ? onSuccessValueTask(result.Value)
+                : onFailureValueTask(result.Error);
         }
 
         /// <summary>
-        ///     Invokes the given <paramref name="onSuccess"/> action if the calling Result is a success. Otherwise, it invokes the given <paramref name="onFailure"/> action.
+        ///     Invokes the given <paramref name="onSuccessValueTask"/> action if the calling Result is a success. Otherwise, it invokes the given <paramref name="onFailureValueTask"/> action.
         /// </summary>
-        public static ValueTask Match<E>(this UnitResult<E> result, Func<ValueTask> onSuccess, Func<E, ValueTask> onFailure)
+        public static ValueTask Match<E>(this UnitResult<E> result, Func<ValueTask> onSuccessValueTask, Func<E, ValueTask> onFailureValueTask)
         {
             return result.IsSuccess
-                ? onSuccess()
-                : onFailure(result.Error);
+                ? onSuccessValueTask()
+                : onFailureValueTask(result.Error);
         }
 
         /// <summary>
-        ///     Invokes the given <paramref name="onSuccess"/> action if the calling Result is a success. Otherwise, it invokes the given <paramref name="onFailure"/> action.
+        ///     Invokes the given <paramref name="onSuccessValueTask"/> action if the calling Result is a success. Otherwise, it invokes the given <paramref name="onFailureValueTask"/> action.
         /// </summary>
-        public static ValueTask Match<T>(this Result<T> result, Func<T, ValueTask> onSuccess, Func<string, ValueTask> onFailure)
+        public static ValueTask Match<T>(this Result<T> result, Func<T, ValueTask> onSuccessValueTask, Func<string, ValueTask> onFailureValueTask)
         {
             return result.IsSuccess
-                ? onSuccess(result.Value)
-                : onFailure(result.Error);
+                ? onSuccessValueTask(result.Value)
+                : onFailureValueTask(result.Error);
         }
 
         /// <summary>
-        ///     Invokes the given <paramref name="onSuccess"/> action if the calling Result is a success. Otherwise, it invokes the given <paramref name="onFailure"/> action.
+        ///     Invokes the given <paramref name="onSuccessValueTask"/> action if the calling Result is a success. Otherwise, it invokes the given <paramref name="onFailureValueTask"/> action.
         /// </summary>
-        public static ValueTask Match(this Result result, Func<ValueTask> onSuccess, Func<string, ValueTask> onFailure)
+        public static ValueTask Match(this Result result, Func<ValueTask> onSuccessValueTask, Func<string, ValueTask> onFailureValueTask)
         {
             return result.IsSuccess
-                ? onSuccess()
-                : onFailure(result.Error);
+                ? onSuccessValueTask()
+                : onFailureValueTask(result.Error);
         }
     }
 }

--- a/CSharpFunctionalExtensions/Result/Methods/Extensions/Match.ValueTask.cs
+++ b/CSharpFunctionalExtensions/Result/Methods/Extensions/Match.ValueTask.cs
@@ -2,71 +2,71 @@
 using System;
 using System.Threading.Tasks;
 
-namespace CSharpFunctionalExtensions
+namespace CSharpFunctionalExtensions.ValueTasks
 {
     public static partial class AsyncResultExtensionsLeftOperand
     {
         /// <summary>
-        ///     Returns the result of the given <paramref name="onSuccess"/> function if the calling Result is a success. Otherwise, it returns the result of the given <paramref name="onFailure"/> function.
+        ///     Returns the result of the given <paramref name="onSuccessValueTask"/> valueTask action if the calling Result is a success. Otherwise, it returns the result of the given <paramref name="onFailureValueTask"/> valueTask action.
         /// </summary>
-        public static async ValueTask<K> Match<T, K, E>(this ValueTask<Result<T, E>> resultTask, Func<T, ValueTask<K>> onSuccess, Func<E, ValueTask<K>> onFailure)
+        public static async ValueTask<K> Match<T, K, E>(this ValueTask<Result<T, E>> resultTask, Func<T, ValueTask<K>> onSuccessValueTask, Func<E, ValueTask<K>> onFailureValueTask)
         {
             return await (await resultTask)
-                .Match(onSuccess, onFailure);
+                .Match(onSuccessValueTask, onFailureValueTask);
         }
 
         /// <summary>
-        ///     Returns the result of the given <paramref name="onSuccess"/> function if the calling Result is a success. Otherwise, it returns the result of the given <paramref name="onFailure"/> function.
+        ///     Returns the result of the given <paramref name="onSuccessValueTask"/> valueTask action if the calling Result is a success. Otherwise, it returns the result of the given <paramref name="onFailureValueTask"/> valueTask action.
         /// </summary>
-        public static async ValueTask<K> Match<K, T>(this ValueTask<Result<T>> resultTask, Func<T, ValueTask<K>> onSuccess, Func<string, ValueTask<K>> onFailure)
+        public static async ValueTask<K> Match<K, T>(this ValueTask<Result<T>> resultTask, Func<T, ValueTask<K>> onSuccessValueTask, Func<string, ValueTask<K>> onFailureValueTask)
         {
             return await (await resultTask)
-                .Match(onSuccess, onFailure);
+                .Match(onSuccessValueTask, onFailureValueTask);
         }
 
         /// <summary>
-        ///     Returns the result of the given <paramref name="onSuccess"/> function if the calling Result is a success. Otherwise, it returns the result of the given <paramref name="onFailure"/> function.
+        ///     Returns the result of the given <paramref name="onSuccessValueTask"/> valueTask action if the calling Result is a success. Otherwise, it returns the result of the given <paramref name="onFailureValueTask"/> valueTask action.
         /// </summary>
-        public static async ValueTask<T> Match<T>(this ValueTask<Result> resultTask, Func<ValueTask<T>> onSuccess, Func<string, ValueTask<T>> onFailure)
+        public static async ValueTask<T> Match<T>(this ValueTask<Result> resultTask, Func<ValueTask<T>> onSuccessValueTask, Func<string, ValueTask<T>> onFailureValueTask)
         {
             return await (await resultTask)
-                .Match(onSuccess, onFailure);
+                .Match(onSuccessValueTask, onFailureValueTask);
         }
 
         /// <summary>
-        ///     Invokes the given <paramref name="onSuccess"/> action if the calling Result is a success. Otherwise, it invokes the given <paramref name="onFailure"/> action.
+        ///     Invokes the given <paramref name="onSuccessValueTask"/> action if the calling Result is a success. Otherwise, it invokes the given <paramref name="onFailureValueTask"/> action.
         /// </summary>
-        public static async Task Match<T, E>(this ValueTask<Result<T, E>> resultTask, Func<T, ValueTask> onSuccess, Func<E, ValueTask> onFailure)
+        public static async Task Match<T, E>(this ValueTask<Result<T, E>> resultTask, Func<T, ValueTask> onSuccessValueTask, Func<E, ValueTask> onFailureValueTask)
         {
             await (await resultTask)
-                .Match(onSuccess, onFailure);
+                .Match(onSuccessValueTask, onFailureValueTask);
         }
 
         /// <summary>
-        ///     Invokes the given <paramref name="onSuccess"/> action if the calling Result is a success. Otherwise, it invokes the given <paramref name="onFailure"/> action.
+        ///     Invokes the given <paramref name="onSuccessValueTask"/> action if the calling Result is a success. Otherwise, it invokes the given <paramref name="onFailureValueTask"/> action.
         /// </summary>
-        public static async Task Match<E>(this ValueTask<UnitResult<E>> resultTask, Func<ValueTask> onSuccess, Func<E, ValueTask> onFailure)
+        public static async Task Match<E>(this ValueTask<UnitResult<E>> resultTask, Func<ValueTask> onSuccessValueTask, Func<E, ValueTask> onFailureValueTask)
         {
             await (await resultTask)
-                .Match(onSuccess, onFailure);
+                .Match(onSuccessValueTask, onFailureValueTask);
         }
 
         /// <summary>
-        ///     Invokes the given <paramref name="onSuccess"/> action if the calling Result is a success. Otherwise, it invokes the given <paramref name="onFailure"/> action.
+        ///     Invokes the given <paramref name="onSuccessValueTask"/> action if the calling Result is a success. Otherwise, it invokes the given <paramref name="onFailureValueTask"/> action.
         /// </summary>
-        public static async Task Match<T>(this ValueTask<Result<T>> resultTask, Func<T, ValueTask> onSuccess, Func<string, ValueTask> onFailure)
+        public static async Task Match<T>(this ValueTask<Result<T>> resultTask, Func<T, ValueTask> onSuccessValueTask, Func<string, ValueTask> onFailureValueTask)
         {
             await (await resultTask)
-                .Match(onSuccess, onFailure);
+                .Match(onSuccessValueTask, onFailureValueTask);
         }
 
         /// <summary>
-        ///     Invokes the given <paramref name="onSuccess"/> action if the calling Result is a success. Otherwise, it invokes the given <paramref name="onFailure"/> action.
+        ///     Invokes the given <paramref name="onSuccessValueTask"/> action if the calling Result is a success. Otherwise, it invokes the given <paramref name="onFailureValueTask"/> action.
         /// </summary>
-        public static async Task Match(this ValueTask<Result> resultTask, Func<ValueTask> onSuccess, Func<string, ValueTask> onFailure)
+        public static async Task Match(this ValueTask<Result> resultTask, Func<ValueTask> onSuccessValueTask, Func<string, ValueTask> onFailureValueTask)
         {
             await (await resultTask)
-                .Match(onSuccess, onFailure);
+                .Match(onSuccessValueTask, onFailureValueTask);
         }
     }
 }

--- a/CSharpFunctionalExtensions/Result/Methods/Extensions/OnFailure.ValueTask.Left.cs
+++ b/CSharpFunctionalExtensions/Result/Methods/Extensions/OnFailure.ValueTask.Left.cs
@@ -2,7 +2,7 @@
 using System;
 using System.Threading.Tasks;
 
-namespace CSharpFunctionalExtensions
+namespace CSharpFunctionalExtensions.ValueTasks
 {
     public static partial class AsyncResultExtensionsLeftOperand
     {

--- a/CSharpFunctionalExtensions/Result/Methods/Extensions/OnFailure.ValueTask.Right.cs
+++ b/CSharpFunctionalExtensions/Result/Methods/Extensions/OnFailure.ValueTask.Right.cs
@@ -2,18 +2,18 @@
 using System;
 using System.Threading.Tasks;
 
-namespace CSharpFunctionalExtensions
+namespace CSharpFunctionalExtensions.ValueTasks
 {
     public static partial class AsyncResultExtensionsRightOperand
     {
         /// <summary>
         ///     Executes the given action if the calling result is a failure. Returns the calling result.
         /// </summary>
-        public static async ValueTask<Result<T>> OnFailure<T>(this Result<T> result, Func<ValueTask> func)
+        public static async ValueTask<Result<T>> OnFailure<T>(this Result<T> result, Func<ValueTask> valueTask)
         {
             if (result.IsFailure)
             {
-                await func();
+                await valueTask();
             }
 
             return result;
@@ -22,11 +22,11 @@ namespace CSharpFunctionalExtensions
         /// <summary>
         ///     Executes the given action if the calling result is a failure. Returns the calling result.
         /// </summary>
-        public static async ValueTask<Result<T, E>> OnFailure<T, E>(this Result<T, E> result, Func<ValueTask> func)
+        public static async ValueTask<Result<T, E>> OnFailure<T, E>(this Result<T, E> result, Func<ValueTask> valueTask)
         {
             if (result.IsFailure)
             {
-                await func();
+                await valueTask();
             }
 
             return result;
@@ -35,11 +35,11 @@ namespace CSharpFunctionalExtensions
         /// <summary>
         ///     Executes the given action if the calling result is a failure. Returns the calling result.
         /// </summary>
-        public static async ValueTask<Result> OnFailure(this Result result, Func<ValueTask> func)
+        public static async ValueTask<Result> OnFailure(this Result result, Func<ValueTask> valueTask)
         {
             if (result.IsFailure)
             {
-                await func();
+                await valueTask();
             }
 
             return result;
@@ -48,11 +48,11 @@ namespace CSharpFunctionalExtensions
         /// <summary>
         ///     Executes the given action if the calling result is a failure. Returns the calling result.
         /// </summary>
-        public static async ValueTask<Result> OnFailure(this Result result, Func<string, ValueTask> func)
+        public static async ValueTask<Result> OnFailure(this Result result, Func<string, ValueTask> valueTask)
         {
             if (result.IsFailure)
             {
-                await func(result.Error);
+                await valueTask(result.Error);
             }
 
             return result;
@@ -61,11 +61,11 @@ namespace CSharpFunctionalExtensions
         /// <summary>
         ///     Executes the given action if the calling result is a failure. Returns the calling result.
         /// </summary>
-        public static async ValueTask<UnitResult<E>> OnFailure<E>(this UnitResult<E> result, Func<ValueTask> func)
+        public static async ValueTask<UnitResult<E>> OnFailure<E>(this UnitResult<E> result, Func<ValueTask> valueTask)
         {
             if (result.IsFailure)
             {
-                await func();
+                await valueTask();
             }
 
             return result;
@@ -74,11 +74,11 @@ namespace CSharpFunctionalExtensions
         /// <summary>
         ///     Executes the given action if the calling result is a failure. Returns the calling result.
         /// </summary>
-        public static async ValueTask<UnitResult<E>> OnFailure<E>(this UnitResult<E> result, Func<E, ValueTask> func)
+        public static async ValueTask<UnitResult<E>> OnFailure<E>(this UnitResult<E> result, Func<E, ValueTask> valueTask)
         {
             if (result.IsFailure)
             {
-                await func(result.Error);
+                await valueTask(result.Error);
             }
 
             return result;
@@ -87,11 +87,11 @@ namespace CSharpFunctionalExtensions
         /// <summary>
         ///     Executes the given action if the calling result is a failure. Returns the calling result.
         /// </summary>
-        public static async ValueTask<Result<T>> OnFailure<T>(this Result<T> result, Func<string, ValueTask> func)
+        public static async ValueTask<Result<T>> OnFailure<T>(this Result<T> result, Func<string, ValueTask> valueTask)
         {
             if (result.IsFailure)
             {
-                await func(result.Error);
+                await valueTask(result.Error);
             }
 
             return result;
@@ -100,11 +100,11 @@ namespace CSharpFunctionalExtensions
         /// <summary>
         ///     Executes the given action if the calling result is a failure. Returns the calling result.
         /// </summary>
-        public static async ValueTask<Result<T, E>> OnFailure<T, E>(this Result<T, E> result, Func<E, ValueTask> func)
+        public static async ValueTask<Result<T, E>> OnFailure<T, E>(this Result<T, E> result, Func<E, ValueTask> valueTask)
         {
             if (result.IsFailure)
             {
-                await func(result.Error);
+                await valueTask(result.Error);
             }
 
             return result;

--- a/CSharpFunctionalExtensions/Result/Methods/Extensions/OnFailure.ValueTask.cs
+++ b/CSharpFunctionalExtensions/Result/Methods/Extensions/OnFailure.ValueTask.cs
@@ -2,20 +2,20 @@
 using System;
 using System.Threading.Tasks;
 
-namespace CSharpFunctionalExtensions
+namespace CSharpFunctionalExtensions.ValueTasks
 {
     public static partial class AsyncResultExtensionsBothOperands
     {
         /// <summary>
         ///     Executes the given action if the calling result is a failure. Returns the calling result.
         /// </summary>
-        public static async ValueTask<Result<T, E>> OnFailure<T, E>(this ValueTask<Result<T, E>> resultTask, Func<ValueTask> func)
+        public static async ValueTask<Result<T, E>> OnFailure<T, E>(this ValueTask<Result<T, E>> resultTask, Func<ValueTask> valueTask)
         {
             Result<T, E> result = await resultTask;
 
             if (result.IsFailure)
             {
-                await func();
+                await valueTask();
             }
 
             return result;
@@ -24,13 +24,13 @@ namespace CSharpFunctionalExtensions
         /// <summary>
         ///     Executes the given action if the calling result is a failure. Returns the calling result.
         /// </summary>
-        public static async ValueTask<Result<T>> OnFailure<T>(this ValueTask<Result<T>> resultTask, Func<ValueTask> func)
+        public static async ValueTask<Result<T>> OnFailure<T>(this ValueTask<Result<T>> resultTask, Func<ValueTask> valueTask)
         {
             Result<T> result = await resultTask;
 
             if (result.IsFailure)
             {
-                await func();
+                await valueTask();
             }
 
             return result;
@@ -39,13 +39,13 @@ namespace CSharpFunctionalExtensions
         /// <summary>
         ///     Executes the given action if the calling result is a failure. Returns the calling result.
         /// </summary>
-        public static async ValueTask<Result> OnFailure(this ValueTask<Result> resultTask, Func<ValueTask> func)
+        public static async ValueTask<Result> OnFailure(this ValueTask<Result> resultTask, Func<ValueTask> valueTask)
         {
             Result result = await resultTask;
 
             if (result.IsFailure)
             {
-                await func();
+                await valueTask();
             }
 
             return result;
@@ -54,13 +54,13 @@ namespace CSharpFunctionalExtensions
         /// <summary>
         ///     Executes the given action if the calling result is a failure. Returns the calling result.
         /// </summary>
-        public static async ValueTask<Result> OnFailure(this ValueTask<Result> resultTask, Func<string, ValueTask> func)
+        public static async ValueTask<Result> OnFailure(this ValueTask<Result> resultTask, Func<string, ValueTask> valueTask)
         {
             Result result = await resultTask;
 
             if (result.IsFailure)
             {
-                await func(result.Error);
+                await valueTask(result.Error);
             }
 
             return result;
@@ -69,13 +69,13 @@ namespace CSharpFunctionalExtensions
         /// <summary>
         ///     Executes the given action if the calling result is a failure. Returns the calling result.
         /// </summary>
-        public static async ValueTask<UnitResult<E>> OnFailure<E>(this ValueTask<UnitResult<E>> resultTask, Func<E, ValueTask> func)
+        public static async ValueTask<UnitResult<E>> OnFailure<E>(this ValueTask<UnitResult<E>> resultTask, Func<E, ValueTask> valueTask)
         {
             UnitResult<E> result = await resultTask;
 
             if (result.IsFailure)
             {
-                await func(result.Error);
+                await valueTask(result.Error);
             }
 
             return result;
@@ -84,13 +84,13 @@ namespace CSharpFunctionalExtensions
         /// <summary>
         ///     Executes the given action if the calling result is a failure. Returns the calling result.
         /// </summary>
-        public static async ValueTask<UnitResult<E>> OnFailure<E>(this ValueTask<UnitResult<E>> resultTask, Func<ValueTask> func)
+        public static async ValueTask<UnitResult<E>> OnFailure<E>(this ValueTask<UnitResult<E>> resultTask, Func<ValueTask> valueTask)
         {
             UnitResult<E> result = await resultTask;
 
             if (result.IsFailure)
             {
-                await func();
+                await valueTask();
             }
 
             return result;
@@ -99,13 +99,13 @@ namespace CSharpFunctionalExtensions
         /// <summary>
         ///     Executes the given action if the calling result is a failure. Returns the calling result.
         /// </summary>
-        public static async ValueTask<Result<T>> OnFailure<T>(this ValueTask<Result<T>> resultTask, Func<string, ValueTask> func)
+        public static async ValueTask<Result<T>> OnFailure<T>(this ValueTask<Result<T>> resultTask, Func<string, ValueTask> valueTask)
         {
             Result<T> result = await resultTask;
 
             if (result.IsFailure)
             {
-                await func(result.Error);
+                await valueTask(result.Error);
             }
 
             return result;
@@ -114,13 +114,13 @@ namespace CSharpFunctionalExtensions
         /// <summary>
         ///     Executes the given action if the calling result is a failure. Returns the calling result.
         /// </summary>
-        public static async ValueTask<Result<T, E>> OnFailure<T, E>(this ValueTask<Result<T, E>> resultTask, Func<E, ValueTask> func)
+        public static async ValueTask<Result<T, E>> OnFailure<T, E>(this ValueTask<Result<T, E>> resultTask, Func<E, ValueTask> valueTask)
         {
             Result<T, E> result = await resultTask;
 
             if (result.IsFailure)
             {
-                await func(result.Error);
+                await valueTask(result.Error);
             }
 
             return result;

--- a/CSharpFunctionalExtensions/Result/Methods/Extensions/OnFailureCompensate.ValueTask.Left.cs
+++ b/CSharpFunctionalExtensions/Result/Methods/Extensions/OnFailureCompensate.ValueTask.Left.cs
@@ -2,46 +2,46 @@
 using System;
 using System.Threading.Tasks;
 
-namespace CSharpFunctionalExtensions
+namespace CSharpFunctionalExtensions.ValueTasks
 {
     public static partial class AsyncResultExtensionsLeftOperand
     {
       public static async ValueTask<Result<T, E>> OnFailureCompensate<T, E>(this ValueTask<Result<T, E>> resultTask,
-            Func<Result<T, E>> func)
+            Func<Result<T, E>> valueTask)
         {
             Result<T, E> result = await resultTask;
-            return result.OnFailureCompensate(func);
+            return result.OnFailureCompensate(valueTask);
         }
         
-        public static async ValueTask<Result<T>> OnFailureCompensate<T>(this ValueTask<Result<T>> resultTask, Func<Result<T>> func)
+        public static async ValueTask<Result<T>> OnFailureCompensate<T>(this ValueTask<Result<T>> resultTask, Func<Result<T>> valueTask)
         {
             Result<T> result = await resultTask;
-            return result.OnFailureCompensate(func);
+            return result.OnFailureCompensate(valueTask);
         }
 
-        public static async ValueTask<Result> OnFailureCompensate(this ValueTask<Result> resultTask, Func<Result> func)
+        public static async ValueTask<Result> OnFailureCompensate(this ValueTask<Result> resultTask, Func<Result> valueTask)
         {
             Result result = await resultTask;
-            return result.OnFailureCompensate(func);
+            return result.OnFailureCompensate(valueTask);
         }
 
-        public static async ValueTask<Result<T>> OnFailureCompensate<T>(this ValueTask<Result<T>> resultTask, Func<string, Result<T>> func)
+        public static async ValueTask<Result<T>> OnFailureCompensate<T>(this ValueTask<Result<T>> resultTask, Func<string, Result<T>> valueTask)
         {
             Result<T> result = await resultTask;
-            return result.OnFailureCompensate(func);
+            return result.OnFailureCompensate(valueTask);
         }
 
         public static async ValueTask<Result<T, E>> OnFailureCompensate<T, E>(this ValueTask<Result<T, E>> resultTask,
-            Func<E, Result<T, E>> func)
+            Func<E, Result<T, E>> valueTask)
         {
             Result<T, E> result = await resultTask;
-            return result.OnFailureCompensate(func);
+            return result.OnFailureCompensate(valueTask);
         }
 
-        public static async ValueTask<Result> OnFailureCompensate(this ValueTask<Result> resultTask, Func<string, Result> func)
+        public static async ValueTask<Result> OnFailureCompensate(this ValueTask<Result> resultTask, Func<string, Result> valueTask)
         {
             Result result = await resultTask;
-            return result.OnFailureCompensate(func);
+            return result.OnFailureCompensate(valueTask);
         }
     }
 }

--- a/CSharpFunctionalExtensions/Result/Methods/Extensions/OnFailureCompensate.ValueTask.Right.cs
+++ b/CSharpFunctionalExtensions/Result/Methods/Extensions/OnFailureCompensate.ValueTask.Right.cs
@@ -2,55 +2,55 @@
 using System;
 using System.Threading.Tasks;
 
-namespace CSharpFunctionalExtensions
+namespace CSharpFunctionalExtensions.ValueTasks
 {
     public static partial class AsyncResultExtensionsRightOperand
     {
-        public static async ValueTask<Result<T>> OnFailureCompensate<T>(this Result<T> result, Func<ValueTask<Result<T>>> func)
+        public static async ValueTask<Result<T>> OnFailureCompensate<T>(this Result<T> result, Func<ValueTask<Result<T>>> valueTask)
         {
             if (result.IsFailure)
-                return await func();
+                return await valueTask();
 
             return result;
         }
 
-        public static async ValueTask<Result<T, E>> OnFailureCompensate<T, E>(this Result<T, E> result, Func<ValueTask<Result<T, E>>> func)
+        public static async ValueTask<Result<T, E>> OnFailureCompensate<T, E>(this Result<T, E> result, Func<ValueTask<Result<T, E>>> valueTask)
         {
             if (result.IsFailure)
-                return await func();
+                return await valueTask();
 
             return result;
         }
 
-        public static async ValueTask<Result> OnFailureCompensate(this Result result, Func<ValueTask<Result>> func)
+        public static async ValueTask<Result> OnFailureCompensate(this Result result, Func<ValueTask<Result>> valueTask)
         {
             if (result.IsFailure)
-                return await func();
+                return await valueTask();
 
             return result;
         }
 
-        public static async ValueTask<Result<T>> OnFailureCompensate<T>(this Result<T> result, Func<string, ValueTask<Result<T>>> func)
+        public static async ValueTask<Result<T>> OnFailureCompensate<T>(this Result<T> result, Func<string, ValueTask<Result<T>>> valueTask)
         {
             if (result.IsFailure)
-                return await func(result.Error);
+                return await valueTask(result.Error);
 
             return result;
         }
 
         public static async ValueTask<Result<T, E>> OnFailureCompensate<T, E>(this Result<T, E> result,
-            Func<E, ValueTask<Result<T, E>>> func)
+            Func<E, ValueTask<Result<T, E>>> valueTask)
         {
             if (result.IsFailure)
-                return await func(result.Error);
+                return await valueTask(result.Error);
 
             return result;
         }
         
-        public static async ValueTask<Result> OnFailureCompensate(this Result result, Func<string, ValueTask<Result>> func)
+        public static async ValueTask<Result> OnFailureCompensate(this Result result, Func<string, ValueTask<Result>> valueTask)
         {
             if (result.IsFailure)
-                return await func(result.Error);
+                return await valueTask(result.Error);
 
             return result;
         }

--- a/CSharpFunctionalExtensions/Result/Methods/Extensions/OnFailureCompensate.ValueTask.cs
+++ b/CSharpFunctionalExtensions/Result/Methods/Extensions/OnFailureCompensate.ValueTask.cs
@@ -2,69 +2,69 @@
 using System;
 using System.Threading.Tasks;
 
-namespace CSharpFunctionalExtensions
+namespace CSharpFunctionalExtensions.ValueTasks
 {
     public static partial class AsyncResultExtensionsBothOperands
     {
        public static async ValueTask<Result<T, E>> OnFailureCompensate<T, E>(this ValueTask<Result<T, E>> resultTask,
-            Func<ValueTask<Result<T, E>>> func)
+            Func<ValueTask<Result<T, E>>> valueTask)
         {
             Result<T, E> result = await resultTask;
 
             if (result.IsFailure)
-                return await func();
+                return await valueTask();
 
             return result;
         }
 
-        public static async ValueTask<Result<T>> OnFailureCompensate<T>(this ValueTask<Result<T>> resultTask, Func<ValueTask<Result<T>>> func)
+        public static async ValueTask<Result<T>> OnFailureCompensate<T>(this ValueTask<Result<T>> resultTask, Func<ValueTask<Result<T>>> valueTask)
         {
             Result<T> result = await resultTask;
 
             if (result.IsFailure)
-                return await func();
+                return await valueTask();
 
             return result;
         }
 
-        public static async ValueTask<Result> OnFailureCompensate(this ValueTask<Result> resultTask, Func<ValueTask<Result>> func)
+        public static async ValueTask<Result> OnFailureCompensate(this ValueTask<Result> resultTask, Func<ValueTask<Result>> valueTask)
         {
             Result result = await resultTask;
 
             if (result.IsFailure)
-                return await func();
+                return await valueTask();
 
             return result;
         }
         
         
-        public static async ValueTask<Result<T>> OnFailureCompensate<T>(this ValueTask<Result<T>> resultTask, Func<string, ValueTask<Result<T>>> func)
+        public static async ValueTask<Result<T>> OnFailureCompensate<T>(this ValueTask<Result<T>> resultTask, Func<string, ValueTask<Result<T>>> valueTask)
         {
             Result<T> result = await resultTask;
 
             if (result.IsFailure)
-                return await func(result.Error);
+                return await valueTask(result.Error);
 
             return result;
         }
 
         public static async ValueTask<Result<T, E>> OnFailureCompensate<T, E>(this ValueTask<Result<T, E>> resultTask,
-            Func<E, ValueTask<Result<T, E>>> func)
+            Func<E, ValueTask<Result<T, E>>> valueTask)
         {
             Result<T, E> result = await resultTask;
 
             if (result.IsFailure)
-                return await func(result.Error);
+                return await valueTask(result.Error);
 
             return result;
         }
 
-        public static async ValueTask<Result> OnFailureCompensate(this ValueTask<Result> resultTask, Func<string, ValueTask<Result>> func)
+        public static async ValueTask<Result> OnFailureCompensate(this ValueTask<Result> resultTask, Func<string, ValueTask<Result>> valueTask)
         {
             Result result = await resultTask;
             
             if (result.IsFailure)
-                return await func(result.Error);
+                return await valueTask(result.Error);
 
             return result;
         }

--- a/CSharpFunctionalExtensions/Result/Methods/Extensions/OnSuccessTry.ValueTask.Left.cs
+++ b/CSharpFunctionalExtensions/Result/Methods/Extensions/OnSuccessTry.ValueTask.Left.cs
@@ -2,7 +2,7 @@
 using System;
 using System.Threading.Tasks;
 
-namespace CSharpFunctionalExtensions
+namespace CSharpFunctionalExtensions.ValueTasks
 {
     public static partial class ResultExtensions
     {

--- a/CSharpFunctionalExtensions/Result/Methods/Extensions/OnSuccessTry.ValueTask.Right.cs
+++ b/CSharpFunctionalExtensions/Result/Methods/Extensions/OnSuccessTry.ValueTask.Right.cs
@@ -2,56 +2,56 @@
 using System;
 using System.Threading.Tasks;
 
-namespace CSharpFunctionalExtensions
+namespace CSharpFunctionalExtensions.ValueTasks
 {
     public static partial class ResultExtensions
     {
-        public static async ValueTask<Result> OnSuccessTry(this Result result, Func<ValueTask> func,
+        public static async ValueTask<Result> OnSuccessTry(this Result result, Func<ValueTask> valueTask,
             Func<Exception, string> errorHandler = null)
         {
             return result.IsFailure
                 ? result
-                : await Result.Try(func, errorHandler);
+                : await Result.Try(valueTask, errorHandler);
         }
 
-        public static async ValueTask<Result<T>> OnSuccessTry<T>(this Result result, Func<ValueTask<T>> func,
+        public static async ValueTask<Result<T>> OnSuccessTry<T>(this Result result, Func<ValueTask<T>> valueTask,
             Func<Exception, string> errorHandler = null)
         {
             return result.IsFailure
                 ? Result.Failure<T>(result.Error)
-                : await Result.Try(func, errorHandler);
+                : await Result.Try(valueTask, errorHandler);
         }
 
-        public static async ValueTask<Result<T, E>> OnSuccessTry<T, E>(this Result<T, E> result, Func<ValueTask<T>> func,
+        public static async ValueTask<Result<T, E>> OnSuccessTry<T, E>(this Result<T, E> result, Func<ValueTask<T>> valueTask,
             Func<Exception, E> errorHandler = null)
         {
             return result.IsFailure
                 ? Result.Failure<T, E>(result.Error)
-                : await Result.Try(func, errorHandler);
+                : await Result.Try(valueTask, errorHandler);
         }
 
-        public static async ValueTask<Result> OnSuccessTry<T>(this Result<T> result, Func<T, ValueTask> func,
+        public static async ValueTask<Result> OnSuccessTry<T>(this Result<T> result, Func<T, ValueTask> valueTask,
             Func<Exception, string> errorHandler = null)
         {
             return result.IsFailure
                 ? Result.Failure(result.Error)
-                : await Result.Try(() => func.Invoke(result.Value), errorHandler);
+                : await Result.Try(() => valueTask.Invoke(result.Value), errorHandler);
         }
 
-        public static async ValueTask<Result<K>> OnSuccessTry<T, K>(this Result<T> result, Func<T, ValueTask<K>> func,
+        public static async ValueTask<Result<K>> OnSuccessTry<T, K>(this Result<T> result, Func<T, ValueTask<K>> valueTask,
             Func<Exception, string> errorHandler = null)
         {
             return result.IsFailure
                 ? Result.Failure<K>(result.Error)
-                : await Result.Try(() => func.Invoke(result.Value), errorHandler);
+                : await Result.Try(() => valueTask.Invoke(result.Value), errorHandler);
         }
 
-        public static async ValueTask<Result<K, E>> OnSuccessTry<T, K, E>(this Result<T, E> result, Func<T, ValueTask<K>> func,
+        public static async ValueTask<Result<K, E>> OnSuccessTry<T, K, E>(this Result<T, E> result, Func<T, ValueTask<K>> valueTask,
             Func<Exception, E> errorHandler = null)
         {
             return result.IsFailure
                 ? Result.Failure<K, E>(result.Error)
-                : await Result.Try(() => func.Invoke(result.Value), errorHandler);
+                : await Result.Try(() => valueTask.Invoke(result.Value), errorHandler);
         }
     }
 }

--- a/CSharpFunctionalExtensions/Result/Methods/Extensions/OnSuccessTry.ValueTask.cs
+++ b/CSharpFunctionalExtensions/Result/Methods/Extensions/OnSuccessTry.ValueTask.cs
@@ -2,50 +2,50 @@
 using System;
 using System.Threading.Tasks;
 
-namespace CSharpFunctionalExtensions
+namespace CSharpFunctionalExtensions.ValueTasks
 {
     public static partial class ResultExtensions
     {
-        public static async ValueTask<Result> OnSuccessTry(this ValueTask<Result> task, Func<Task> func,
+        public static async ValueTask<Result> OnSuccessTry(this ValueTask<Result> task, Func<ValueTask> valueTask,
             Func<Exception, string> errorHandler = null)
         {
             var result = await task;
-            return await result.OnSuccessTry(func, errorHandler).DefaultAwait();
+            return await result.OnSuccessTry(valueTask, errorHandler);
         }
 
-        public static async ValueTask<Result<T>> OnSuccessTry<T>(this ValueTask<Result> task, Func<ValueTask<T>> func,
+        public static async ValueTask<Result<T>> OnSuccessTry<T>(this ValueTask<Result> task, Func<ValueTask<T>> valueTask,
             Func<Exception, string> errorHandler = null)
         {
             var result = await task;
-            return await result.OnSuccessTry(func, errorHandler);
+            return await result.OnSuccessTry(valueTask, errorHandler);
         }
 
-        public static async ValueTask<Result<T, E>> OnSuccessTry<T, E>(this ValueTask<Result<T, E>> task, Func<ValueTask<T>> func,
+        public static async ValueTask<Result<T, E>> OnSuccessTry<T, E>(this ValueTask<Result<T, E>> task, Func<ValueTask<T>> valueTask,
             Func<Exception, E> errorHandler = null)
         {
             var result = await task;
-            return await result.OnSuccessTry(func, errorHandler);
+            return await result.OnSuccessTry(valueTask, errorHandler);
         }
 
-        public static async ValueTask<Result> OnSuccessTry<T>(this ValueTask<Result<T>> task, Func<T, ValueTask> func,
+        public static async ValueTask<Result> OnSuccessTry<T>(this ValueTask<Result<T>> task, Func<T, ValueTask> valueTask,
             Func<Exception, string> errorHandler = null)
         {
             var result = await task;
-            return await result.OnSuccessTry(func, errorHandler);
+            return await result.OnSuccessTry(valueTask, errorHandler);
         }
 
-        public static async ValueTask<Result<K>> OnSuccessTry<T, K>(this ValueTask<Result<T>> task, Func<T, ValueTask<K>> func,
+        public static async ValueTask<Result<K>> OnSuccessTry<T, K>(this ValueTask<Result<T>> task, Func<T, ValueTask<K>> valueTask,
             Func<Exception, string> errorHandler = null)
         {
             var result = await task;
-            return await result.OnSuccessTry(func, errorHandler);
+            return await result.OnSuccessTry(valueTask, errorHandler);
         }
         
-        public static async ValueTask<Result<K, E>> OnSuccessTry<T, K, E>(this ValueTask<Result<T, E>> task, Func<T, ValueTask<K>> func,
+        public static async ValueTask<Result<K, E>> OnSuccessTry<T, K, E>(this ValueTask<Result<T, E>> task, Func<T, ValueTask<K>> valueTask,
             Func<Exception, E> errorHandler = null)
         {
             var result = await task;
-            return await result.OnSuccessTry(func, errorHandler);
+            return await result.OnSuccessTry(valueTask, errorHandler);
         }
     }
 }

--- a/CSharpFunctionalExtensions/Result/Methods/Extensions/SelectMany.ValueTask.Left.cs
+++ b/CSharpFunctionalExtensions/Result/Methods/Extensions/SelectMany.ValueTask.Left.cs
@@ -2,7 +2,7 @@
 using System;
 using System.Threading.Tasks;
 
-namespace CSharpFunctionalExtensions
+namespace CSharpFunctionalExtensions.ValueTasks
 {
     public static partial class ResultExtensions
     {
@@ -11,11 +11,11 @@ namespace CSharpFunctionalExtensions
         /// </summary>
         public static async ValueTask<Result<TR>> SelectMany<T, TK, TR>(
             this ValueTask<Result<T>> resultTask,
-            Func<T, Result<TK>> func,
+            Func<T, Result<TK>> valueTask,
             Func<T, TK, TR> project)
         {
             Result<T> result = await resultTask;
-            return result.SelectMany(func, project);
+            return result.SelectMany(valueTask, project);
         }
 
         /// <summary>
@@ -23,11 +23,11 @@ namespace CSharpFunctionalExtensions
         /// </summary>
         public static async ValueTask<Result<TR, TE>> SelectMany<T, TK, TE, TR>(
             this ValueTask<Result<T, TE>> resultTask,
-            Func<T, Result<TK, TE>> func,
+            Func<T, Result<TK, TE>> valueTask,
             Func<T, TK, TR> project)
         {
             Result<T, TE> result = await resultTask;
-            return result.SelectMany(func, project);
+            return result.SelectMany(valueTask, project);
         }
     }
 }

--- a/CSharpFunctionalExtensions/Result/Methods/Extensions/SelectMany.ValueTask.Right.cs
+++ b/CSharpFunctionalExtensions/Result/Methods/Extensions/SelectMany.ValueTask.Right.cs
@@ -2,7 +2,7 @@
 using System;
 using System.Threading.Tasks;
 
-namespace CSharpFunctionalExtensions
+namespace CSharpFunctionalExtensions.ValueTasks
 {
     public static partial class ResultExtensions
     {
@@ -11,11 +11,11 @@ namespace CSharpFunctionalExtensions
         /// </summary>
         public static ValueTask<Result<TR>> SelectMany<T, TK, TR>(
             this Result<T> result,
-            Func<T, ValueTask<Result<TK>>> func,
+            Func<T, ValueTask<Result<TK>>> valueTask,
             Func<T, TK, TR> project)
         {
             return result
-                .Bind(func)
+                .Bind(valueTask)
                 .Map(x => project(result.Value, x));
         }
 
@@ -24,11 +24,11 @@ namespace CSharpFunctionalExtensions
         /// </summary>
         public static ValueTask<Result<TR, TE>> SelectMany<T, TK, TE, TR>(
             this Result<T, TE> result,
-            Func<T, ValueTask<Result<TK, TE>>> func,
+            Func<T, ValueTask<Result<TK, TE>>> valueTask,
             Func<T, TK, TR> project)
         {
             return result
-                .Bind(func)
+                .Bind(valueTask)
                 .Map(x => project(result.Value, x));
         }
     }

--- a/CSharpFunctionalExtensions/Result/Methods/Extensions/SelectMany.ValueTask.cs
+++ b/CSharpFunctionalExtensions/Result/Methods/Extensions/SelectMany.ValueTask.cs
@@ -2,7 +2,7 @@
 using System;
 using System.Threading.Tasks;
 
-namespace CSharpFunctionalExtensions
+namespace CSharpFunctionalExtensions.ValueTasks
 {
     public static partial class ResultExtensions
     {
@@ -11,11 +11,11 @@ namespace CSharpFunctionalExtensions
         /// </summary>
         public static async ValueTask<Result<TR>> SelectMany<T, TK, TR>(
             this ValueTask<Result<T>> resultTask,
-            Func<T, ValueTask<Result<TK>>> func,
+            Func<T, ValueTask<Result<TK>>> valueTask,
             Func<T, TK, TR> project)
         {
             Result<T> result = await resultTask;
-            return await result.SelectMany(func, project);
+            return await result.SelectMany(valueTask, project);
         }
 
         /// <summary>
@@ -23,11 +23,11 @@ namespace CSharpFunctionalExtensions
         /// </summary>
         public static async ValueTask<Result<TR, TE>> SelectMany<T, TK, TE, TR>(
             this ValueTask<Result<T, TE>> resultTask,
-            Func<T, ValueTask<Result<TK, TE>>> func,
+            Func<T, ValueTask<Result<TK, TE>>> valueTask,
             Func<T, TK, TR> project)
         {
             Result<T, TE> result = await resultTask;
-            return await result.SelectMany(func, project);
+            return await result.SelectMany(valueTask, project);
         }
     }
 }

--- a/CSharpFunctionalExtensions/Result/Methods/Extensions/Tap.ValueTask.Left.cs
+++ b/CSharpFunctionalExtensions/Result/Methods/Extensions/Tap.ValueTask.Left.cs
@@ -2,7 +2,7 @@
 using System;
 using System.Threading.Tasks;
 
-namespace CSharpFunctionalExtensions
+namespace CSharpFunctionalExtensions.ValueTasks
 {
     public static partial class AsyncResultExtensionsLeftOperand
     {

--- a/CSharpFunctionalExtensions/Result/Methods/Extensions/Tap.ValueTask.Right.cs
+++ b/CSharpFunctionalExtensions/Result/Methods/Extensions/Tap.ValueTask.Right.cs
@@ -2,17 +2,17 @@
 using System;
 using System.Threading.Tasks;
 
-namespace CSharpFunctionalExtensions
+namespace CSharpFunctionalExtensions.ValueTasks
 {
     public static partial class AsyncResultExtensionsRightOperand
     {
         /// <summary>
         ///     Executes the given action if the calling result is a success. Returns the calling result.
         /// </summary>
-        public static async ValueTask<Result> Tap(this Result result, Func<ValueTask> func)
+        public static async ValueTask<Result> Tap(this Result result, Func<ValueTask> valueTask)
         {
             if (result.IsSuccess)
-                await func();
+                await valueTask();
 
             return result;
         }
@@ -20,10 +20,10 @@ namespace CSharpFunctionalExtensions
         /// <summary>
         ///     Executes the given action if the calling result is a success. Returns the calling result.
         /// </summary>
-        public static async ValueTask<Result<T>> Tap<T>(this Result<T> result, Func<ValueTask> func)
+        public static async ValueTask<Result<T>> Tap<T>(this Result<T> result, Func<ValueTask> valueTask)
         {
             if (result.IsSuccess)
-                await func();
+                await valueTask();
 
             return result;
         }
@@ -31,10 +31,10 @@ namespace CSharpFunctionalExtensions
         /// <summary>
         ///     Executes the given action if the calling result is a success. Returns the calling result.
         /// </summary>
-        public static async ValueTask<Result<T>> Tap<T>(this Result<T> result, Func<T, ValueTask> func)
+        public static async ValueTask<Result<T>> Tap<T>(this Result<T> result, Func<T, ValueTask> valueTask)
         {
             if (result.IsSuccess)
-                await func(result.Value);
+                await valueTask(result.Value);
 
             return result;
         }
@@ -42,10 +42,10 @@ namespace CSharpFunctionalExtensions
         /// <summary>
         ///     Executes the given action if the calling result is a success. Returns the calling result.
         /// </summary>
-        public static async ValueTask<UnitResult<E>> Tap<E>(this UnitResult<E> result, Func<ValueTask> func)
+        public static async ValueTask<UnitResult<E>> Tap<E>(this UnitResult<E> result, Func<ValueTask> valueTask)
         {
             if (result.IsSuccess)
-                await func();
+                await valueTask();
 
             return result;
         }
@@ -53,10 +53,10 @@ namespace CSharpFunctionalExtensions
         /// <summary>
         ///     Executes the given action if the calling result is a success. Returns the calling result.
         /// </summary>
-        public static async ValueTask<Result<T, E>> Tap<T, E>(this Result<T, E> result, Func<ValueTask> func)
+        public static async ValueTask<Result<T, E>> Tap<T, E>(this Result<T, E> result, Func<ValueTask> valueTask)
         {
             if (result.IsSuccess)
-                await func();
+                await valueTask();
 
             return result;
         }
@@ -64,10 +64,10 @@ namespace CSharpFunctionalExtensions
         /// <summary>
         ///     Executes the given action if the calling result is a success. Returns the calling result.
         /// </summary>
-        public static async ValueTask<Result<T, E>> Tap<T, E>(this Result<T, E> result, Func<T, ValueTask> func)
+        public static async ValueTask<Result<T, E>> Tap<T, E>(this Result<T, E> result, Func<T, ValueTask> valueTask)
         {
             if (result.IsSuccess)
-                await func(result.Value);
+                await valueTask(result.Value);
 
             return result;
         }

--- a/CSharpFunctionalExtensions/Result/Methods/Extensions/Tap.ValueTask.cs
+++ b/CSharpFunctionalExtensions/Result/Methods/Extensions/Tap.ValueTask.cs
@@ -2,19 +2,19 @@
 using System;
 using System.Threading.Tasks;
 
-namespace CSharpFunctionalExtensions
+namespace CSharpFunctionalExtensions.ValueTasks
 {
     public static partial class AsyncResultExtensionsBothOperands
     {
         /// <summary>
         ///     Executes the given action if the calling result is a success. Returns the calling result.
         /// </summary>
-        public static async ValueTask<Result> Tap(this ValueTask<Result> resultTask, Func<ValueTask> func)
+        public static async ValueTask<Result> Tap(this ValueTask<Result> resultTask, Func<ValueTask> valueTask)
         {
             Result result = await resultTask;
 
             if (result.IsSuccess)
-                await func();
+                await valueTask();
 
             return result;
         }
@@ -22,12 +22,12 @@ namespace CSharpFunctionalExtensions
         /// <summary>
         ///     Executes the given action if the calling result is a success. Returns the calling result.
         /// </summary>
-        public static async ValueTask<Result<T>> Tap<T>(this ValueTask<Result<T>> resultTask, Func<ValueTask> func)
+        public static async ValueTask<Result<T>> Tap<T>(this ValueTask<Result<T>> resultTask, Func<ValueTask> valueTask)
         {
             Result<T> result = await resultTask;
 
             if (result.IsSuccess)
-                await func();
+                await valueTask();
 
             return result;
         }
@@ -35,12 +35,12 @@ namespace CSharpFunctionalExtensions
         /// <summary>
         ///     Executes the given action if the calling result is a success. Returns the calling result.
         /// </summary>
-        public static async ValueTask<Result<T>> Tap<T>(this ValueTask<Result<T>> resultTask, Func<T, ValueTask> func)
+        public static async ValueTask<Result<T>> Tap<T>(this ValueTask<Result<T>> resultTask, Func<T, ValueTask> valueTask)
         {
             Result<T> result = await resultTask;
 
             if (result.IsSuccess)
-                await func(result.Value);
+                await valueTask(result.Value);
 
             return result;
         }
@@ -48,12 +48,12 @@ namespace CSharpFunctionalExtensions
         /// <summary>
         ///     Executes the given action if the calling result is a success. Returns the calling result.
         /// </summary>
-        public static async ValueTask<UnitResult<E>> Tap<E>(this ValueTask<UnitResult<E>> resultTask, Func<ValueTask> func)
+        public static async ValueTask<UnitResult<E>> Tap<E>(this ValueTask<UnitResult<E>> resultTask, Func<ValueTask> valueTask)
         {
             UnitResult<E> result = await resultTask;
 
             if (result.IsSuccess)
-                await func();
+                await valueTask();
 
             return result;
         }
@@ -61,12 +61,12 @@ namespace CSharpFunctionalExtensions
         /// <summary>
         ///     Executes the given action if the calling result is a success. Returns the calling result.
         /// </summary>
-        public static async ValueTask<Result<T, E>> Tap<T, E>(this ValueTask<Result<T, E>> resultTask, Func<ValueTask> func)
+        public static async ValueTask<Result<T, E>> Tap<T, E>(this ValueTask<Result<T, E>> resultTask, Func<ValueTask> valueTask)
         {
             Result<T, E> result = await resultTask;
 
             if (result.IsSuccess)
-                await func();
+                await valueTask();
 
             return result;
         }
@@ -74,12 +74,12 @@ namespace CSharpFunctionalExtensions
         /// <summary>
         ///     Executes the given action if the calling result is a success. Returns the calling result.
         /// </summary>
-        public static async ValueTask<Result<T, E>> Tap<T, E>(this ValueTask<Result<T, E>> resultTask, Func<T, ValueTask> func)
+        public static async ValueTask<Result<T, E>> Tap<T, E>(this ValueTask<Result<T, E>> resultTask, Func<T, ValueTask> valueTask)
         {
             Result<T, E> result = await resultTask;
 
             if (result.IsSuccess)
-                await func(result.Value);
+                await valueTask(result.Value);
 
             return result;
         }

--- a/CSharpFunctionalExtensions/Result/Methods/Extensions/TapIf.ValueTask.Left.cs
+++ b/CSharpFunctionalExtensions/Result/Methods/Extensions/TapIf.ValueTask.Left.cs
@@ -2,7 +2,7 @@
 using System;
 using System.Threading.Tasks;
 
-namespace CSharpFunctionalExtensions
+namespace CSharpFunctionalExtensions.ValueTasks
 {
     public static partial class AsyncResultExtensionsLeftOperand
     {

--- a/CSharpFunctionalExtensions/Result/Methods/Extensions/TapIf.ValueTask.Right.cs
+++ b/CSharpFunctionalExtensions/Result/Methods/Extensions/TapIf.ValueTask.Right.cs
@@ -2,17 +2,17 @@
 using System;
 using System.Threading.Tasks;
 
-namespace CSharpFunctionalExtensions
+namespace CSharpFunctionalExtensions.ValueTasks
 {
     public static partial class AsyncResultExtensionsRightOperand
     {
         /// <summary>
         ///     Executes the given action if the calling result is a success and condition is true. Returns the calling result.
         /// </summary>
-        public static ValueTask<Result> TapIf(this Result result, bool condition, Func<ValueTask> func)
+        public static ValueTask<Result> TapIf(this Result result, bool condition, Func<ValueTask> valueTask)
         {
             if (condition)
-                return result.Tap(func);
+                return result.Tap(valueTask);
             else
                 return result.AsCompletedValueTask();
         }
@@ -20,10 +20,10 @@ namespace CSharpFunctionalExtensions
         /// <summary>
         ///     Executes the given action if the calling result is a success and condition is true. Returns the calling result.
         /// </summary>
-        public static ValueTask<Result<T>> TapIf<T>(this Result<T> result, bool condition, Func<ValueTask> func)
+        public static ValueTask<Result<T>> TapIf<T>(this Result<T> result, bool condition, Func<ValueTask> valueTask)
         {
             if (condition)
-                return result.Tap(func);
+                return result.Tap(valueTask);
             else
                 return result.AsCompletedValueTask();
         }
@@ -31,10 +31,10 @@ namespace CSharpFunctionalExtensions
         /// <summary>
         ///     Executes the given action if the calling result is a success and condition is true. Returns the calling result.
         /// </summary>
-        public static ValueTask<Result<T>> TapIf<T>(this Result<T> result, bool condition, Func<T, ValueTask> func)
+        public static ValueTask<Result<T>> TapIf<T>(this Result<T> result, bool condition, Func<T, ValueTask> valueTask)
         {
             if (condition)
-                return result.Tap(func);
+                return result.Tap(valueTask);
             else
                 return result.AsCompletedValueTask();
         }
@@ -42,10 +42,10 @@ namespace CSharpFunctionalExtensions
         /// <summary>
         ///     Executes the given action if the calling result is a success and condition is true. Returns the calling result.
         /// </summary>
-        public static ValueTask<Result<T, E>> TapIf<T, E>(this Result<T, E> result, bool condition, Func<ValueTask> func)
+        public static ValueTask<Result<T, E>> TapIf<T, E>(this Result<T, E> result, bool condition, Func<ValueTask> valueTask)
         {
             if (condition)
-                return result.Tap(func);
+                return result.Tap(valueTask);
             else
                 return result.AsCompletedValueTask();
         }
@@ -53,10 +53,10 @@ namespace CSharpFunctionalExtensions
         /// <summary>
         ///     Executes the given action if the calling result is a success and condition is true. Returns the calling result.
         /// </summary>
-        public static ValueTask<Result<T, E>> TapIf<T, E>(this Result<T, E> result, bool condition, Func<T, ValueTask> func)
+        public static ValueTask<Result<T, E>> TapIf<T, E>(this Result<T, E> result, bool condition, Func<T, ValueTask> valueTask)
         {
             if (condition)
-                return result.Tap(func);
+                return result.Tap(valueTask);
             else
                 return result.AsCompletedValueTask();
         }
@@ -64,10 +64,10 @@ namespace CSharpFunctionalExtensions
         /// <summary>
         ///     Executes the given action if the calling result is a success and condition is true. Returns the calling result.
         /// </summary>
-        public static ValueTask<UnitResult<E>> TapIf<E>(this UnitResult<E> result, bool condition, Func<ValueTask> func)
+        public static ValueTask<UnitResult<E>> TapIf<E>(this UnitResult<E> result, bool condition, Func<ValueTask> valueTask)
         {
             if (condition)
-                return result.Tap(func);
+                return result.Tap(valueTask);
             else
                 return result.AsCompletedValueTask();
         }
@@ -75,10 +75,10 @@ namespace CSharpFunctionalExtensions
         /// <summary>
         ///     Executes the given action if the calling result is a success and condition is true. Returns the calling result.
         /// </summary>
-        public static ValueTask<Result<T>> TapIf<T>(this Result<T> result, Func<T, bool> predicate, Func<ValueTask> func)
+        public static ValueTask<Result<T>> TapIf<T>(this Result<T> result, Func<T, bool> predicate, Func<ValueTask> valueTask)
         {
             if (result.IsSuccess && predicate(result.Value))
-                return result.Tap(func);
+                return result.Tap(valueTask);
             else
                 return result.AsCompletedValueTask();
         }
@@ -86,10 +86,10 @@ namespace CSharpFunctionalExtensions
         /// <summary>
         ///     Executes the given action if the calling result is a success and condition is true. Returns the calling result.
         /// </summary>
-        public static ValueTask<Result<T>> TapIf<T>(this Result<T> result, Func<T, bool> predicate, Func<T, ValueTask> func)
+        public static ValueTask<Result<T>> TapIf<T>(this Result<T> result, Func<T, bool> predicate, Func<T, ValueTask> valueTask)
         {
             if (result.IsSuccess && predicate(result.Value))
-                return result.Tap(func);
+                return result.Tap(valueTask);
             else
                 return result.AsCompletedValueTask();
         }
@@ -97,10 +97,10 @@ namespace CSharpFunctionalExtensions
         /// <summary>
         ///     Executes the given action if the calling result is a success and condition is true. Returns the calling result.
         /// </summary>
-        public static ValueTask<Result<T, E>> TapIf<T, E>(this Result<T, E> result, Func<T, bool> predicate, Func<ValueTask> func)
+        public static ValueTask<Result<T, E>> TapIf<T, E>(this Result<T, E> result, Func<T, bool> predicate, Func<ValueTask> valueTask)
         {
             if (result.IsSuccess && predicate(result.Value))
-                return result.Tap(func);
+                return result.Tap(valueTask);
             else
                 return result.AsCompletedValueTask();
         }
@@ -108,10 +108,10 @@ namespace CSharpFunctionalExtensions
         /// <summary>
         ///     Executes the given action if the calling result is a success and condition is true. Returns the calling result.
         /// </summary>
-        public static ValueTask<Result<T, E>> TapIf<T, E>(this Result<T, E> result, Func<T, bool> predicate, Func<T, ValueTask> func)
+        public static ValueTask<Result<T, E>> TapIf<T, E>(this Result<T, E> result, Func<T, bool> predicate, Func<T, ValueTask> valueTask)
         {
             if (result.IsSuccess && predicate(result.Value))
-                return result.Tap(func);
+                return result.Tap(valueTask);
             else
                 return result.AsCompletedValueTask();
         }
@@ -119,10 +119,10 @@ namespace CSharpFunctionalExtensions
         /// <summary>
         ///     Executes the given action if the calling result is a success and condition is true. Returns the calling result.
         /// </summary>
-        public static ValueTask<UnitResult<E>> TapIf<E>(this UnitResult<E> result, Func<bool> predicate, Func<ValueTask> func)
+        public static ValueTask<UnitResult<E>> TapIf<E>(this UnitResult<E> result, Func<bool> predicate, Func<ValueTask> valueTask)
         {
             if (result.IsSuccess && predicate())
-                return result.Tap(func);
+                return result.Tap(valueTask);
             else
                 return result.AsCompletedValueTask();
         }

--- a/CSharpFunctionalExtensions/Result/Methods/Extensions/TapIf.ValueTask.cs
+++ b/CSharpFunctionalExtensions/Result/Methods/Extensions/TapIf.ValueTask.cs
@@ -2,17 +2,17 @@
 using System;
 using System.Threading.Tasks;
 
-namespace CSharpFunctionalExtensions
+namespace CSharpFunctionalExtensions.ValueTasks
 {
     public static partial class AsyncResultExtensionsBothOperands
     {
         /// <summary>
         ///     Executes the given action if the calling result is a success and condition is true. Returns the calling result.
         /// </summary>
-        public static ValueTask<Result> TapIf(this ValueTask<Result> resultTask, bool condition, Func<ValueTask> func)
+        public static ValueTask<Result> TapIf(this ValueTask<Result> resultTask, bool condition, Func<ValueTask> valueTask)
         {
             if (condition)
-                return resultTask.Tap(func);
+                return resultTask.Tap(valueTask);
             else
                 return resultTask;
         }
@@ -20,10 +20,10 @@ namespace CSharpFunctionalExtensions
         /// <summary>
         ///     Executes the given action if the calling result is a success and condition is true. Returns the calling result.
         /// </summary>
-        public static ValueTask<Result<T>> TapIf<T>(this ValueTask<Result<T>> resultTask, bool condition, Func<ValueTask> func)
+        public static ValueTask<Result<T>> TapIf<T>(this ValueTask<Result<T>> resultTask, bool condition, Func<ValueTask> valueTask)
         {
             if (condition)
-                return resultTask.Tap(func);
+                return resultTask.Tap(valueTask);
             else
                 return resultTask;
         }
@@ -31,10 +31,10 @@ namespace CSharpFunctionalExtensions
         /// <summary>
         ///     Executes the given action if the calling result is a success and condition is true. Returns the calling result.
         /// </summary>
-        public static ValueTask<Result<T>> TapIf<T>(this ValueTask<Result<T>> resultTask, bool condition, Func<T, ValueTask> func)
+        public static ValueTask<Result<T>> TapIf<T>(this ValueTask<Result<T>> resultTask, bool condition, Func<T, ValueTask> valueTask)
         {
             if (condition)
-                return resultTask.Tap(func);
+                return resultTask.Tap(valueTask);
             else
                 return resultTask;
         }
@@ -42,10 +42,10 @@ namespace CSharpFunctionalExtensions
         /// <summary>
         ///     Executes the given action if the calling result is a success and condition is true. Returns the calling result.
         /// </summary>
-        public static ValueTask<Result<T, E>> TapIf<T, E>(this ValueTask<Result<T, E>> resultTask, bool condition, Func<ValueTask> func)
+        public static ValueTask<Result<T, E>> TapIf<T, E>(this ValueTask<Result<T, E>> resultTask, bool condition, Func<ValueTask> valueTask)
         {
             if (condition)
-                return resultTask.Tap(func);
+                return resultTask.Tap(valueTask);
             else
                 return resultTask;
         }
@@ -53,10 +53,10 @@ namespace CSharpFunctionalExtensions
         /// <summary>
         ///     Executes the given action if the calling result is a success and condition is true. Returns the calling result.
         /// </summary>
-        public static ValueTask<Result<T, E>> TapIf<T, E>(this ValueTask<Result<T, E>> resultTask, bool condition, Func<T, ValueTask> func)
+        public static ValueTask<Result<T, E>> TapIf<T, E>(this ValueTask<Result<T, E>> resultTask, bool condition, Func<T, ValueTask> valueTask)
         {
             if (condition)
-                return resultTask.Tap(func);
+                return resultTask.Tap(valueTask);
             else
                 return resultTask;
         }
@@ -64,10 +64,10 @@ namespace CSharpFunctionalExtensions
         /// <summary>
         ///     Executes the given action if the calling result is a success and condition is true. Returns the calling result.
         /// </summary>
-        public static ValueTask<UnitResult<E>> TapIf<E>(this ValueTask<UnitResult<E>> resultTask, bool condition, Func<ValueTask> func)
+        public static ValueTask<UnitResult<E>> TapIf<E>(this ValueTask<UnitResult<E>> resultTask, bool condition, Func<ValueTask> valueTask)
         {
             if (condition)
-                return resultTask.Tap(func);
+                return resultTask.Tap(valueTask);
             else
                 return resultTask;
         }
@@ -75,12 +75,12 @@ namespace CSharpFunctionalExtensions
         /// <summary>
         ///     Executes the given action if the calling result is a success and condition is true. Returns the calling result.
         /// </summary>
-        public static async ValueTask<Result<T>> TapIf<T>(this ValueTask<Result<T>> resultTask, Func<T, bool> predicate, Func<ValueTask> func)
+        public static async ValueTask<Result<T>> TapIf<T>(this ValueTask<Result<T>> resultTask, Func<T, bool> predicate, Func<ValueTask> valueTask)
         {
             Result<T> result = await resultTask;
 
             if (result.IsSuccess && predicate(result.Value))
-                return await result.Tap(func);
+                return await result.Tap(valueTask);
             else
                 return result;
         }
@@ -88,12 +88,12 @@ namespace CSharpFunctionalExtensions
         /// <summary>
         ///     Executes the given action if the calling result is a success and condition is true. Returns the calling result.
         /// </summary>
-        public static async ValueTask<Result<T>> TapIf<T>(this ValueTask<Result<T>> resultTask, Func<T, bool> predicate, Func<T, ValueTask> func)
+        public static async ValueTask<Result<T>> TapIf<T>(this ValueTask<Result<T>> resultTask, Func<T, bool> predicate, Func<T, ValueTask> valueTask)
         {
             Result<T> result = await resultTask;
 
             if (result.IsSuccess && predicate(result.Value))
-                return await result.Tap(func);
+                return await result.Tap(valueTask);
             else
                 return result;
         }
@@ -101,12 +101,12 @@ namespace CSharpFunctionalExtensions
         /// <summary>
         ///     Executes the given action if the calling result is a success and condition is true. Returns the calling result.
         /// </summary>
-        public static async ValueTask<Result<T, E>> TapIf<T, E>(this ValueTask<Result<T, E>> resultTask, Func<T, bool> predicate, Func<ValueTask> func)
+        public static async ValueTask<Result<T, E>> TapIf<T, E>(this ValueTask<Result<T, E>> resultTask, Func<T, bool> predicate, Func<ValueTask> valueTask)
         {
             Result<T, E> result = await resultTask;
 
             if (result.IsSuccess && predicate(result.Value))
-                return await result.Tap(func);
+                return await result.Tap(valueTask);
             else
                 return result;
         }
@@ -114,12 +114,12 @@ namespace CSharpFunctionalExtensions
         /// <summary>
         ///     Executes the given action if the calling result is a success and condition is true. Returns the calling result.
         /// </summary>
-        public static async ValueTask<Result<T, E>> TapIf<T, E>(this ValueTask<Result<T, E>> resultTask, Func<T, bool> predicate, Func<T, ValueTask> func)
+        public static async ValueTask<Result<T, E>> TapIf<T, E>(this ValueTask<Result<T, E>> resultTask, Func<T, bool> predicate, Func<T, ValueTask> valueTask)
         {
             Result<T, E> result = await resultTask;
 
             if (result.IsSuccess && predicate(result.Value))
-                return await result.Tap(func);
+                return await result.Tap(valueTask);
             else
                 return result;
         }
@@ -127,12 +127,12 @@ namespace CSharpFunctionalExtensions
         /// <summary>
         ///     Executes the given action if the calling result is a success and condition is true. Returns the calling result.
         /// </summary>
-        public static async ValueTask<UnitResult<E>> TapIf<E>(this ValueTask<UnitResult<E>> resultTask, Func<bool> predicate, Func<ValueTask> func)
+        public static async ValueTask<UnitResult<E>> TapIf<E>(this ValueTask<UnitResult<E>> resultTask, Func<bool> predicate, Func<ValueTask> valueTask)
         {
             UnitResult<E> result = await resultTask;
 
             if (result.IsSuccess && predicate())
-                return await result.Tap(func);
+                return await result.Tap(valueTask);
             else
                 return result;
         }

--- a/CSharpFunctionalExtensions/Result/Methods/Extensions/WithTransactionScope.cs
+++ b/CSharpFunctionalExtensions/Result/Methods/Extensions/WithTransactionScope.cs
@@ -16,13 +16,15 @@ namespace CSharpFunctionalExtensions
         private static T WithTransactionScope<T>(Func<T> f)
             where T : IResult
         {
-            using (var trans = new TransactionScope(TransactionScopeOption.Required, _transactionOptions, TransactionScopeAsyncFlowOption.Enabled))
+            using (var trans = new TransactionScope(TransactionScopeOption.Required, _transactionOptions,
+                       TransactionScopeAsyncFlowOption.Enabled))
             {
                 var result = f();
                 if (result.IsSuccess)
                 {
                     trans.Complete();
                 }
+
                 return result;
             }
         }
@@ -30,18 +32,26 @@ namespace CSharpFunctionalExtensions
         private static async Task<T> WithTransactionScope<T>(Func<Task<T>> f)
             where T : IResult
         {
-            using (var trans = new TransactionScope(TransactionScopeOption.Required, _transactionOptions, TransactionScopeAsyncFlowOption.Enabled))
+            using (var trans = new TransactionScope(TransactionScopeOption.Required, _transactionOptions,
+                       TransactionScopeAsyncFlowOption.Enabled))
             {
                 var result = await f().DefaultAwait();
                 if (result.IsSuccess)
                 {
                     trans.Complete();
                 }
+
                 return result;
             }
         }
-        
-        #if NET5_0_OR_GREATER
+    }
+}
+
+#if NET5_0_OR_GREATER
+namespace CSharpFunctionalExtensions.ValueTasks
+{
+    public static partial class ResultExtensions
+    {
         private static async ValueTask<T> WithTransactionScope<T>(Func<ValueTask<T>> f)
             where T : IResult
         {
@@ -52,10 +62,11 @@ namespace CSharpFunctionalExtensions
                 {
                     trans.Complete();
                 }
+
                 return result;
             }
         }
-        #endif
     }
 }
+    #endif
 #endif

--- a/CSharpFunctionalExtensions/Result/Methods/Try.ValueTask.cs
+++ b/CSharpFunctionalExtensions/Result/Methods/Try.ValueTask.cs
@@ -9,13 +9,13 @@ namespace CSharpFunctionalExtensions
         /// <summary>
         ///     Attempts to execute the supplied action. Returns a Result indicating whether the action executed successfully.
         /// </summary>
-        public static async ValueTask<Result> Try(Func<ValueTask> action, Func<Exception, string> errorHandler = null)
+        public static async ValueTask<Result> Try(Func<ValueTask> valueTask, Func<Exception, string> errorHandler = null)
         {
             errorHandler ??= Configuration.DefaultTryErrorHandler;
 
             try
             {
-                await action();
+                await valueTask();
                 return Success();
             }
             catch (Exception exc)
@@ -26,16 +26,16 @@ namespace CSharpFunctionalExtensions
         }
         
         /// <summary>
-        ///     Attempts to execute the supplied function. Returns a Result indicating whether the function executed successfully.
-        ///     If the function executed successfully, the result contains its return value.
+        ///     Attempts to execute the supplied valueTask action. Returns a Result indicating whether the valueTask action executed successfully.
+        ///     If the valueTask action executed successfully, the result contains its return value.
         /// </summary>
-        public static async ValueTask<Result<T>> Try<T>(Func<ValueTask<T>> func, Func<Exception, string> errorHandler = null)
+        public static async ValueTask<Result<T>> Try<T>(Func<ValueTask<T>> valueTask, Func<Exception, string> errorHandler = null)
         {
             errorHandler ??= Configuration.DefaultTryErrorHandler;
 
             try
             {
-                var result = await func();
+                var result = await valueTask();
                 return Success(result);
             }
             catch (Exception exc)
@@ -46,14 +46,14 @@ namespace CSharpFunctionalExtensions
         }
         
         /// <summary>
-        ///     Attempts to execute the supplied function. Returns a Result indicating whether the function executed successfully.
-        ///     If the function executed successfully, the result contains its return value.
+        ///     Attempts to execute the supplied valueTask action. Returns a Result indicating whether the valueTask action executed successfully.
+        ///     If the valueTask action executed successfully, the result contains its return value.
         /// </summary>
-        public static async ValueTask<Result<T, E>> Try<T, E>(Func<ValueTask<T>> func, Func<Exception, E> errorHandler)
+        public static async ValueTask<Result<T, E>> Try<T, E>(Func<ValueTask<T>> valueTask, Func<Exception, E> errorHandler)
         {
             try
             {
-                var result = await func();
+                var result = await valueTask();
                 return Success<T, E>(result);
             }
             catch (Exception exc)


### PR DESCRIPTION
- Added nameValueTask params to differentiate when both namepsaces are imported.

Please note that the Result.Try ambigious test is impossible to fix. 
My suggestion would be in this case if the valueTask named param is not an option we should remove one of the overloads. 