### PR TITLE
fix IReadOnlyDictionary.TryFind() availability on .NET 6

### DIFF
--- a/CSharpFunctionalExtensions/Maybe/Extensions/TryFind.cs
+++ b/CSharpFunctionalExtensions/Maybe/Extensions/TryFind.cs
@@ -4,7 +4,7 @@ namespace CSharpFunctionalExtensions
 {
     public static partial class MaybeExtensions
     {
-#if !NETCORE || !NET45_OR_GREATER || !NETSTANDARD
+#if !NETCORE && !NET45_OR_GREATER && !NETSTANDARD && !NET
         public static Maybe<V> TryFind<K, V>(this IDictionary<K, V> dict, K key)
         {
             if (dict.ContainsKey(key)) return dict[key];


### PR DESCRIPTION
fixes #441