### PR TITLE
Add BindTry extensions

### DIFF
--- a/CSharpFunctionalExtensions.Tests/CSharpFunctionalExtensions.Tests.csproj
+++ b/CSharpFunctionalExtensions.Tests/CSharpFunctionalExtensions.Tests.csproj
@@ -460,28 +460,26 @@
     <Compile Update="ResultTests\Extensions\TapIfTests.Base.cs">
       <DependentUpon>TapIfTests.cs</DependentUpon>
     </Compile>
-  </ItemGroup>
-  <ItemGroup Label="BindTryTests">
-	  <Compile Update="ResultTests\Extensions\BindTryTests.Task.cs">
+	<Compile Update="ResultTests\Extensions\BindTryTests.Task.cs">
 		<DependentUpon>BindTryTests.cs</DependentUpon>
-	  </Compile>
-	  <Compile Update="ResultTests\Extensions\BindTryTests.ValueTask.cs">
-		  <DependentUpon>BindTryTests.cs</DependentUpon>
-	  </Compile>
-	  <Compile Update="ResultTests\Extensions\BindTryTests.Base.cs">
-		  <DependentUpon>BindTryTests.cs</DependentUpon>
-	  </Compile>
-	  <Compile Update="ResultTests\Extensions\BindTryTests.Task.Left.cs">
-		  <DependentUpon>BindTryTests.Task.cs</DependentUpon>
-	  </Compile>
-	  <Compile Update="ResultTests\Extensions\BindTryTests.Task.Right.cs">
-		  <DependentUpon>BindTryTests.Task.cs</DependentUpon>
-	  </Compile>
-	  <Compile Update="ResultTests\Extensions\BindTryTests.ValueTask.Left.cs">
-		  <DependentUpon>BindTryTests.ValueTask.cs</DependentUpon>
-	  </Compile>
-	  <Compile Update="ResultTests\Extensions\BindTryTests.ValueTask.Right.cs">
-		  <DependentUpon>BindTryTests.ValueTask.cs</DependentUpon>
-	  </Compile>
-  </ItemGroup>
+	</Compile>
+	<Compile Update="ResultTests\Extensions\BindTryTests.ValueTask.cs">
+		<DependentUpon>BindTryTests.cs</DependentUpon>
+	</Compile>
+	<Compile Update="ResultTests\Extensions\BindTryTests.Base.cs">
+		<DependentUpon>BindTryTests.cs</DependentUpon>
+	</Compile>
+	<Compile Update="ResultTests\Extensions\BindTryTests.Task.Left.cs">
+		<DependentUpon>BindTryTests.Task.cs</DependentUpon>
+	</Compile>
+	<Compile Update="ResultTests\Extensions\BindTryTests.Task.Right.cs">
+		<DependentUpon>BindTryTests.Task.cs</DependentUpon>
+	</Compile>
+	<Compile Update="ResultTests\Extensions\BindTryTests.ValueTask.Left.cs">
+		<DependentUpon>BindTryTests.ValueTask.cs</DependentUpon>
+	</Compile>
+	<Compile Update="ResultTests\Extensions\BindTryTests.ValueTask.Right.cs">
+		<DependentUpon>BindTryTests.ValueTask.cs</DependentUpon>
+	</Compile>
+  </ItemGroup>  
 </Project>

--- a/CSharpFunctionalExtensions.Tests/CSharpFunctionalExtensions.Tests.csproj
+++ b/CSharpFunctionalExtensions.Tests/CSharpFunctionalExtensions.Tests.csproj
@@ -461,5 +461,27 @@
       <DependentUpon>TapIfTests.cs</DependentUpon>
     </Compile>
   </ItemGroup>
-
+  <ItemGroup Label="BindTryTests">
+	  <Compile Update="ResultTests\Extensions\BindTryTests.Task.cs">
+		<DependentUpon>BindTryTests.cs</DependentUpon>
+	  </Compile>
+	  <Compile Update="ResultTests\Extensions\BindTryTests.ValueTask.cs">
+		  <DependentUpon>BindTryTests.cs</DependentUpon>
+	  </Compile>
+	  <Compile Update="ResultTests\Extensions\BindTryTests.Base.cs">
+		  <DependentUpon>BindTryTests.cs</DependentUpon>
+	  </Compile>
+	  <Compile Update="ResultTests\Extensions\BindTryTests.Task.Left.cs">
+		  <DependentUpon>BindTryTests.Task.cs</DependentUpon>
+	  </Compile>
+	  <Compile Update="ResultTests\Extensions\BindTryTests.Task.Right.cs">
+		  <DependentUpon>BindTryTests.Task.cs</DependentUpon>
+	  </Compile>
+	  <Compile Update="ResultTests\Extensions\BindTryTests.ValueTask.Left.cs">
+		  <DependentUpon>BindTryTests.ValueTask.cs</DependentUpon>
+	  </Compile>
+	  <Compile Update="ResultTests\Extensions\BindTryTests.ValueTask.Right.cs">
+		  <DependentUpon>BindTryTests.ValueTask.cs</DependentUpon>
+	  </Compile>
+  </ItemGroup>
 </Project>

--- a/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/BindTests.Base.cs
+++ b/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/BindTests.Base.cs
@@ -15,6 +15,8 @@ namespace CSharpFunctionalExtensions.Tests
             FuncParam = null;
         }
 
+        protected bool FuncExecuted => _funcExecuted;
+
         protected Result Success()
         {
             _funcExecuted = true;
@@ -50,6 +52,11 @@ namespace CSharpFunctionalExtensions.Tests
         {
             _funcExecuted = true;
             return Result.Success(K.Value);
+        }
+        protected Result<K> Failure_K()
+        {
+            _funcExecuted = false;
+            return Result.Failure<K>(ErrorMessage);
         }
 
         protected Result<K> Success_T_Func_K(T value)

--- a/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/BindTests.Base.cs
+++ b/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/BindTests.Base.cs
@@ -194,6 +194,10 @@ namespace CSharpFunctionalExtensions.Tests
         {
             return Failure_T().AsValueTask();
         }
+        protected ValueTask<Result<T, E>> ValueTask_Success_T_E()
+        {
+            return Success_T_E().AsValueTask();
+        }
 
         protected ValueTask<Result<T, E>> ValueTask_Failure_T_E()
         {
@@ -204,6 +208,10 @@ namespace CSharpFunctionalExtensions.Tests
         {
             return Success_K().AsValueTask();
         }
+        protected ValueTask<Result<K>> ValueTask_Failure_K()
+        {
+            return Failure_K().AsValueTask();
+        }
 
         protected ValueTask<Result<K>> Func_T_ValueTask_Success_K(T value)
         {
@@ -213,6 +221,11 @@ namespace CSharpFunctionalExtensions.Tests
         protected ValueTask<Result<K, E>> ValueTask_Success_K_E(T value)
         {
             return Success_T_E_Func_K(value).AsValueTask();
+        }
+
+        protected ValueTask<Result<K, E>> ValueTask_Failure_K_E(T value)
+        {
+            return Failure_T_E_Func_K(value).AsValueTask();
         }
 
         protected ValueTask<Result<T, E>> Func_ValueTask_Success_T_E()

--- a/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/BindTests.Base.cs
+++ b/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/BindTests.Base.cs
@@ -73,6 +73,13 @@ namespace CSharpFunctionalExtensions.Tests
             return Result.Success<K, E>(K.Value);
         }
 
+        protected Result<K, E> Failure_T_E_Func_K(T value)
+        {
+            _funcExecuted = false;
+            FuncParam = value;
+            return Result.Failure<K, E>(E.Value);
+        }
+
         protected Result<T, E> Success_T_E()
         {
             _funcExecuted = true;
@@ -128,6 +135,11 @@ namespace CSharpFunctionalExtensions.Tests
             return Success_K().AsTask();
         }
 
+        protected Task<Result<K>> Task_Failure_K()
+        {
+            return Failure_K().AsTask();
+        }
+
         protected Task<Result<K>> Func_T_Task_Success_K(T value)
         {
             return Success_T_Func_K(value).AsTask();
@@ -138,8 +150,13 @@ namespace CSharpFunctionalExtensions.Tests
             return Success_T_E_Func_K(value).AsTask();
         }
 
-        protected Task<Result<T, E>> Task_Success_T_E()
+        protected Task<Result<K, E>> Task_Failure_K_E(T value)
         {
+            return Failure_T_E_Func_K(value).AsTask();            
+        }
+
+        protected Task<Result<T, E>> Task_Success_T_E()
+        {            
             return Success_T_E().AsTask();
         }
 

--- a/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/BindTryTests.Base.cs
+++ b/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/BindTryTests.Base.cs
@@ -22,6 +22,14 @@ namespace CSharpFunctionalExtensions.Tests.ResultTests.Extensions
         protected static Task<Result<T, K>> Task_Throwing_T_K() => throw new Exception(ErrorMessage);
         protected static Task<Result<K, E>> Task_Throwing_K_E() => throw new Exception(ErrorMessage);
 
+        protected static ValueTask<Result> ValueTask_Throwing() => throw new Exception(ErrorMessage);
+        protected static ValueTask<Result<T>> ValueTask_Throwing_T() => throw new Exception(ErrorMessage);
+        protected static ValueTask<UnitResult<E>> ValueTask_Throwing_E() => throw new Exception(ErrorMessage);
+        protected static ValueTask<Result<T, E>> ValueTask_Throwing_T_E() => throw new Exception(ErrorMessage);
+        protected static ValueTask<Result<K>> ValueTask_Throwing_K() => throw new Exception(ErrorMessage);
+        protected static ValueTask<Result<T, K>> ValueTask_Throwing_T_K() => throw new Exception(ErrorMessage);
+        protected static ValueTask<Result<K, E>> ValueTask_Throwing_K_E() => throw new Exception(ErrorMessage);
+
 
         protected void AssertFailure(Result result, string message)
         {

--- a/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/BindTryTests.Base.cs
+++ b/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/BindTryTests.Base.cs
@@ -6,28 +6,22 @@ namespace CSharpFunctionalExtensions.Tests.ResultTests.Extensions
 {
     public class BindTryTestsBase : BindTestsBase
     {
-        protected static Result Throwing() => throw new Exception(ErrorMessage);
-        protected static Result<T> Throwing_T() => throw new Exception(ErrorMessage);
+        protected static Result Throwing() => throw new Exception(ErrorMessage);        
         protected static UnitResult<E> Throwing_E() => throw new Exception(ErrorMessage);
         protected static Result<T, E> Throwing_T_E() => throw new Exception(ErrorMessage);
-        protected static Result<K> Throwing_K() => throw new Exception(ErrorMessage);
-        protected static Result<T, K> Throwing_T_K() => throw new Exception(ErrorMessage);
+        protected static Result<K> Throwing_K() => throw new Exception(ErrorMessage);        
         protected static Result<K, E> Throwing_K_E() => throw new Exception(ErrorMessage);
 
-        protected static Task<Result> Task_Throwing() => throw new Exception(ErrorMessage);
-        protected static Task<Result<T>> Task_Throwing_T() => throw new Exception(ErrorMessage);
+        protected static Task<Result> Task_Throwing() => throw new Exception(ErrorMessage);        
         protected static Task<UnitResult<E>> Task_Throwing_E() => throw new Exception(ErrorMessage);
         protected static Task<Result<T, E>> Task_Throwing_T_E() => throw new Exception(ErrorMessage);
-        protected static Task<Result<K>> Task_Throwing_K() => throw new Exception(ErrorMessage);
-        protected static Task<Result<T, K>> Task_Throwing_T_K() => throw new Exception(ErrorMessage);
+        protected static Task<Result<K>> Task_Throwing_K() => throw new Exception(ErrorMessage);        
         protected static Task<Result<K, E>> Task_Throwing_K_E() => throw new Exception(ErrorMessage);
 
-        protected static ValueTask<Result> ValueTask_Throwing() => throw new Exception(ErrorMessage);
-        protected static ValueTask<Result<T>> ValueTask_Throwing_T() => throw new Exception(ErrorMessage);
+        protected static ValueTask<Result> ValueTask_Throwing() => throw new Exception(ErrorMessage);        
         protected static ValueTask<UnitResult<E>> ValueTask_Throwing_E() => throw new Exception(ErrorMessage);
         protected static ValueTask<Result<T, E>> ValueTask_Throwing_T_E() => throw new Exception(ErrorMessage);
-        protected static ValueTask<Result<K>> ValueTask_Throwing_K() => throw new Exception(ErrorMessage);
-        protected static ValueTask<Result<T, K>> ValueTask_Throwing_T_K() => throw new Exception(ErrorMessage);
+        protected static ValueTask<Result<K>> ValueTask_Throwing_K() => throw new Exception(ErrorMessage);        
         protected static ValueTask<Result<K, E>> ValueTask_Throwing_K_E() => throw new Exception(ErrorMessage);
 
 

--- a/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/BindTryTests.Base.cs
+++ b/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/BindTryTests.Base.cs
@@ -1,11 +1,11 @@
 ﻿using FluentAssertions;
 using System;
+using System.Threading.Tasks;
 
 namespace CSharpFunctionalExtensions.Tests.ResultTests.Extensions
 {
     public class BindTryTestsBase : BindTestsBase
-    {       
-
+    {
         protected static Result Throwing() => throw new Exception(ErrorMessage);
         protected static Result<T> Throwing_T() => throw new Exception(ErrorMessage);
         protected static UnitResult<E> Throwing_E() => throw new Exception(ErrorMessage);
@@ -13,6 +13,14 @@ namespace CSharpFunctionalExtensions.Tests.ResultTests.Extensions
         protected static Result<K> Throwing_K() => throw new Exception(ErrorMessage);
         protected static Result<T, K> Throwing_T_K() => throw new Exception(ErrorMessage);
         protected static Result<K, E> Throwing_K_E() => throw new Exception(ErrorMessage);
+
+        protected static Task<Result> Task_Throwing() => throw new Exception(ErrorMessage);
+        protected static Task<Result<T>> Task_Throwing_T() => throw new Exception(ErrorMessage);
+        protected static Task<UnitResult<E>> Task_Throwing_E() => throw new Exception(ErrorMessage);
+        protected static Task<Result<T, E>> Task_Throwing_T_E() => throw new Exception(ErrorMessage);
+        protected static Task<Result<K>> Task_Throwing_K() => throw new Exception(ErrorMessage);
+        protected static Task<Result<T, K>> Task_Throwing_T_K() => throw new Exception(ErrorMessage);
+        protected static Task<Result<K, E>> Task_Throwing_K_E() => throw new Exception(ErrorMessage);
 
 
         protected void AssertFailure(Result result, string message)

--- a/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/BindTryTests.Base.cs
+++ b/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/BindTryTests.Base.cs
@@ -1,0 +1,31 @@
+﻿using FluentAssertions;
+using System;
+
+namespace CSharpFunctionalExtensions.Tests.ResultTests.Extensions
+{
+    public class BindTryTestsBase : BindTestsBase
+    {       
+
+        protected static Result Throwing() => throw new Exception(ErrorMessage);
+        protected static Result<T> Throwing_T() => throw new Exception(ErrorMessage);
+        protected static UnitResult<E> Throwing_E() => throw new Exception(ErrorMessage);
+        protected static Result<T, E> Throwing_T_E() => throw new Exception(ErrorMessage);
+        protected static Result<K> Throwing_K() => throw new Exception(ErrorMessage);
+        protected static Result<T, K> Throwing_T_K() => throw new Exception(ErrorMessage);
+        protected static Result<K, E> Throwing_K_E() => throw new Exception(ErrorMessage);
+
+
+        protected void AssertFailure(Result result, string message)
+        {
+            result.IsFailure.Should().BeTrue();
+            result.Error.Should().Be(message);
+            FuncExecuted.Should().BeFalse();
+        }
+        protected void AssertFailure(UnitResult<E> result, E errorValue)
+        {
+            result.IsFailure.Should().BeTrue();
+            result.Error.Should().Be(errorValue);
+            FuncExecuted.Should().BeFalse();
+        }
+    }
+}

--- a/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/BindTryTests.Task.Left.cs
+++ b/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/BindTryTests.Task.Left.cs
@@ -1,0 +1,384 @@
+﻿using System.Threading.Tasks;
+using Xunit;
+
+namespace CSharpFunctionalExtensions.Tests.ResultTests.Extensions
+{
+    public class BindTryTests_Task_Left : BindTryTestsBase
+    {
+        #region BindTry for Task<Result> with function returning Result
+        [Fact]
+        public async Task BindTry_execute_func_returning_success_on_task_success_returns_success()
+        {
+            Task<Result> sut = Result.Success().AsTask();
+
+            Result result = await sut.BindTry(Success);
+
+            AssertSuccess(result);
+        }
+
+        [Fact]
+        public async Task BindTry_execute_func_returning_success_on_task_failure_returns_failure()
+        {
+            Task<Result> sut = Result.Failure(ErrorMessage).AsTask();
+
+            Result result = await sut.BindTry(Success);
+
+            AssertFailure(result);
+        }
+
+        [Fact]
+        public async Task BindTry_execute_func_returning_failure_on_task_success_returns_failure()
+        {
+            Task<Result> sut = Result.Success().AsTask();
+
+            Result result = await sut.BindTry(Failure);
+
+            AssertFailure(result);
+        }
+
+        [Fact]
+        public async Task BindTry_execute_throwing_func_on_taks_success_returns_failure_with_exception_message()
+        {
+            Task<Result> sut = Result.Success().AsTask();
+
+            Result result = await sut.BindTry(Throwing);
+
+            AssertFailure(result);
+        }
+
+        [Fact]
+        public async Task BindTry_execute_throwing_func_on_task_success_with_custom_error_handler_returns_failure_with_custom_message()
+        {
+            Task<Result> sut = Result.Success().AsTask();
+
+            Result result = await sut.BindTry(Throwing, e => ErrorMessage2);
+
+            AssertFailure(result, ErrorMessage2);
+        }
+        #endregion
+
+        #region BindTry for Task<Result> with function returning Result<K>
+        [Fact]
+        public async Task BindTry_execute_func_returning_success_K_on_task_success_returns_success()
+        {
+            Task<Result> sut = Result.Success().AsTask();
+
+            Result<K> result = await sut.BindTry(Success_K);
+
+            AssertSuccess(result);
+        }
+
+        [Fact]
+        public async Task BindTry_execute_func_returning_success_K_on_task_failure_returns_failure()
+        {
+            Task<Result> sut = Result.Failure(ErrorMessage).AsTask();
+
+            Result<K> result = await sut.BindTry(Success_K);
+
+            AssertFailure(result);
+        }
+
+        [Fact]
+        public async Task BindTry_execute_func_returning_failure_K_on_task_success_returns_failure()
+        {
+            Task<Result> sut = Result.Success().AsTask();
+
+            Result<K> result = await sut.BindTry(Failure_K);
+
+            AssertFailure(result);
+        }
+
+        [Fact]
+        public async Task BindTry_execute_throwing_func_K_on_taks_success_returns_failure_with_exception_message()
+        {
+            Task<Result> sut = Result.Success().AsTask();
+
+            Result<K> result = await sut.BindTry(Throwing_K);
+
+            AssertFailure(result);
+        }
+
+        [Fact]
+        public async Task BindTry_execute_throwing_func_K_on_success_with_custom_error_handler_returns_failure_with_custom_message()
+        {
+            Task<Result> sut = Result.Success().AsTask();
+
+            Result<K> result = await sut.BindTry(Throwing_K, e => ErrorMessage2);
+
+            AssertFailure(result, ErrorMessage2);
+        }
+        #endregion
+
+        #region BindTry for Task<Result<T>> with function returning Result
+        [Fact]
+        public async Task BindTry_execute_func_returning_success_on_task_success_T_returns_success()
+        {
+            Task<Result<T>> sut = Result.Success(T.Value).AsTask();
+
+            Result result = await sut.BindTry(t => Success());
+
+            AssertSuccess(result);
+        }
+
+        [Fact]
+        public async Task BindTry_execute_task_func_returning_success_T_on_task_failure_returns_failure()
+        {
+            Task<Result<T>> sut = Result.Failure<T>(ErrorMessage).AsTask();
+
+            Result result = await sut.BindTry(t => Success());
+
+            AssertFailure(result);
+        }
+
+        [Fact]
+        public async Task BindTry_execute_func_returning_failure_on_task_success_T_returns_failure()
+        {
+            Task<Result<T>> sut = Result.Success(T.Value).AsTask();
+
+            Result result = await sut.BindTry(t => Failure());
+
+            AssertFailure(result);
+        }
+
+        [Fact]
+        public async Task BindTry_execute_throwing_func_on_taks_success_T_returns_failure_with_exception_message()
+        {
+            Task<Result<T>> sut = Result.Success(T.Value).AsTask();
+
+            Result result = await sut.BindTry(t => Throwing());
+
+            AssertFailure(result);
+        }
+
+        [Fact]
+        public async Task BindTry_execute_throwing_func_on_success_T_with_custom_error_handler_returns_failure_with_custom_message()
+        {
+            Task<Result<T>> sut = Result.Success(T.Value).AsTask();
+
+            Result result = await sut.BindTry(t => Throwing(), e => ErrorMessage2);
+
+            AssertFailure(result, ErrorMessage2);
+        }
+        #endregion
+
+        #region BindTry for Task<Result<T>> with function returning Result<K>
+        [Fact]
+        public async Task BindTry_execute_func_returning_success_K_on_task_success_T_returns_success()
+        {
+            Task<Result<T>> sut = Result.Success(T.Value).AsTask();
+
+            Result<K> result = await sut.BindTry(t => Success_K());
+
+            AssertSuccess(result);
+        }
+
+        [Fact]
+        public async Task BindTry_execute_func_returning_success_K_on_task_failure_T_returns_failure()
+        {
+            Task<Result<T>> sut = Result.Failure<T>(ErrorMessage).AsTask();
+
+            Result<K> result = await sut.BindTry(t => Success_K());
+
+            AssertFailure(result);
+        }
+
+        [Fact]
+        public async Task BindTry_execute_func_returning_failure_K_on_task_success_T_returns_failure()
+        {
+            Task<Result<T>> sut = Result.Success(T.Value).AsTask();
+
+            Result<K> result = await sut.BindTry(t => Failure_K());
+
+            AssertFailure(result);
+        }
+
+        [Fact]
+        public async Task BindTry_execute_throwing_func_K_on_taks_success_T_returns_failure_with_exception_message()
+        {
+            Task<Result<T>> sut = Result.Success(T.Value).AsTask();
+
+            Result<K> result = await sut.BindTry(t => Throwing_K());
+
+            AssertFailure(result);
+        }
+
+        [Fact]
+        public async Task BindTry_execute_throwing_func_K_on_success_T_with_custom_error_handler_returns_failure_with_custom_message()
+        {
+            Task<Result<T>> sut = Result.Success(T.Value).AsTask();
+
+            Result<K> result = await sut.BindTry(t => Throwing_K(), e => ErrorMessage2);
+
+            AssertFailure(result, ErrorMessage2);
+        }
+        #endregion
+
+        #region BindTry for Task<Result<T,E>> with function returning UnitResult<E>
+        [Fact]
+        public async Task BindTry_execute_func_returning_success_E_on_task_success_T_E_returns_success()
+        {
+            Task<Result<T, E>> sut = Result.Success<T, E>(T.Value).AsTask();
+
+            UnitResult<E> result = await sut.BindTry(t => UnitResult_Success_E(), e => E.Value2);
+
+            AssertSuccess(result);
+        }
+
+        [Fact]
+        public async Task BindTry_execute_func_returning_success_E_on_task_failure_T_E_returns_failure()
+        {
+            Task<Result<T, E>> sut = Result.Failure<T, E>(E.Value).AsTask();
+
+            UnitResult<E> result = await sut.BindTry(t => UnitResult_Success_E(), e => E.Value2);
+
+            AssertFailure(result);
+        }
+
+        [Fact]
+        public async Task BindTry_execute_func_returning_failure_E_on_task_success_T_E_returns_failure()
+        {
+            Task<Result<T, E>> sut = Result.Success<T, E>(T.Value).AsTask();
+
+            UnitResult<E> result = await sut.BindTry(t => UnitResult_Failure_E(), e => E.Value2);
+
+            AssertFailure(result);
+        }
+
+        [Fact]
+        public async Task BindTry_execute_throwing_func_E_on_success_T_E_returns_failure_with_value_from_error_handler()
+        {
+            Task<Result<T, E>> sut = Result.Success<T, E>(T.Value).AsTask();
+
+            UnitResult<E> result = await sut.BindTry(t => Throwing_E(), e => E.Value2);
+
+            AssertFailure(result, E.Value2);
+        }
+        #endregion
+
+        #region BindTry for Task<Result<T,E>> with function returning Result<K,E>
+        [Fact]
+        public async Task BindTry_execute_func_returning_success_K_E_on_task_success_T_E_returns_success()
+        {
+            Task<Result<T, E>> sut = Result.Success<T, E>(T.Value).AsTask();
+
+            Result<K, E> result = await sut.BindTry(Success_T_E_Func_K, e => E.Value2);
+
+            AssertSuccess(result);
+        }
+
+        [Fact]
+        public async Task BindTry_execute_func_returning_success_K_E_on_task_failure_T_E_returns_failure()
+        {
+            Task<Result<T, E>> sut = Result.Failure<T, E>(E.Value).AsTask();
+
+            Result<K, E> result = await sut.BindTry(Success_T_E_Func_K, e => E.Value2);
+
+            AssertFailure(result);
+        }
+
+        [Fact]
+        public async Task BindTry_execute_func_returning_failure_K_E_on_task_success_T_E_returns_failure()
+        {
+            Task<Result<T, E>> sut = Result.Success<T, E>(T.Value).AsTask();
+
+            Result<K, E> result = await sut.BindTry(Failure_T_E_Func_K, e => E.Value2);
+
+            AssertFailure(result);
+        }
+
+        [Fact]
+        public async Task BindTry_execute_throwing_func_K_E_on_success_T_E_returns_failure_with_value_from_error_handler()
+        {
+            Task<Result<T, E>> sut = Result.Success<T, E>(T.Value).AsTask();
+
+            Result<K, E> result = await sut.BindTry(t => Throwing_K_E(), e => E.Value2);
+
+            AssertFailure(result, E.Value2);
+        }
+        #endregion
+
+        #region BindTry for Task<UnitResult<E>> with function returning Result<T,E>
+        [Fact]
+        public async Task BindTry_execute_func_returning_success_T_E_on_task_success_E_returns_success()
+        {
+            Task<UnitResult<E>> sut = UnitResult.Success<E>().AsTask();
+
+            Result<T, E> result = await sut.BindTry(Success_T_E, e => E.Value2);
+
+            AssertSuccess(result);
+        }
+
+        [Fact]
+        public async Task BindTry_execute_func_returning_success_T_E_on_task_failure_E_returns_failure()
+        {
+            Task<UnitResult<E>> sut = UnitResult.Failure(E.Value).AsTask();
+
+            Result<T, E> result = await sut.BindTry(Success_T_E, e => E.Value2);
+
+            AssertFailure(result);
+        }
+
+        [Fact]
+        public async Task BindTry_execute_func_returning_failure_T_E_on_task_success_E_returns_failure()
+        {
+            Task<UnitResult<E>> sut = UnitResult.Success<E>().AsTask();
+
+            Result<T, E> result = await sut.BindTry(Failure_T_E, e => E.Value2);
+
+            AssertFailure(result);
+        }
+
+        [Fact]
+        public async Task BindTry_execute_throwing_func_T_E_on_success_E_returns_failure_with_value_from_error_handler()
+        {
+            Task<UnitResult<E>> sut = UnitResult.Success<E>().AsTask();
+
+            Result<T, E> result = await sut.BindTry(Throwing_T_E, e => E.Value2);
+
+            AssertFailure(result, E.Value2);
+        }
+        #endregion
+
+        #region BindTry for Task<UnitResult<E>> with function returning UnitResult<E>
+        [Fact]
+        public async Task BindTry_execute_func_returning_success_E_on_task_success_E_returns_success()
+        {
+            Task<UnitResult<E>> sut = UnitResult.Success<E>().AsTask();
+
+            UnitResult<E> result = await sut.BindTry(UnitResult_Success_E, e => E.Value2);
+
+            AssertSuccess(result);
+        }
+
+        [Fact]
+        public async Task BindTry_execute_func_returning_success_E_on_task_failure_E_returns_failure()
+        {
+            Task<UnitResult<E>> sut = UnitResult.Failure(E.Value).AsTask();
+
+            UnitResult<E> result = await sut.BindTry(UnitResult_Success_E, e => E.Value2);
+
+            AssertFailure(result);
+        }
+
+        [Fact]
+        public async Task BindTry_execute_func_returning_failure_E_on_task_success_E_returns_failure()
+        {
+            Task<UnitResult<E>> sut = UnitResult.Success<E>().AsTask();
+
+            UnitResult<E> result = await sut.BindTry(UnitResult_Failure_E, e => E.Value2);
+
+            AssertFailure(result);
+        }
+
+        [Fact]
+        public async Task BindTry_execute_throwing_func_E_on_success_E_returns_failure_with_value_from_error_handler()
+        {
+            Task<UnitResult<E>> sut = UnitResult.Success<E>().AsTask();
+
+            UnitResult<E> result = await sut.BindTry(Throwing_E, e => E.Value2);
+
+            AssertFailure(result, E.Value2);
+        }
+        #endregion
+    }
+}

--- a/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/BindTryTests.Task.Right.cs
+++ b/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/BindTryTests.Task.Right.cs
@@ -295,6 +295,15 @@ namespace CSharpFunctionalExtensions.Tests.ResultTests.Extensions
 
             AssertFailure(result, E.Value2);
         }
+        [Fact]
+        public async Task BindTry_execute_async_lambda_success_K_E_on_success_T_E_expected_success()
+        {
+            Result<T, E> sut = Result.Success<T, E>(new());
+
+            Result<K, E> result = await sut.BindTry(async _ => await Task_Success_K_E(T.Value), e => E.Value2);
+
+            AssertSuccess(result);
+        }
         #endregion
 
         #region BindTry for UnitResult<E> with function returning Task<Result<T,E>>
@@ -379,6 +388,6 @@ namespace CSharpFunctionalExtensions.Tests.ResultTests.Extensions
 
             AssertFailure(result, E.Value2);
         }
-        #endregion
+        #endregion        
     }
 }

--- a/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/BindTryTests.Task.Right.cs
+++ b/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/BindTryTests.Task.Right.cs
@@ -3,13 +3,13 @@ using Xunit;
 
 namespace CSharpFunctionalExtensions.Tests.ResultTests.Extensions
 {
-    public class BindTryTests_Task : BindTryTestsBase
+    public class BindTryTests_Task_Right : BindTryTestsBase
     {
-        #region BindTry for Task<Result> with function returning Task<Result>
+        #region BindTry for Result with function returning Task<Result>
         [Fact]
-        public async Task BindTry_execute_task_func_returning_success_on_task_success_returns_success()
+        public async Task BindTry_execute_task_func_returning_success_on_success_returns_success()
         {
-            Task<Result> sut = Result.Success().AsTask();
+            Result sut = Result.Success();
 
             Result result = await sut.BindTry(Task_Success);
 
@@ -17,9 +17,9 @@ namespace CSharpFunctionalExtensions.Tests.ResultTests.Extensions
         }
 
         [Fact]
-        public async Task BindTry_execute_task_func_returning_success_on_task_failure_returns_failure()
+        public async Task BindTry_execute_task_func_returning_success_on_failure_returns_failure()
         {
-            Task<Result> sut = Result.Failure(ErrorMessage).AsTask();
+            Result sut = Result.Failure(ErrorMessage);
 
             Result result = await sut.BindTry(Task_Success);
 
@@ -27,9 +27,9 @@ namespace CSharpFunctionalExtensions.Tests.ResultTests.Extensions
         }
 
         [Fact]
-        public async Task BindTry_execute_task_func_returning_failure_on_task_success_returns_failure()
+        public async Task BindTry_execute_task_func_returning_failure_on_success_returns_failure()
         {
-            Task<Result> sut = Result.Success().AsTask();
+            Result sut = Result.Success();
 
             Result result = await sut.BindTry(Task_Failure);
 
@@ -37,9 +37,9 @@ namespace CSharpFunctionalExtensions.Tests.ResultTests.Extensions
         }
 
         [Fact]
-        public async Task BindTry_execute_throwing_task_func_on_taks_success_returns_failure_with_exception_message()
+        public async Task BindTry_execute_throwing_task_func_on_success_returns_failure_with_exception_message()
         {
-            Task<Result> sut = Result.Success().AsTask();
+            Result sut = Result.Success();
 
             Result result = await sut.BindTry(Task_Throwing);
 
@@ -49,7 +49,7 @@ namespace CSharpFunctionalExtensions.Tests.ResultTests.Extensions
         [Fact]
         public async Task BindTry_execute_throwing_task_func_on_success_with_custom_error_handler_returns_failure_with_custom_message()
         {
-            Task<Result> sut = Result.Success().AsTask();
+            Result sut = Result.Success();
 
             Result result = await sut.BindTry(Task_Throwing, e => ErrorMessage2);
 
@@ -57,11 +57,11 @@ namespace CSharpFunctionalExtensions.Tests.ResultTests.Extensions
         }
         #endregion
 
-        #region BindTry for Task<Result> with function returning Task<Result<K>>
+        #region BindTry for Result with function returning Task<Result<K>>
         [Fact]
-        public async Task BindTry_execute_task_func_returning_success_K_on_task_success_returns_success()
+        public async Task BindTry_execute_task_func_returning_success_K_on_success_returns_success()
         {
-            Task<Result> sut = Result.Success().AsTask();
+            Result sut = Result.Success();
 
             Result<K> result = await sut.BindTry(Task_Success_K);
 
@@ -69,9 +69,9 @@ namespace CSharpFunctionalExtensions.Tests.ResultTests.Extensions
         }
 
         [Fact]
-        public async Task BindTry_execute_task_func_returning_success_K_on_task_failure_returns_failure()
+        public async Task BindTry_execute_task_func_returning_success_K_on_failure_returns_failure()
         {
-            Task<Result> sut = Result.Failure(ErrorMessage).AsTask();
+            Result sut = Result.Failure(ErrorMessage);
 
             Result<K> result = await sut.BindTry(Task_Success_K);
 
@@ -79,9 +79,9 @@ namespace CSharpFunctionalExtensions.Tests.ResultTests.Extensions
         }
 
         [Fact]
-        public async Task BindTry_execute_task_func_returning_failure_K_on_task_success_returns_failure()
+        public async Task BindTry_execute_task_func_returning_failure_K_on_success_returns_failure()
         {
-            Task<Result> sut = Result.Success().AsTask();
+            Result sut = Result.Success();
 
             Result<K> result = await sut.BindTry(Task_Failure_K);
 
@@ -89,9 +89,9 @@ namespace CSharpFunctionalExtensions.Tests.ResultTests.Extensions
         }
 
         [Fact]
-        public async Task BindTry_execute_throwing_task_func_K_on_taks_success_returns_failure_with_exception_message()
+        public async Task BindTry_execute_throwing_task_func_K_on_success_returns_failure_with_exception_message()
         {
-            Task<Result> sut = Result.Success().AsTask();
+            Result sut = Result.Success();
 
             Result<K> result = await sut.BindTry(Task_Throwing_K);
 
@@ -99,9 +99,9 @@ namespace CSharpFunctionalExtensions.Tests.ResultTests.Extensions
         }
 
         [Fact]
-        public async Task BindTry_execute_throwing_task_func_K_on_task_success_with_custom_error_handler_returns_failure_with_custom_message()
+        public async Task BindTry_execute_throwing_task_func_K_on_success_with_custom_error_handler_returns_failure_with_custom_message()
         {
-            Task<Result> sut = Result.Success().AsTask();
+            Result sut = Result.Success();
 
             Result<K> result = await sut.BindTry(Task_Throwing_K, e => ErrorMessage2);
 
@@ -109,11 +109,11 @@ namespace CSharpFunctionalExtensions.Tests.ResultTests.Extensions
         }
         #endregion
 
-        #region BindTry for Task<Result<T>> with function returning Task<Result>
+        #region BindTry for Result<T> with function returning Task<Result>
         [Fact]
-        public async Task BindTry_execute_task_func_returning_success_T_on_task_success_returns_success()
+        public async Task BindTry_execute_task_func_returning_success_T_on_success_returns_success()
         {
-            Task<Result<T>> sut = Result.Success(T.Value).AsTask();
+            Result<T> sut = Result.Success(T.Value);
 
             Result result = await sut.BindTry(t => Task_Success());
 
@@ -121,9 +121,9 @@ namespace CSharpFunctionalExtensions.Tests.ResultTests.Extensions
         }
 
         [Fact]
-        public async Task BindTry_execute_task_func_returning_success_T_on_task_failure_returns_failure()
+        public async Task BindTry_execute_task_func_returning_success_T_on_failure_returns_failure()
         {
-            Task<Result<T>> sut = Result.Failure<T>(ErrorMessage).AsTask();
+            Result<T> sut = Result.Failure<T>(ErrorMessage);
 
             Result result = await sut.BindTry(t => Task_Success());
 
@@ -131,9 +131,9 @@ namespace CSharpFunctionalExtensions.Tests.ResultTests.Extensions
         }
 
         [Fact]
-        public async Task BindTry_execute_task_func_returning_failure_T_on_task_success_returns_failure()
+        public async Task BindTry_execute_task_func_returning_failure_T_on_success_returns_failure()
         {
-            Task<Result<T>> sut = Result.Success(T.Value).AsTask();
+            Result<T> sut = Result.Failure<T>(ErrorMessage);
 
             Result result = await sut.BindTry(t => Task_Failure());
 
@@ -141,9 +141,9 @@ namespace CSharpFunctionalExtensions.Tests.ResultTests.Extensions
         }
 
         [Fact]
-        public async Task BindTry_execute_throwing_task_func_on_taks_success_T_returns_failure_with_exception_message()
+        public async Task BindTry_execute_throwing_task_func_on_success_T_returns_failure_with_exception_message()
         {
-            Task<Result<T>> sut = Result.Success(T.Value).AsTask();
+            Result<T> sut = Result.Success(T.Value);
 
             Result result = await sut.BindTry(t => Task_Throwing());
 
@@ -153,7 +153,7 @@ namespace CSharpFunctionalExtensions.Tests.ResultTests.Extensions
         [Fact]
         public async Task BindTry_execute_throwing_task_func_on_success_T_with_custom_error_handler_returns_failure_with_custom_message()
         {
-            Task<Result<T>> sut = Result.Success(T.Value).AsTask();
+            Result<T> sut = Result.Success(T.Value);
 
             Result result = await sut.BindTry(t => Task_Throwing(), e => ErrorMessage2);
 
@@ -161,11 +161,11 @@ namespace CSharpFunctionalExtensions.Tests.ResultTests.Extensions
         }
         #endregion
 
-        #region BindTry for Task<Result<T>> with function returning Task<Result<K>>
+        #region BindTry for Result<T> with function returning Task<Result<K>>
         [Fact]
-        public async Task BindTry_execute_task_func_returning_success_K_on_task_success_T_returns_success()
+        public async Task BindTry_execute_task_func_returning_success_K_on_success_T_returns_success()
         {
-            Task<Result<T>> sut = Result.Success(T.Value).AsTask();
+            Result<T> sut = Result.Success(T.Value);
 
             Result<K> result = await sut.BindTry(t => Task_Success_K());
 
@@ -173,9 +173,9 @@ namespace CSharpFunctionalExtensions.Tests.ResultTests.Extensions
         }
 
         [Fact]
-        public async Task BindTry_execute_task_func_returning_success_K_on_task_failure_T_returns_failure()
+        public async Task BindTry_execute_task_func_returning_success_K_on_failure_T_returns_failure()
         {
-            Task<Result<T>> sut = Result.Failure<T>(ErrorMessage).AsTask();
+            Result<T> sut = Result.Failure<T>(ErrorMessage);
 
             Result<K> result = await sut.BindTry(t => Task_Success_K());
 
@@ -183,9 +183,9 @@ namespace CSharpFunctionalExtensions.Tests.ResultTests.Extensions
         }
 
         [Fact]
-        public async Task BindTry_execute_task_func_returning_failure_K_on_task_success_T_returns_failure()
+        public async Task BindTry_execute_task_func_returning_failure_K_on_success_T_returns_failure()
         {
-            Task<Result<T>> sut = Result.Success(T.Value).AsTask();
+            Result<T> sut = Result.Success(T.Value);
 
             Result<K> result = await sut.BindTry(t => Task_Failure_K());
 
@@ -193,9 +193,9 @@ namespace CSharpFunctionalExtensions.Tests.ResultTests.Extensions
         }
 
         [Fact]
-        public async Task BindTry_execute_throwing_task_func_K_on_taks_success_T_returns_failure_with_exception_message()
+        public async Task BindTry_execute_throwing_task_func_K_on_success_T_returns_failure_with_exception_message()
         {
-            Task<Result<T>> sut = Result.Success(T.Value).AsTask();
+            Result<T> sut = Result.Success(T.Value);
 
             Result<K> result = await sut.BindTry(t => Task_Throwing_K());
 
@@ -205,7 +205,7 @@ namespace CSharpFunctionalExtensions.Tests.ResultTests.Extensions
         [Fact]
         public async Task BindTry_execute_throwing_task_func_K_on_success_T_with_custom_error_handler_returns_failure_with_custom_message()
         {
-            Task<Result<T>> sut = Result.Success(T.Value).AsTask();
+            Result<T> sut = Result.Success(T.Value);
 
             Result<K> result = await sut.BindTry(t => Task_Throwing_K(), e => ErrorMessage2);
 
@@ -213,11 +213,11 @@ namespace CSharpFunctionalExtensions.Tests.ResultTests.Extensions
         }
         #endregion
 
-        #region BindTry for Task<Result<T,E>> with function returning Task<UnitResult<E>>
+        #region BindTry for Result<T,E> with function returning Task<UnitResult<E>>
         [Fact]
-        public async Task BindTry_execute_task_func_returning_success_E_on_task_success_T_E_returns_success()
+        public async Task BindTry_execute_task_func_returning_success_E_on_success_T_E_returns_success()
         {
-            Task<Result<T,E>> sut = Result.Success<T,E>(T.Value).AsTask();
+            Result<T, E> sut = Result.Success<T, E>(T.Value);
 
             UnitResult<E> result = await sut.BindTry(t => Task_UnitResult_Success_E(), e => E.Value2);
 
@@ -225,9 +225,9 @@ namespace CSharpFunctionalExtensions.Tests.ResultTests.Extensions
         }
 
         [Fact]
-        public async Task BindTry_execute_task_func_returning_success_E_on_task_failure_T_E_returns_failure()
+        public async Task BindTry_execute_task_func_returning_success_E_on_failure_T_E_returns_failure()
         {
-            Task<Result<T,E>> sut = Result.Failure<T,E>(E.Value).AsTask();
+            Result<T, E> sut = Result.Failure<T, E>(E.Value);
 
             UnitResult<E> result = await sut.BindTry(t => Task_UnitResult_Success_E(), e => E.Value2);
 
@@ -235,9 +235,9 @@ namespace CSharpFunctionalExtensions.Tests.ResultTests.Extensions
         }
 
         [Fact]
-        public async Task BindTry_execute_task_func_returning_failure_E_on_task_success_T_E_returns_failure()
+        public async Task BindTry_execute_task_func_returning_failure_E_on_success_T_E_returns_failure()
         {
-            Task<Result<T,E>> sut = Result.Success<T,E>(T.Value).AsTask();
+            Result<T, E> sut = Result.Success<T, E>(T.Value);
 
             UnitResult<E> result = await sut.BindTry(t => Task_UnitResult_Failure_E(), e => E.Value2);
 
@@ -247,7 +247,7 @@ namespace CSharpFunctionalExtensions.Tests.ResultTests.Extensions
         [Fact]
         public async Task BindTry_execute_throwing_task_func_E_on_success_T_E_returns_failure_with_value_from_error_handler()
         {
-            Task<Result<T,E>> sut = Result.Success<T,E>(T.Value).AsTask();
+            Result<T, E> sut = Result.Success<T, E>(T.Value);
 
             UnitResult<E> result = await sut.BindTry(t => Task_Throwing_E(), e => E.Value2);
 
@@ -255,21 +255,21 @@ namespace CSharpFunctionalExtensions.Tests.ResultTests.Extensions
         }
         #endregion
 
-        #region BindTry for Task<Result<T,E>> with function returning Task<Result<K,E>>
+        #region BindTry for Result<T,E> with function returning Task<Result<K,E>>
         [Fact]
-        public async Task BindTry_execute_task_func_returning_success_K_E_on_task_success_T_E_returns_success()
+        public async Task BindTry_execute_task_func_returning_success_K_E_on_success_T_E_returns_success()
         {
-            Task<Result<T, E>> sut = Result.Success<T, E>(T.Value).AsTask();
+            Result<T, E> sut = Result.Success<T, E>(T.Value);
 
-            Result<K,E> result = await sut.BindTry(Task_Success_K_E, e => E.Value2);
+            Result<K, E> result = await sut.BindTry(Task_Success_K_E, e => E.Value2);
 
             AssertSuccess(result);
         }
 
         [Fact]
-        public async Task BindTry_execute_task_func_returning_success_K_E_on_task_failure_T_E_returns_failure()
+        public async Task BindTry_execute_task_func_returning_success_K_E_on_failure_T_E_returns_failure()
         {
-            Task<Result<T, E>> sut = Result.Failure<T, E>(E.Value).AsTask();
+            Result<T, E> sut = Result.Failure<T, E>(E.Value);
 
             Result<K, E> result = await sut.BindTry(Task_Success_K_E, e => E.Value2);
 
@@ -277,9 +277,9 @@ namespace CSharpFunctionalExtensions.Tests.ResultTests.Extensions
         }
 
         [Fact]
-        public async Task BindTry_execute_task_func_returning_failure_K_E_on_task_success_T_E_returns_failure()
+        public async Task BindTry_execute_task_func_returning_failure_K_E_on_success_T_E_returns_failure()
         {
-            Task<Result<T, E>> sut = Result.Success<T, E>(T.Value).AsTask();
+            Result<T, E> sut = Result.Success<T, E>(T.Value);
 
             Result<K, E> result = await sut.BindTry(Task_Failure_K_E, e => E.Value2);
 
@@ -289,7 +289,7 @@ namespace CSharpFunctionalExtensions.Tests.ResultTests.Extensions
         [Fact]
         public async Task BindTry_execute_throwing_task_func_K_E_on_success_T_E_returns_failure_with_value_from_error_handler()
         {
-            Task<Result<T, E>> sut = Result.Success<T, E>(T.Value).AsTask();
+            Result<T, E> sut = Result.Success<T, E>(T.Value);
 
             Result<K, E> result = await sut.BindTry(t => Task_Throwing_K_E(), e => E.Value2);
 
@@ -297,11 +297,11 @@ namespace CSharpFunctionalExtensions.Tests.ResultTests.Extensions
         }
         #endregion
 
-        #region BindTry for Task<UnitResult<E>> with function returning Task<Result<T,E>>
+        #region BindTry for UnitResult<E> with function returning Task<Result<T,E>>
         [Fact]
-        public async Task BindTry_execute_task_func_returning_success_T_E_on_task_success_E_returns_success()
+        public async Task BindTry_execute_task_func_returning_success_T_E_on_success_E_returns_success()
         {
-            Task<UnitResult<E>> sut = UnitResult.Success<E>().AsTask();
+            UnitResult<E> sut = UnitResult.Success<E>();
 
             Result<T, E> result = await sut.BindTry(Task_Success_T_E, e => E.Value2);
 
@@ -309,9 +309,9 @@ namespace CSharpFunctionalExtensions.Tests.ResultTests.Extensions
         }
 
         [Fact]
-        public async Task BindTry_execute_task_func_returning_success_T_E_on_task_failure_E_returns_failure()
+        public async Task BindTry_execute_task_func_returning_success_T_E_on_failure_E_returns_failure()
         {
-            Task<UnitResult<E>> sut = UnitResult.Failure(E.Value).AsTask();
+            UnitResult<E> sut = UnitResult.Failure(E.Value);
 
             Result<T, E> result = await sut.BindTry(Task_Success_T_E, e => E.Value2);
 
@@ -319,9 +319,9 @@ namespace CSharpFunctionalExtensions.Tests.ResultTests.Extensions
         }
 
         [Fact]
-        public async Task BindTry_execute_task_func_returning_failure_T_E_on_task_success_E_returns_failure()
+        public async Task BindTry_execute_task_func_returning_failure_T_E_on_success_E_returns_failure()
         {
-            Task<UnitResult<E>> sut = UnitResult.Success<E>().AsTask();
+            UnitResult<E> sut = UnitResult.Success<E>();
 
             Result<T, E> result = await sut.BindTry(Task_Failure_T_E, e => E.Value2);
 
@@ -331,7 +331,7 @@ namespace CSharpFunctionalExtensions.Tests.ResultTests.Extensions
         [Fact]
         public async Task BindTry_execute_throwing_task_func_T_E_on_success_E_returns_failure_with_value_from_error_handler()
         {
-            Task<UnitResult<E>> sut = UnitResult.Success<E>().AsTask();
+            UnitResult<E> sut = UnitResult.Success<E>();
 
             Result<T, E> result = await sut.BindTry(Task_Throwing_T_E, e => E.Value2);
 
@@ -339,11 +339,11 @@ namespace CSharpFunctionalExtensions.Tests.ResultTests.Extensions
         }
         #endregion
 
-        #region BindTry for Task<UnitResult<E>> with function returning Task<UnitResult<E>>
+        #region BindTry for UnitResult<E> with function returning Task<UnitResult<E>>
         [Fact]
-        public async Task BindTry_execute_task_func_returning_success_E_on_task_success_E_returns_success()
+        public async Task BindTry_execute_task_func_returning_success_E_on_success_E_returns_success()
         {
-            Task<UnitResult<E>> sut = UnitResult.Success<E>().AsTask();
+            UnitResult<E> sut = UnitResult.Success<E>();
 
             UnitResult<E> result = await sut.BindTry(Task_UnitResult_Success_E, e => E.Value2);
 
@@ -351,9 +351,9 @@ namespace CSharpFunctionalExtensions.Tests.ResultTests.Extensions
         }
 
         [Fact]
-        public async Task BindTry_execute_task_func_returning_success_E_on_task_failure_E_returns_failure()
+        public async Task BindTry_execute_task_func_returning_success_E_on_failure_E_returns_failure()
         {
-            Task<UnitResult<E>> sut = UnitResult.Failure(E.Value).AsTask();
+            UnitResult<E> sut = UnitResult.Failure(E.Value);
 
             UnitResult<E> result = await sut.BindTry(Task_UnitResult_Success_E, e => E.Value2);
 
@@ -361,9 +361,9 @@ namespace CSharpFunctionalExtensions.Tests.ResultTests.Extensions
         }
 
         [Fact]
-        public async Task BindTry_execute_task_func_returning_failure_E_on_task_success_E_returns_failure()
+        public async Task BindTry_execute_task_func_returning_failure_E_on_success_E_returns_failure()
         {
-            Task<UnitResult<E>> sut = UnitResult.Success<E>().AsTask();
+            UnitResult<E> sut = UnitResult.Success<E>();
 
             UnitResult<E> result = await sut.BindTry(Task_UnitResult_Failure_E, e => E.Value2);
 
@@ -373,13 +373,12 @@ namespace CSharpFunctionalExtensions.Tests.ResultTests.Extensions
         [Fact]
         public async Task BindTry_execute_throwing_task_func_E_on_success_E_returns_failure_with_value_from_error_handler()
         {
-            Task<UnitResult<E>> sut = UnitResult.Success<E>().AsTask();
+            UnitResult<E> sut = UnitResult.Success<E>();
 
             UnitResult<E> result = await sut.BindTry(Task_Throwing_E, e => E.Value2);
 
             AssertFailure(result, E.Value2);
         }
         #endregion
-
     }
 }

--- a/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/BindTryTests.Task.cs
+++ b/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/BindTryTests.Task.cs
@@ -1,12 +1,385 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
+using Xunit;
 
 namespace CSharpFunctionalExtensions.Tests.ResultTests.Extensions
 {
-    public class BindTryTests_Task
+    public class BindTryTests_Task : BindTryTestsBase
     {
+        #region BindTry for Task<Result> with function returning Task<Result>
+        [Fact]
+        public async Task BindTry_execute_task_func_returning_success_on_task_success_returns_success()
+        {
+            Task<Result> sut = Result.Success().AsTask();
+
+            Result result = await sut.BindTry(Task_Success);
+
+            AssertSuccess(result);
+        }
+
+        [Fact]
+        public async Task BindTry_execute_task_func_returning_success_on_task_failure_returns_failure()
+        {
+            Task<Result> sut = Result.Failure(ErrorMessage).AsTask();
+
+            Result result = await sut.BindTry(Task_Success);
+
+            AssertFailure(result);
+        }
+
+        [Fact]
+        public async Task BindTry_execute_task_func_returning_failure_on_task_success_returns_failure()
+        {
+            Task<Result> sut = Result.Success().AsTask();
+
+            Result result = await sut.BindTry(Task_Failure);
+
+            AssertFailure(result);
+        }
+
+        [Fact]
+        public async Task BindTry_execute_throwing_task_func_on_taks_success_returns_failure_with_exception_message()
+        {
+            Task<Result> sut = Result.Success().AsTask();
+
+            Result result = await sut.BindTry(Task_Throwing);
+
+            AssertFailure(result);
+        }
+
+        [Fact]
+        public async Task BindTry_execute_throwing_func_on_success_with_custom_error_handler_returns_failure_with_custom_message()
+        {
+            Task<Result> sut = Result.Success().AsTask();
+
+            Result result = await sut.BindTry(Task_Throwing, e => ErrorMessage2);
+
+            AssertFailure(result, ErrorMessage2);
+        }
+        #endregion
+
+        #region BindTry for Task<Result> with function returning Task<Result<K>>
+        [Fact]
+        public async Task BindTry_execute_task_func_returning_success_K_on_task_success_returns_success()
+        {
+            Task<Result> sut = Result.Success().AsTask();
+
+            Result<K> result = await sut.BindTry(Task_Success_K);
+
+            AssertSuccess(result);
+        }
+
+        [Fact]
+        public async Task BindTry_execute_task_func_returning_success_K_on_task_failure_returns_failure()
+        {
+            Task<Result> sut = Result.Failure(ErrorMessage).AsTask();
+
+            Result<K> result = await sut.BindTry(Task_Success_K);
+
+            AssertFailure(result);
+        }
+
+        [Fact]
+        public async Task BindTry_execute_task_func_returning_failure_K_on_task_success_returns_failure()
+        {
+            Task<Result> sut = Result.Success().AsTask();
+
+            Result<K> result = await sut.BindTry(Task_Failure_K);
+
+            AssertFailure(result);
+        }
+
+        [Fact]
+        public async Task BindTry_execute_throwing_task_func_K_on_taks_success_returns_failure_with_exception_message()
+        {
+            Task<Result> sut = Result.Success().AsTask();
+
+            Result<K> result = await sut.BindTry(Task_Throwing_K);
+
+            AssertFailure(result);
+        }
+
+        [Fact]
+        public async Task BindTry_execute_throwing_func_K_on_success_with_custom_error_handler_returns_failure_with_custom_message()
+        {
+            Task<Result> sut = Result.Success().AsTask();
+
+            Result<K> result = await sut.BindTry(Task_Throwing_K, e => ErrorMessage2);
+
+            AssertFailure(result, ErrorMessage2);
+        }
+        #endregion
+
+        #region BindTry for Task<Result<T>> with function returning Task<Result>
+        [Fact]
+        public async Task BindTry_execute_task_func_returning_success_T_on_task_success_returns_success()
+        {
+            Task<Result<T>> sut = Result.Success(T.Value).AsTask();
+
+            Result result = await sut.BindTry(t => Task_Success());
+
+            AssertSuccess(result);
+        }
+
+        [Fact]
+        public async Task BindTry_execute_task_func_returning_success_T_on_task_failure_returns_failure()
+        {
+            Task<Result<T>> sut = Result.Failure<T>(ErrorMessage).AsTask();
+
+            Result result = await sut.BindTry(t => Task_Success());
+
+            AssertFailure(result);
+        }
+
+        [Fact]
+        public async Task BindTry_execute_task_func_returning_failure_T_on_task_success_returns_failure()
+        {
+            Task<Result<T>> sut = Result.Success(T.Value).AsTask();
+
+            Result result = await sut.BindTry(t => Task_Failure());
+
+            AssertFailure(result);
+        }
+
+        [Fact]
+        public async Task BindTry_execute_throwing_task_func_on_taks_success_T_returns_failure_with_exception_message()
+        {
+            Task<Result<T>> sut = Result.Success(T.Value).AsTask();
+
+            Result result = await sut.BindTry(t => Task_Throwing());
+
+            AssertFailure(result);
+        }
+
+        [Fact]
+        public async Task BindTry_execute_throwing_func_on_success_T_with_custom_error_handler_returns_failure_with_custom_message()
+        {
+            Task<Result<T>> sut = Result.Success(T.Value).AsTask();
+
+            Result result = await sut.BindTry(t => Task_Throwing(), e => ErrorMessage2);
+
+            AssertFailure(result, ErrorMessage2);
+        }
+        #endregion
+
+        #region BindTry for Task<Result<T>> with function returning Task<Result<K>>
+        [Fact]
+        public async Task BindTry_execute_task_func_returning_success_K_on_task_success_T_returns_success()
+        {
+            Task<Result<T>> sut = Result.Success(T.Value).AsTask();
+
+            Result<K> result = await sut.BindTry(t => Task_Success_K());
+
+            AssertSuccess(result);
+        }
+
+        [Fact]
+        public async Task BindTry_execute_task_func_returning_success_K_on_task_failure_T_returns_failure()
+        {
+            Task<Result<T>> sut = Result.Failure<T>(ErrorMessage).AsTask();
+
+            Result<K> result = await sut.BindTry(t => Task_Success_K());
+
+            AssertFailure(result);
+        }
+
+        [Fact]
+        public async Task BindTry_execute_task_func_returning_failure_K_on_task_success_T_returns_failure()
+        {
+            Task<Result<T>> sut = Result.Success(T.Value).AsTask();
+
+            Result<K> result = await sut.BindTry(t => Task_Failure_K());
+
+            AssertFailure(result);
+        }
+
+        [Fact]
+        public async Task BindTry_execute_throwing_task_func_K_on_taks_success_T_returns_failure_with_exception_message()
+        {
+            Task<Result<T>> sut = Result.Success(T.Value).AsTask();
+
+            Result<K> result = await sut.BindTry(t => Task_Throwing_K());
+
+            AssertFailure(result);
+        }
+
+        [Fact]
+        public async Task BindTry_execute_throwing_func_K_on_success_T_with_custom_error_handler_returns_failure_with_custom_message()
+        {
+            Task<Result<T>> sut = Result.Success(T.Value).AsTask();
+
+            Result<K> result = await sut.BindTry(t => Task_Throwing_K(), e => ErrorMessage2);
+
+            AssertFailure(result, ErrorMessage2);
+        }
+        #endregion
+
+        #region BindTry for Task<Result<T,E>> with function returning Task<UnitResult<E>>
+        [Fact]
+        public async Task BindTry_execute_task_func_returning_success_E_on_task_success_T_E_returns_success()
+        {
+            Task<Result<T,E>> sut = Result.Success<T,E>(T.Value).AsTask();
+
+            UnitResult<E> result = await sut.BindTry(t => Task_UnitResult_Success_E(), e => E.Value2);
+
+            AssertSuccess(result);
+        }
+
+        [Fact]
+        public async Task BindTry_execute_task_func_returning_success_E_on_task_failure_T_E_returns_failure()
+        {
+            Task<Result<T,E>> sut = Result.Failure<T,E>(E.Value).AsTask();
+
+            UnitResult<E> result = await sut.BindTry(t => Task_UnitResult_Success_E(), e => E.Value2);
+
+            AssertFailure(result);
+        }
+
+        [Fact]
+        public async Task BindTry_execute_task_func_returning_failure_E_on_task_success_T_E_returns_failure()
+        {
+            Task<Result<T,E>> sut = Result.Success<T,E>(T.Value).AsTask();
+
+            UnitResult<E> result = await sut.BindTry(t => Task_UnitResult_Failure_E(), e => E.Value2);
+
+            AssertFailure(result);
+        }
+
+        [Fact]
+        public async Task BindTry_execute_throwing_func_E_on_success_T_E_returns_failure_with_value_from_error_handler()
+        {
+            Task<Result<T,E>> sut = Result.Success<T,E>(T.Value).AsTask();
+
+            UnitResult<E> result = await sut.BindTry(t => Task_Throwing_E(), e => E.Value2);
+
+            AssertFailure(result, E.Value2);
+        }
+        #endregion
+
+        #region BindTry for Task<Result<T,E>> with function returning Task<Result<K,E>>
+        [Fact]
+        public async Task BindTry_execute_task_func_returning_success_K_E_on_task_success_T_E_returns_success()
+        {
+            Task<Result<T, E>> sut = Result.Success<T, E>(T.Value).AsTask();
+
+            Result<K,E> result = await sut.BindTry(Task_Success_K_E, e => E.Value2);
+
+            AssertSuccess(result);
+        }
+
+        [Fact]
+        public async Task BindTry_execute_task_func_returning_success_K_E_on_task_failure_T_E_returns_failure()
+        {
+            Task<Result<T, E>> sut = Result.Failure<T, E>(E.Value).AsTask();
+
+            Result<K, E> result = await sut.BindTry(Task_Success_K_E, e => E.Value2);
+
+            AssertFailure(result);
+        }
+
+        [Fact]
+        public async Task BindTry_execute_task_func_returning_failure_K_E_on_task_success_T_E_returns_failure()
+        {
+            Task<Result<T, E>> sut = Result.Success<T, E>(T.Value).AsTask();
+
+            Result<K, E> result = await sut.BindTry(Task_Failure_K_E, e => E.Value2);
+
+            AssertFailure(result);
+        }
+
+        [Fact]
+        public async Task BindTry_execute_throwing_func_K_E_on_success_T_E_returns_failure_with_value_from_error_handler()
+        {
+            Task<Result<T, E>> sut = Result.Success<T, E>(T.Value).AsTask();
+
+            Result<K, E> result = await sut.BindTry(t => Task_Throwing_K_E(), e => E.Value2);
+
+            AssertFailure(result, E.Value2);
+        }
+        #endregion
+
+        #region BindTry for Task<UnitResult<E>> with function returning Task<Result<T,E>>
+        [Fact]
+        public async Task BindTry_execute_task_func_returning_success_T_E_on_task_success_E_returns_success()
+        {
+            Task<UnitResult<E>> sut = UnitResult.Success<E>().AsTask();
+
+            Result<T, E> result = await sut.BindTry(Task_Success_T_E, e => E.Value2);
+
+            AssertSuccess(result);
+        }
+
+        [Fact]
+        public async Task BindTry_execute_task_func_returning_success_T_E_on_task_failure_E_returns_failure()
+        {
+            Task<UnitResult<E>> sut = UnitResult.Failure(E.Value).AsTask();
+
+            Result<T, E> result = await sut.BindTry(Task_Success_T_E, e => E.Value2);
+
+            AssertFailure(result);
+        }
+
+        [Fact]
+        public async Task BindTry_execute_task_func_returning_failure_T_E_on_task_success_E_returns_failure()
+        {
+            Task<UnitResult<E>> sut = UnitResult.Success<E>().AsTask();
+
+            Result<T, E> result = await sut.BindTry(Task_Failure_T_E, e => E.Value2);
+
+            AssertFailure(result);
+        }
+
+        [Fact]
+        public async Task BindTry_execute_throwing_func_T_E_on_success_E_returns_failure_with_value_from_error_handler()
+        {
+            Task<UnitResult<E>> sut = UnitResult.Success<E>().AsTask();
+
+            Result<T, E> result = await sut.BindTry(Task_Throwing_T_E, e => E.Value2);
+
+            AssertFailure(result, E.Value2);
+        }
+        #endregion
+
+        #region BindTry for Task<UnitResult<E>> with function returning Task<UnitResult<E>>
+        [Fact]
+        public async Task BindTry_execute_task_func_returning_success_E_on_task_success_E_returns_success()
+        {
+            Task<UnitResult<E>> sut = UnitResult.Success<E>().AsTask();
+
+            UnitResult<E> result = await sut.BindTry(Task_UnitResult_Success_E, e => E.Value2);
+
+            AssertSuccess(result);
+        }
+
+        [Fact]
+        public async Task BindTry_execute_task_func_returning_success_E_on_task_failure_E_returns_failure()
+        {
+            Task<UnitResult<E>> sut = UnitResult.Failure(E.Value).AsTask();
+
+            UnitResult<E> result = await sut.BindTry(Task_UnitResult_Success_E, e => E.Value2);
+
+            AssertFailure(result);
+        }
+
+        [Fact]
+        public async Task BindTry_execute_task_func_returning_failure_E_on_task_success_E_returns_failure()
+        {
+            Task<UnitResult<E>> sut = UnitResult.Success<E>().AsTask();
+
+            UnitResult<E> result = await sut.BindTry(Task_UnitResult_Failure_E, e => E.Value2);
+
+            AssertFailure(result);
+        }
+
+        [Fact]
+        public async Task BindTry_execute_throwing_func_E_on_success_E_returns_failure_with_value_from_error_handler()
+        {
+            Task<UnitResult<E>> sut = UnitResult.Success<E>().AsTask();
+
+            UnitResult<E> result = await sut.BindTry(Task_Throwing_E, e => E.Value2);
+
+            AssertFailure(result, E.Value2);
+        }
+        #endregion
+
     }
 }

--- a/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/BindTryTests.Task.cs
+++ b/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/BindTryTests.Task.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace CSharpFunctionalExtensions.Tests.ResultTests.Extensions
+{
+    public class BindTryTests_Task
+    {
+    }
+}

--- a/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/BindTryTests.ValueTask.Left.cs
+++ b/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/BindTryTests.ValueTask.Left.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading.Tasks;
+﻿using CSharpFunctionalExtensions.ValueTasks;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace CSharpFunctionalExtensions.Tests.ResultTests.Extensions

--- a/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/BindTryTests.ValueTask.Left.cs
+++ b/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/BindTryTests.ValueTask.Left.cs
@@ -1,0 +1,384 @@
+﻿using System.Threading.Tasks;
+using Xunit;
+
+namespace CSharpFunctionalExtensions.Tests.ResultTests.Extensions
+{
+    public class BindTryTests_ValueTask_Left : BindTryTestsBase
+    {
+        #region BindTry for ValueTask<Result> with function returning Result
+        [Fact]
+        public async ValueTask BindTry_execute_func_returning_success_on_valuetask_success_returns_success()
+        {
+            ValueTask<Result> sut = Result.Success().AsValueTask();
+
+            Result result = await sut.BindTry(Success);
+
+            AssertSuccess(result);
+        }
+
+        [Fact]
+        public async ValueTask BindTry_execute_func_returning_success_on_valuetask_failure_returns_failure()
+        {
+            ValueTask<Result> sut = Result.Failure(ErrorMessage).AsValueTask();
+
+            Result result = await sut.BindTry(Success);
+
+            AssertFailure(result);
+        }
+
+        [Fact]
+        public async ValueTask BindTry_execute_func_returning_failure_on_valuetask_success_returns_failure()
+        {
+            ValueTask<Result> sut = Result.Success().AsValueTask();
+
+            Result result = await sut.BindTry(Failure);
+
+            AssertFailure(result);
+        }
+
+        [Fact]
+        public async ValueTask BindTry_execute_throwing_func_on_valuetask_success_returns_failure_with_exception_message()
+        {
+            ValueTask<Result> sut = Result.Success().AsValueTask();
+
+            Result result = await sut.BindTry(Throwing);
+
+            AssertFailure(result);
+        }
+
+        [Fact]
+        public async ValueTask BindTry_execute_throwing_func_on_valuetask_success_with_custom_error_handler_returns_failure_with_custom_message()
+        {
+            ValueTask<Result> sut = Result.Success().AsValueTask();
+
+            Result result = await sut.BindTry(Throwing, e => ErrorMessage2);
+
+            AssertFailure(result, ErrorMessage2);
+        }
+        #endregion
+
+        #region BindTry for ValueTask<Result> with function returning Result<K>
+        [Fact]
+        public async ValueTask BindTry_execute_func_returning_success_K_on_valuetask_success_returns_success()
+        {
+            ValueTask<Result> sut = Result.Success().AsValueTask();
+
+            Result<K> result = await sut.BindTry(Success_K);
+
+            AssertSuccess(result);
+        }
+
+        [Fact]
+        public async ValueTask BindTry_execute_func_returning_success_K_on_valuetask_failure_returns_failure()
+        {
+            ValueTask<Result> sut = Result.Failure(ErrorMessage).AsValueTask();
+
+            Result<K> result = await sut.BindTry(Success_K);
+
+            AssertFailure(result);
+        }
+
+        [Fact]
+        public async ValueTask BindTry_execute_func_returning_failure_K_on_valuetask_success_returns_failure()
+        {
+            ValueTask<Result> sut = Result.Success().AsValueTask();
+
+            Result<K> result = await sut.BindTry(Failure_K);
+
+            AssertFailure(result);
+        }
+
+        [Fact]
+        public async ValueTask BindTry_execute_throwing_func_K_on_valuetask_success_returns_failure_with_exception_message()
+        {
+            ValueTask<Result> sut = Result.Success().AsValueTask();
+
+            Result<K> result = await sut.BindTry(Throwing_K);
+
+            AssertFailure(result);
+        }
+
+        [Fact]
+        public async ValueTask BindTry_execute_throwing_func_K_on_success_with_custom_error_handler_returns_failure_with_custom_message()
+        {
+            ValueTask<Result> sut = Result.Success().AsValueTask();
+
+            Result<K> result = await sut.BindTry(Throwing_K, e => ErrorMessage2);
+
+            AssertFailure(result, ErrorMessage2);
+        }
+        #endregion
+
+        #region BindTry for ValueTask<Result<T>> with function returning Result
+        [Fact]
+        public async ValueTask BindTry_execute_func_returning_success_on_valuetask_success_T_returns_success()
+        {
+            ValueTask<Result<T>> sut = Result.Success(T.Value).AsValueTask();
+
+            Result result = await sut.BindTry(t => Success());
+
+            AssertSuccess(result);
+        }
+
+        [Fact]
+        public async ValueTask BindTry_execute_valuetask_func_returning_success_T_on_valuetask_failure_returns_failure()
+        {
+            ValueTask<Result<T>> sut = Result.Failure<T>(ErrorMessage).AsValueTask();
+
+            Result result = await sut.BindTry(t => Success());
+
+            AssertFailure(result);
+        }
+
+        [Fact]
+        public async ValueTask BindTry_execute_func_returning_failure_on_valuetask_success_T_returns_failure()
+        {
+            ValueTask<Result<T>> sut = Result.Success(T.Value).AsValueTask();
+
+            Result result = await sut.BindTry(t => Failure());
+
+            AssertFailure(result);
+        }
+
+        [Fact]
+        public async ValueTask BindTry_execute_throwing_func_on_valuetask_success_T_returns_failure_with_exception_message()
+        {
+            ValueTask<Result<T>> sut = Result.Success(T.Value).AsValueTask();
+
+            Result result = await sut.BindTry(t => Throwing());
+
+            AssertFailure(result);
+        }
+
+        [Fact]
+        public async ValueTask BindTry_execute_throwing_func_on_success_T_with_custom_error_handler_returns_failure_with_custom_message()
+        {
+            ValueTask<Result<T>> sut = Result.Success(T.Value).AsValueTask();
+
+            Result result = await sut.BindTry(t => Throwing(), e => ErrorMessage2);
+
+            AssertFailure(result, ErrorMessage2);
+        }
+        #endregion
+
+        #region BindTry for ValueTask<Result<T>> with function returning Result<K>
+        [Fact]
+        public async ValueTask BindTry_execute_func_returning_success_K_on_valuetask_success_T_returns_success()
+        {
+            ValueTask<Result<T>> sut = Result.Success(T.Value).AsValueTask();
+
+            Result<K> result = await sut.BindTry(t => Success_K());
+
+            AssertSuccess(result);
+        }
+
+        [Fact]
+        public async ValueTask BindTry_execute_func_returning_success_K_on_valuetask_failure_T_returns_failure()
+        {
+            ValueTask<Result<T>> sut = Result.Failure<T>(ErrorMessage).AsValueTask();
+
+            Result<K> result = await sut.BindTry(t => Success_K());
+
+            AssertFailure(result);
+        }
+
+        [Fact]
+        public async ValueTask BindTry_execute_func_returning_failure_K_on_valuetask_success_T_returns_failure()
+        {
+            ValueTask<Result<T>> sut = Result.Success(T.Value).AsValueTask();
+
+            Result<K> result = await sut.BindTry(t => Failure_K());
+
+            AssertFailure(result);
+        }
+
+        [Fact]
+        public async ValueTask BindTry_execute_throwing_func_K_on_valuetask_success_T_returns_failure_with_exception_message()
+        {
+            ValueTask<Result<T>> sut = Result.Success(T.Value).AsValueTask();
+
+            Result<K> result = await sut.BindTry(t => Throwing_K());
+
+            AssertFailure(result);
+        }
+
+        [Fact]
+        public async ValueTask BindTry_execute_throwing_func_K_on_success_T_with_custom_error_handler_returns_failure_with_custom_message()
+        {
+            ValueTask<Result<T>> sut = Result.Success(T.Value).AsValueTask();
+
+            Result<K> result = await sut.BindTry(t => Throwing_K(), e => ErrorMessage2);
+
+            AssertFailure(result, ErrorMessage2);
+        }
+        #endregion
+
+        #region BindTry for ValueTask<Result<T,E>> with function returning UnitResult<E>
+        [Fact]
+        public async ValueTask BindTry_execute_func_returning_success_E_on_valuetask_success_T_E_returns_success()
+        {
+            ValueTask<Result<T, E>> sut = Result.Success<T, E>(T.Value).AsValueTask();
+
+            UnitResult<E> result = await sut.BindTry(t => UnitResult_Success_E(), e => E.Value2);
+
+            AssertSuccess(result);
+        }
+
+        [Fact]
+        public async ValueTask BindTry_execute_func_returning_success_E_on_valuetask_failure_T_E_returns_failure()
+        {
+            ValueTask<Result<T, E>> sut = Result.Failure<T, E>(E.Value).AsValueTask();
+
+            UnitResult<E> result = await sut.BindTry(t => UnitResult_Success_E(), e => E.Value2);
+
+            AssertFailure(result);
+        }
+
+        [Fact]
+        public async ValueTask BindTry_execute_func_returning_failure_E_on_valuetask_success_T_E_returns_failure()
+        {
+            ValueTask<Result<T, E>> sut = Result.Success<T, E>(T.Value).AsValueTask();
+
+            UnitResult<E> result = await sut.BindTry(t => UnitResult_Failure_E(), e => E.Value2);
+
+            AssertFailure(result);
+        }
+
+        [Fact]
+        public async ValueTask BindTry_execute_throwing_func_E_on_success_T_E_returns_failure_with_value_from_error_handler()
+        {
+            ValueTask<Result<T, E>> sut = Result.Success<T, E>(T.Value).AsValueTask();
+
+            UnitResult<E> result = await sut.BindTry(t => Throwing_E(), e => E.Value2);
+
+            AssertFailure(result, E.Value2);
+        }
+        #endregion
+
+        #region BindTry for ValueTask<Result<T,E>> with function returning Result<K,E>
+        [Fact]
+        public async ValueTask BindTry_execute_func_returning_success_K_E_on_valuetask_success_T_E_returns_success()
+        {
+            ValueTask<Result<T, E>> sut = Result.Success<T, E>(T.Value).AsValueTask();
+
+            Result<K, E> result = await sut.BindTry(Success_T_E_Func_K, e => E.Value2);
+
+            AssertSuccess(result);
+        }
+
+        [Fact]
+        public async ValueTask BindTry_execute_func_returning_success_K_E_on_valuetask_failure_T_E_returns_failure()
+        {
+            ValueTask<Result<T, E>> sut = Result.Failure<T, E>(E.Value).AsValueTask();
+
+            Result<K, E> result = await sut.BindTry(Success_T_E_Func_K, e => E.Value2);
+
+            AssertFailure(result);
+        }
+
+        [Fact]
+        public async ValueTask BindTry_execute_func_returning_failure_K_E_on_valuetask_success_T_E_returns_failure()
+        {
+            ValueTask<Result<T, E>> sut = Result.Success<T, E>(T.Value).AsValueTask();
+
+            Result<K, E> result = await sut.BindTry(Failure_T_E_Func_K, e => E.Value2);
+
+            AssertFailure(result);
+        }
+
+        [Fact]
+        public async ValueTask BindTry_execute_throwing_func_K_E_on_success_T_E_returns_failure_with_value_from_error_handler()
+        {
+            ValueTask<Result<T, E>> sut = Result.Success<T, E>(T.Value).AsValueTask();
+
+            Result<K, E> result = await sut.BindTry(t => Throwing_K_E(), e => E.Value2);
+
+            AssertFailure(result, E.Value2);
+        }
+        #endregion
+
+        #region BindTry for ValueTask<UnitResult<E>> with function returning Result<T,E>
+        [Fact]
+        public async ValueTask BindTry_execute_func_returning_success_T_E_on_valuetask_success_E_returns_success()
+        {
+            ValueTask<UnitResult<E>> sut = UnitResult.Success<E>().AsValueTask();
+
+            Result<T, E> result = await sut.BindTry(Success_T_E, e => E.Value2);
+
+            AssertSuccess(result);
+        }
+
+        [Fact]
+        public async ValueTask BindTry_execute_func_returning_success_T_E_on_valuetask_failure_E_returns_failure()
+        {
+            ValueTask<UnitResult<E>> sut = UnitResult.Failure(E.Value).AsValueTask();
+
+            Result<T, E> result = await sut.BindTry(Success_T_E, e => E.Value2);
+
+            AssertFailure(result);
+        }
+
+        [Fact]
+        public async ValueTask BindTry_execute_func_returning_failure_T_E_on_valuetask_success_E_returns_failure()
+        {
+            ValueTask<UnitResult<E>> sut = UnitResult.Success<E>().AsValueTask();
+
+            Result<T, E> result = await sut.BindTry(Failure_T_E, e => E.Value2);
+
+            AssertFailure(result);
+        }
+
+        [Fact]
+        public async ValueTask BindTry_execute_throwing_func_T_E_on_success_E_returns_failure_with_value_from_error_handler()
+        {
+            ValueTask<UnitResult<E>> sut = UnitResult.Success<E>().AsValueTask();
+
+            Result<T, E> result = await sut.BindTry(Throwing_T_E, e => E.Value2);
+
+            AssertFailure(result, E.Value2);
+        }
+        #endregion
+
+        #region BindTry for ValueTask<UnitResult<E>> with function returning UnitResult<E>
+        [Fact]
+        public async ValueTask BindTry_execute_func_returning_success_E_on_valuetask_success_E_returns_success()
+        {
+            ValueTask<UnitResult<E>> sut = UnitResult.Success<E>().AsValueTask();
+
+            UnitResult<E> result = await sut.BindTry(UnitResult_Success_E, e => E.Value2);
+
+            AssertSuccess(result);
+        }
+
+        [Fact]
+        public async ValueTask BindTry_execute_func_returning_success_E_on_valuetask_failure_E_returns_failure()
+        {
+            ValueTask<UnitResult<E>> sut = UnitResult.Failure(E.Value).AsValueTask();
+
+            UnitResult<E> result = await sut.BindTry(UnitResult_Success_E, e => E.Value2);
+
+            AssertFailure(result);
+        }
+
+        [Fact]
+        public async ValueTask BindTry_execute_func_returning_failure_E_on_valuetask_success_E_returns_failure()
+        {
+            ValueTask<UnitResult<E>> sut = UnitResult.Success<E>().AsValueTask();
+
+            UnitResult<E> result = await sut.BindTry(UnitResult_Failure_E, e => E.Value2);
+
+            AssertFailure(result);
+        }
+
+        [Fact]
+        public async ValueTask BindTry_execute_throwing_func_E_on_success_E_returns_failure_with_value_from_error_handler()
+        {
+            ValueTask<UnitResult<E>> sut = UnitResult.Success<E>().AsValueTask();
+
+            UnitResult<E> result = await sut.BindTry(Throwing_E, e => E.Value2);
+
+            AssertFailure(result, E.Value2);
+        }
+        #endregion
+    }
+}

--- a/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/BindTryTests.ValueTask.Right.cs
+++ b/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/BindTryTests.ValueTask.Right.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading.Tasks;
+﻿using CSharpFunctionalExtensions.ValueTasks;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace CSharpFunctionalExtensions.Tests.ResultTests.Extensions

--- a/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/BindTryTests.ValueTask.Right.cs
+++ b/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/BindTryTests.ValueTask.Right.cs
@@ -1,0 +1,384 @@
+﻿using System.Threading.Tasks;
+using Xunit;
+
+namespace CSharpFunctionalExtensions.Tests.ResultTests.Extensions
+{
+    public class BindTryTests_ValueTask_Right : BindTryTestsBase
+    {
+        #region BindTry for Result with function returning ValueTask<Result>
+        [Fact]
+        public async ValueTask BindTry_execute_valuetask_func_returning_success_on_success_returns_success()
+        {
+            Result sut = Result.Success();
+
+            Result result = await sut.BindTry(ValueTask_Success);
+
+            AssertSuccess(result);
+        }
+
+        [Fact]
+        public async ValueTask BindTry_execute_valuetask_func_returning_success_on_failure_returns_failure()
+        {
+            Result sut = Result.Failure(ErrorMessage);
+
+            Result result = await sut.BindTry(ValueTask_Success);
+
+            AssertFailure(result);
+        }
+
+        [Fact]
+        public async ValueTask BindTry_execute_valuetask_func_returning_failure_on_success_returns_failure()
+        {
+            Result sut = Result.Success();
+
+            Result result = await sut.BindTry(ValueTask_Failure);
+
+            AssertFailure(result);
+        }
+
+        [Fact]
+        public async ValueTask BindTry_execute_throwing_valuetask_func_on_success_returns_failure_with_exception_message()
+        {
+            Result sut = Result.Success();
+
+            Result result = await sut.BindTry(ValueTask_Throwing);
+
+            AssertFailure(result);
+        }
+
+        [Fact]
+        public async ValueTask BindTry_execute_throwing_valuetask_func_on_success_with_custom_error_handler_returns_failure_with_custom_message()
+        {
+            Result sut = Result.Success();
+
+            Result result = await sut.BindTry(ValueTask_Throwing, e => ErrorMessage2);
+
+            AssertFailure(result, ErrorMessage2);
+        }
+        #endregion
+
+        #region BindTry for Result with function returning ValueTask<Result<K>>
+        [Fact]
+        public async ValueTask BindTry_execute_valuetask_func_returning_success_K_on_success_returns_success()
+        {
+            Result sut = Result.Success();
+
+            Result<K> result = await sut.BindTry(ValueTask_Success_K);
+
+            AssertSuccess(result);
+        }
+
+        [Fact]
+        public async ValueTask BindTry_execute_valuetask_func_returning_success_K_on_failure_returns_failure()
+        {
+            Result sut = Result.Failure(ErrorMessage);
+
+            Result<K> result = await sut.BindTry(ValueTask_Success_K);
+
+            AssertFailure(result);
+        }
+
+        [Fact]
+        public async ValueTask BindTry_execute_valuetask_func_returning_failure_K_on_success_returns_failure()
+        {
+            Result sut = Result.Success();
+
+            Result<K> result = await sut.BindTry(ValueTask_Failure_K);
+
+            AssertFailure(result);
+        }
+
+        [Fact]
+        public async ValueTask BindTry_execute_throwing_valuetask_func_K_on_success_returns_failure_with_exception_message()
+        {
+            Result sut = Result.Success();
+
+            Result<K> result = await sut.BindTry(ValueTask_Throwing_K);
+
+            AssertFailure(result);
+        }
+
+        [Fact]
+        public async ValueTask BindTry_execute_throwing_valuetask_func_K_on_success_with_custom_error_handler_returns_failure_with_custom_message()
+        {
+            Result sut = Result.Success();
+
+            Result<K> result = await sut.BindTry(ValueTask_Throwing_K, e => ErrorMessage2);
+
+            AssertFailure(result, ErrorMessage2);
+        }
+        #endregion
+
+        #region BindTry for Result<T> with function returning ValueTask<Result>
+        [Fact]
+        public async ValueTask BindTry_execute_valuetask_func_returning_success_T_on_success_returns_success()
+        {
+            Result<T> sut = Result.Success(T.Value);
+
+            Result result = await sut.BindTry(t => ValueTask_Success());
+
+            AssertSuccess(result);
+        }
+
+        [Fact]
+        public async ValueTask BindTry_execute_valuetask_func_returning_success_T_on_failure_returns_failure()
+        {
+            Result<T> sut = Result.Failure<T>(ErrorMessage);
+
+            Result result = await sut.BindTry(t => ValueTask_Success());
+
+            AssertFailure(result);
+        }
+
+        [Fact]
+        public async ValueTask BindTry_execute_valuetask_func_returning_failure_T_on_success_returns_failure()
+        {
+            Result<T> sut = Result.Failure<T>(ErrorMessage);
+
+            Result result = await sut.BindTry(t => ValueTask_Failure());
+
+            AssertFailure(result);
+        }
+
+        [Fact]
+        public async ValueTask BindTry_execute_throwing_valuetask_func_on_success_T_returns_failure_with_exception_message()
+        {
+            Result<T> sut = Result.Success(T.Value);
+
+            Result result = await sut.BindTry(t => ValueTask_Throwing());
+
+            AssertFailure(result);
+        }
+
+        [Fact]
+        public async ValueTask BindTry_execute_throwing_valuetask_func_on_success_T_with_custom_error_handler_returns_failure_with_custom_message()
+        {
+            Result<T> sut = Result.Success(T.Value);
+
+            Result result = await sut.BindTry(t => ValueTask_Throwing(), e => ErrorMessage2);
+
+            AssertFailure(result, ErrorMessage2);
+        }
+        #endregion
+
+        #region BindTry for Result<T> with function returning ValueTask<Result<K>>
+        [Fact]
+        public async ValueTask BindTry_execute_valuetask_func_returning_success_K_on_success_T_returns_success()
+        {
+            Result<T> sut = Result.Success(T.Value);
+
+            Result<K> result = await sut.BindTry(t => ValueTask_Success_K());
+
+            AssertSuccess(result);
+        }
+
+        [Fact]
+        public async ValueTask BindTry_execute_valuetask_func_returning_success_K_on_failure_T_returns_failure()
+        {
+            Result<T> sut = Result.Failure<T>(ErrorMessage);
+
+            Result<K> result = await sut.BindTry(t => ValueTask_Success_K());
+
+            AssertFailure(result);
+        }
+
+        [Fact]
+        public async ValueTask BindTry_execute_valuetask_func_returning_failure_K_on_success_T_returns_failure()
+        {
+            Result<T> sut = Result.Success(T.Value);
+
+            Result<K> result = await sut.BindTry(t => ValueTask_Failure_K());
+
+            AssertFailure(result);
+        }
+
+        [Fact]
+        public async ValueTask BindTry_execute_throwing_valuetask_func_K_on_success_T_returns_failure_with_exception_message()
+        {
+            Result<T> sut = Result.Success(T.Value);
+
+            Result<K> result = await sut.BindTry(t => ValueTask_Throwing_K());
+
+            AssertFailure(result);
+        }
+
+        [Fact]
+        public async ValueTask BindTry_execute_throwing_valuetask_func_K_on_success_T_with_custom_error_handler_returns_failure_with_custom_message()
+        {
+            Result<T> sut = Result.Success(T.Value);
+
+            Result<K> result = await sut.BindTry(t => ValueTask_Throwing_K(), e => ErrorMessage2);
+
+            AssertFailure(result, ErrorMessage2);
+        }
+        #endregion
+
+        #region BindTry for Result<T,E> with function returning ValueTask<UnitResult<E>>
+        [Fact]
+        public async ValueTask BindTry_execute_valuetask_func_returning_success_E_on_success_T_E_returns_success()
+        {
+            Result<T, E> sut = Result.Success<T, E>(T.Value);
+
+            UnitResult<E> result = await sut.BindTry(t => ValueTask_UnitResult_Success_E(), e => E.Value2);
+
+            AssertSuccess(result);
+        }
+
+        [Fact]
+        public async ValueTask BindTry_execute_valuetask_func_returning_success_E_on_failure_T_E_returns_failure()
+        {
+            Result<T, E> sut = Result.Failure<T, E>(E.Value);
+
+            UnitResult<E> result = await sut.BindTry(t => ValueTask_UnitResult_Success_E(), e => E.Value2);
+
+            AssertFailure(result);
+        }
+
+        [Fact]
+        public async ValueTask BindTry_execute_valuetask_func_returning_failure_E_on_success_T_E_returns_failure()
+        {
+            Result<T, E> sut = Result.Success<T, E>(T.Value);
+
+            UnitResult<E> result = await sut.BindTry(t => ValueTask_UnitResult_Failure_E(), e => E.Value2);
+
+            AssertFailure(result);
+        }
+
+        [Fact]
+        public async ValueTask BindTry_execute_throwing_valuetask_func_E_on_success_T_E_returns_failure_with_value_from_error_handler()
+        {
+            Result<T, E> sut = Result.Success<T, E>(T.Value);
+
+            UnitResult<E> result = await sut.BindTry(t => ValueTask_Throwing_E(), e => E.Value2);
+
+            AssertFailure(result, E.Value2);
+        }
+        #endregion
+
+        #region BindTry for Result<T,E> with function returning ValueTask<Result<K,E>>
+        [Fact]
+        public async ValueTask BindTry_execute_valuetask_func_returning_success_K_E_on_success_T_E_returns_success()
+        {
+            Result<T, E> sut = Result.Success<T, E>(T.Value);
+
+            Result<K, E> result = await sut.BindTry(ValueTask_Success_K_E, e => E.Value2);
+
+            AssertSuccess(result);
+        }
+
+        [Fact]
+        public async ValueTask BindTry_execute_valuetask_func_returning_success_K_E_on_failure_T_E_returns_failure()
+        {
+            Result<T, E> sut = Result.Failure<T, E>(E.Value);
+
+            Result<K, E> result = await sut.BindTry(ValueTask_Success_K_E, e => E.Value2);
+
+            AssertFailure(result);
+        }
+
+        [Fact]
+        public async ValueTask BindTry_execute_valuetask_func_returning_failure_K_E_on_success_T_E_returns_failure()
+        {
+            Result<T, E> sut = Result.Success<T, E>(T.Value);
+
+            Result<K, E> result = await sut.BindTry(ValueTask_Failure_K_E, e => E.Value2);
+
+            AssertFailure(result);
+        }
+
+        [Fact]
+        public async ValueTask BindTry_execute_throwing_valuetask_func_K_E_on_success_T_E_returns_failure_with_value_from_error_handler()
+        {
+            Result<T, E> sut = Result.Success<T, E>(T.Value);
+
+            Result<K, E> result = await sut.BindTry(t => ValueTask_Throwing_K_E(), e => E.Value2);
+
+            AssertFailure(result, E.Value2);
+        }
+        #endregion
+
+        #region BindTry for UnitResult<E> with function returning ValueTask<Result<T,E>>
+        [Fact]
+        public async ValueTask BindTry_execute_valuetask_func_returning_success_T_E_on_success_E_returns_success()
+        {
+            UnitResult<E> sut = UnitResult.Success<E>();
+
+            Result<T, E> result = await sut.BindTry(ValueTask_Success_T_E, e => E.Value2);
+
+            AssertSuccess(result);
+        }
+
+        [Fact]
+        public async ValueTask BindTry_execute_valuetask_func_returning_success_T_E_on_failure_E_returns_failure()
+        {
+            UnitResult<E> sut = UnitResult.Failure(E.Value);
+
+            Result<T, E> result = await sut.BindTry(ValueTask_Success_T_E, e => E.Value2);
+
+            AssertFailure(result);
+        }
+
+        [Fact]
+        public async ValueTask BindTry_execute_valuetask_func_returning_failure_T_E_on_success_E_returns_failure()
+        {
+            UnitResult<E> sut = UnitResult.Success<E>();
+
+            Result<T, E> result = await sut.BindTry(ValueTask_Failure_T_E, e => E.Value2);
+
+            AssertFailure(result);
+        }
+
+        [Fact]
+        public async ValueTask BindTry_execute_throwing_valuetask_func_T_E_on_success_E_returns_failure_with_value_from_error_handler()
+        {
+            UnitResult<E> sut = UnitResult.Success<E>();
+
+            Result<T, E> result = await sut.BindTry(ValueTask_Throwing_T_E, e => E.Value2);
+
+            AssertFailure(result, E.Value2);
+        }
+        #endregion
+
+        #region BindTry for UnitResult<E> with function returning ValueTask<UnitResult<E>>
+        [Fact]
+        public async ValueTask BindTry_execute_valuetask_func_returning_success_E_on_success_E_returns_success()
+        {
+            UnitResult<E> sut = UnitResult.Success<E>();
+
+            UnitResult<E> result = await sut.BindTry(ValueTask_UnitResult_Success_E, e => E.Value2);
+
+            AssertSuccess(result);
+        }
+
+        [Fact]
+        public async ValueTask BindTry_execute_valuetask_func_returning_success_E_on_failure_E_returns_failure()
+        {
+            UnitResult<E> sut = UnitResult.Failure(E.Value);
+
+            UnitResult<E> result = await sut.BindTry(ValueTask_UnitResult_Success_E, e => E.Value2);
+
+            AssertFailure(result);
+        }
+
+        [Fact]
+        public async ValueTask BindTry_execute_valuetask_func_returning_failure_E_on_success_E_returns_failure()
+        {
+            UnitResult<E> sut = UnitResult.Success<E>();
+
+            UnitResult<E> result = await sut.BindTry(ValueTask_UnitResult_Failure_E, e => E.Value2);
+
+            AssertFailure(result);
+        }
+
+        [Fact]
+        public async ValueTask BindTry_execute_throwing_valuetask_func_E_on_success_E_returns_failure_with_value_from_error_handler()
+        {
+            UnitResult<E> sut = UnitResult.Success<E>();
+
+            UnitResult<E> result = await sut.BindTry(ValueTask_Throwing_E, e => E.Value2);
+
+            AssertFailure(result, E.Value2);
+        }
+        #endregion
+    }
+}

--- a/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/BindTryTests.ValueTask.cs
+++ b/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/BindTryTests.ValueTask.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading.Tasks;
+﻿using CSharpFunctionalExtensions.ValueTasks;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace CSharpFunctionalExtensions.Tests.ResultTests.Extensions

--- a/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/BindTryTests.ValueTask.cs
+++ b/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/BindTryTests.ValueTask.cs
@@ -1,0 +1,384 @@
+﻿using System.Threading.Tasks;
+using Xunit;
+
+namespace CSharpFunctionalExtensions.Tests.ResultTests.Extensions
+{
+    public class BindTryTests_ValueTask : BindTryTestsBase
+    {
+        #region BindTry for ValueTask<Result> with function returning ValueTask<Result>
+        [Fact]
+        public async ValueTask BindTry_execute_valuetask_func_returning_success_on_valuetask_success_returns_success()
+        {
+            ValueTask<Result> sut = Result.Success().AsValueTask();
+
+            Result result = await sut.BindTry(ValueTask_Success);
+
+            AssertSuccess(result);
+        }
+
+        [Fact]
+        public async ValueTask BindTry_execute_valuetask_func_returning_success_on_valuetask_failure_returns_failure()
+        {
+            ValueTask<Result> sut = Result.Failure(ErrorMessage).AsValueTask();
+
+            Result result = await sut.BindTry(ValueTask_Success);
+
+            AssertFailure(result);
+        }
+
+        [Fact]
+        public async ValueTask BindTry_execute_valuetask_func_returning_failure_on_valuetask_success_returns_failure()
+        {
+            ValueTask<Result> sut = Result.Success().AsValueTask();
+
+            Result result = await sut.BindTry(ValueTask_Failure);
+
+            AssertFailure(result);
+        }
+
+        [Fact]
+        public async ValueTask BindTry_execute_throwing_valuetask_func_on_taks_success_returns_failure_with_exception_message()
+        {
+            ValueTask<Result> sut = Result.Success().AsValueTask();
+
+            Result result = await sut.BindTry(ValueTask_Throwing);
+
+            AssertFailure(result);
+        }
+
+        [Fact]
+        public async ValueTask BindTry_execute_throwing_valuetask_func_on_success_with_custom_error_handler_returns_failure_with_custom_message()
+        {
+            ValueTask<Result> sut = Result.Success().AsValueTask();
+
+            Result result = await sut.BindTry(ValueTask_Throwing, e => ErrorMessage2);
+
+            AssertFailure(result, ErrorMessage2);
+        }
+        #endregion
+
+        #region BindTry for ValueTask<Result> with function returning ValueTask<Result<K>>
+        [Fact]
+        public async ValueTask BindTry_execute_valuetask_func_returning_success_K_on_valuetask_success_returns_success()
+        {
+            ValueTask<Result> sut = Result.Success().AsValueTask();
+
+            Result<K> result = await sut.BindTry(ValueTask_Success_K);
+
+            AssertSuccess(result);
+        }
+
+        [Fact]
+        public async ValueTask BindTry_execute_valuetask_func_returning_success_K_on_valuetask_failure_returns_failure()
+        {
+            ValueTask<Result> sut = Result.Failure(ErrorMessage).AsValueTask();
+
+            Result<K> result = await sut.BindTry(ValueTask_Success_K);
+
+            AssertFailure(result);
+        }
+
+        [Fact]
+        public async ValueTask BindTry_execute_valuetask_func_returning_failure_K_on_valuetask_success_returns_failure()
+        {
+            ValueTask<Result> sut = Result.Success().AsValueTask();
+
+            Result<K> result = await sut.BindTry(ValueTask_Failure_K);
+
+            AssertFailure(result);
+        }
+
+        [Fact]
+        public async ValueTask BindTry_execute_throwing_valuetask_func_K_on_taks_success_returns_failure_with_exception_message()
+        {
+            ValueTask<Result> sut = Result.Success().AsValueTask();
+
+            Result<K> result = await sut.BindTry(ValueTask_Throwing_K);
+
+            AssertFailure(result);
+        }
+
+        [Fact]
+        public async ValueTask BindTry_execute_throwing_valuetask_func_K_on_valuetask_success_with_custom_error_handler_returns_failure_with_custom_message()
+        {
+            ValueTask<Result> sut = Result.Success().AsValueTask();
+
+            Result<K> result = await sut.BindTry(ValueTask_Throwing_K, e => ErrorMessage2);
+
+            AssertFailure(result, ErrorMessage2);
+        }
+        #endregion
+
+        #region BindTry for ValueTask<Result<T>> with function returning ValueTask<Result>
+        [Fact]
+        public async ValueTask BindTry_execute_valuetask_func_returning_success_T_on_valuetask_success_returns_success()
+        {
+            ValueTask<Result<T>> sut = Result.Success(T.Value).AsValueTask();
+
+            Result result = await sut.BindTry(t => ValueTask_Success());
+
+            AssertSuccess(result);
+        }
+
+        [Fact]
+        public async ValueTask BindTry_execute_valuetask_func_returning_success_T_on_valuetask_failure_returns_failure()
+        {
+            ValueTask<Result<T>> sut = Result.Failure<T>(ErrorMessage).AsValueTask();
+
+            Result result = await sut.BindTry(t => ValueTask_Success());
+
+            AssertFailure(result);
+        }
+
+        [Fact]
+        public async ValueTask BindTry_execute_valuetask_func_returning_failure_T_on_valuetask_success_returns_failure()
+        {
+            ValueTask<Result<T>> sut = Result.Success(T.Value).AsValueTask();
+
+            Result result = await sut.BindTry(t => ValueTask_Failure());
+
+            AssertFailure(result);
+        }
+
+        [Fact]
+        public async ValueTask BindTry_execute_throwing_valuetask_func_on_taks_success_T_returns_failure_with_exception_message()
+        {
+            ValueTask<Result<T>> sut = Result.Success(T.Value).AsValueTask();
+
+            Result result = await sut.BindTry(t => ValueTask_Throwing());
+
+            AssertFailure(result);
+        }
+
+        [Fact]
+        public async ValueTask BindTry_execute_throwing_valuetask_func_on_success_T_with_custom_error_handler_returns_failure_with_custom_message()
+        {
+            ValueTask<Result<T>> sut = Result.Success(T.Value).AsValueTask();
+
+            Result result = await sut.BindTry(t => ValueTask_Throwing(), e => ErrorMessage2);
+
+            AssertFailure(result, ErrorMessage2);
+        }
+        #endregion
+
+        #region BindTry for ValueTask<Result<T>> with function returning ValueTask<Result<K>>
+        [Fact]
+        public async ValueTask BindTry_execute_valuetask_func_returning_success_K_on_valuetask_success_T_returns_success()
+        {
+            ValueTask<Result<T>> sut = Result.Success(T.Value).AsValueTask();
+
+            Result<K> result = await sut.BindTry(t => ValueTask_Success_K());
+
+            AssertSuccess(result);
+        }
+
+        [Fact]
+        public async ValueTask BindTry_execute_valuetask_func_returning_success_K_on_valuetask_failure_T_returns_failure()
+        {
+            ValueTask<Result<T>> sut = Result.Failure<T>(ErrorMessage).AsValueTask();
+
+            Result<K> result = await sut.BindTry(t => ValueTask_Success_K());
+
+            AssertFailure(result);
+        }
+
+        [Fact]
+        public async ValueTask BindTry_execute_valuetask_func_returning_failure_K_on_valuetask_success_T_returns_failure()
+        {
+            ValueTask<Result<T>> sut = Result.Success(T.Value).AsValueTask();
+
+            Result<K> result = await sut.BindTry(t => ValueTask_Failure_K());
+
+            AssertFailure(result);
+        }
+
+        [Fact]
+        public async ValueTask BindTry_execute_throwing_valuetask_func_K_on_taks_success_T_returns_failure_with_exception_message()
+        {
+            ValueTask<Result<T>> sut = Result.Success(T.Value).AsValueTask();
+
+            Result<K> result = await sut.BindTry(t => ValueTask_Throwing_K());
+
+            AssertFailure(result);
+        }
+
+        [Fact]
+        public async ValueTask BindTry_execute_throwing_valuetask_func_K_on_success_T_with_custom_error_handler_returns_failure_with_custom_message()
+        {
+            ValueTask<Result<T>> sut = Result.Success(T.Value).AsValueTask();
+
+            Result<K> result = await sut.BindTry(t => ValueTask_Throwing_K(), e => ErrorMessage2);
+
+            AssertFailure(result, ErrorMessage2);
+        }
+        #endregion
+
+        #region BindTry for ValueTask<Result<T,E>> with function returning ValueTask<UnitResult<E>>
+        [Fact]
+        public async ValueTask BindTry_execute_valuetask_func_returning_success_E_on_valuetask_success_T_E_returns_success()
+        {
+            ValueTask<Result<T, E>> sut = Result.Success<T, E>(T.Value).AsValueTask();
+
+            UnitResult<E> result = await sut.BindTry(t => ValueTask_UnitResult_Success_E(), e => E.Value2);
+
+            AssertSuccess(result);
+        }
+
+        [Fact]
+        public async ValueTask BindTry_execute_valuetask_func_returning_success_E_on_valuetask_failure_T_E_returns_failure()
+        {
+            ValueTask<Result<T, E>> sut = Result.Failure<T, E>(E.Value).AsValueTask();
+
+            UnitResult<E> result = await sut.BindTry(t => ValueTask_UnitResult_Success_E(), e => E.Value2);
+
+            AssertFailure(result);
+        }
+
+        [Fact]
+        public async ValueTask BindTry_execute_valuetask_func_returning_failure_E_on_valuetask_success_T_E_returns_failure()
+        {
+            ValueTask<Result<T, E>> sut = Result.Success<T, E>(T.Value).AsValueTask();
+
+            UnitResult<E> result = await sut.BindTry(t => ValueTask_UnitResult_Failure_E(), e => E.Value2);
+
+            AssertFailure(result);
+        }
+
+        [Fact]
+        public async ValueTask BindTry_execute_throwing_valuetask_func_E_on_success_T_E_returns_failure_with_value_from_error_handler()
+        {
+            ValueTask<Result<T, E>> sut = Result.Success<T, E>(T.Value).AsValueTask();
+
+            UnitResult<E> result = await sut.BindTry(t => ValueTask_Throwing_E(), e => E.Value2);
+
+            AssertFailure(result, E.Value2);
+        }
+        #endregion
+
+        #region BindTry for ValueTask<Result<T,E>> with function returning ValueTask<Result<K,E>>
+        [Fact]
+        public async ValueTask BindTry_execute_valuetask_func_returning_success_K_E_on_valuetask_success_T_E_returns_success()
+        {
+            ValueTask<Result<T, E>> sut = Result.Success<T, E>(T.Value).AsValueTask();
+
+            Result<K, E> result = await sut.BindTry(ValueTask_Success_K_E, e => E.Value2);
+
+            AssertSuccess(result);
+        }
+
+        [Fact]
+        public async ValueTask BindTry_execute_valuetask_func_returning_success_K_E_on_valuetask_failure_T_E_returns_failure()
+        {
+            ValueTask<Result<T, E>> sut = Result.Failure<T, E>(E.Value).AsValueTask();
+
+            Result<K, E> result = await sut.BindTry(ValueTask_Success_K_E, e => E.Value2);
+
+            AssertFailure(result);
+        }
+
+        [Fact]
+        public async ValueTask BindTry_execute_valuetask_func_returning_failure_K_E_on_valuetask_success_T_E_returns_failure()
+        {
+            ValueTask<Result<T, E>> sut = Result.Success<T, E>(T.Value).AsValueTask();
+
+            Result<K, E> result = await sut.BindTry(ValueTask_Failure_K_E, e => E.Value2);
+
+            AssertFailure(result);
+        }
+
+        [Fact]
+        public async ValueTask BindTry_execute_throwing_valuetask_func_K_E_on_success_T_E_returns_failure_with_value_from_error_handler()
+        {
+            ValueTask<Result<T, E>> sut = Result.Success<T, E>(T.Value).AsValueTask();
+
+            Result<K, E> result = await sut.BindTry(t => ValueTask_Throwing_K_E(), e => E.Value2);
+
+            AssertFailure(result, E.Value2);
+        }
+        #endregion
+
+        #region BindTry for ValueTask<UnitResult<E>> with function returning ValueTask<Result<T,E>>
+        [Fact]
+        public async ValueTask BindTry_execute_valuetask_func_returning_success_T_E_on_valuetask_success_E_returns_success()
+        {
+            ValueTask<UnitResult<E>> sut = UnitResult.Success<E>().AsValueTask();
+
+            Result<T, E> result = await sut.BindTry(ValueTask_Success_T_E, e => E.Value2);
+
+            AssertSuccess(result);
+        }
+
+        [Fact]
+        public async ValueTask BindTry_execute_valuetask_func_returning_success_T_E_on_valuetask_failure_E_returns_failure()
+        {
+            ValueTask<UnitResult<E>> sut = UnitResult.Failure(E.Value).AsValueTask();
+
+            Result<T, E> result = await sut.BindTry(ValueTask_Success_T_E, e => E.Value2);
+
+            AssertFailure(result);
+        }
+
+        [Fact]
+        public async ValueTask BindTry_execute_valuetask_func_returning_failure_T_E_on_valuetask_success_E_returns_failure()
+        {
+            ValueTask<UnitResult<E>> sut = UnitResult.Success<E>().AsValueTask();
+
+            Result<T, E> result = await sut.BindTry(ValueTask_Failure_T_E, e => E.Value2);
+
+            AssertFailure(result);
+        }
+
+        [Fact]
+        public async ValueTask BindTry_execute_throwing_valuetask_func_T_E_on_success_E_returns_failure_with_value_from_error_handler()
+        {
+            ValueTask<UnitResult<E>> sut = UnitResult.Success<E>().AsValueTask();
+
+            Result<T, E> result = await sut.BindTry(ValueTask_Throwing_T_E, e => E.Value2);
+
+            AssertFailure(result, E.Value2);
+        }
+        #endregion
+
+        #region BindTry for ValueTask<UnitResult<E>> with function returning ValueTask<UnitResult<E>>
+        [Fact]
+        public async ValueTask BindTry_execute_valuetask_func_returning_success_E_on_valuetask_success_E_returns_success()
+        {
+            ValueTask<UnitResult<E>> sut = UnitResult.Success<E>().AsValueTask();
+
+            UnitResult<E> result = await sut.BindTry(ValueTask_UnitResult_Success_E, e => E.Value2);
+
+            AssertSuccess(result);
+        }
+
+        [Fact]
+        public async ValueTask BindTry_execute_valuetask_func_returning_success_E_on_valuetask_failure_E_returns_failure()
+        {
+            ValueTask<UnitResult<E>> sut = UnitResult.Failure(E.Value).AsValueTask();
+
+            UnitResult<E> result = await sut.BindTry(ValueTask_UnitResult_Success_E, e => E.Value2);
+
+            AssertFailure(result);
+        }
+
+        [Fact]
+        public async ValueTask BindTry_execute_valuetask_func_returning_failure_E_on_valuetask_success_E_returns_failure()
+        {
+            ValueTask<UnitResult<E>> sut = UnitResult.Success<E>().AsValueTask();
+
+            UnitResult<E> result = await sut.BindTry(ValueTask_UnitResult_Failure_E, e => E.Value2);
+
+            AssertFailure(result);
+        }
+
+        [Fact]
+        public async ValueTask BindTry_execute_throwing_valuetask_func_E_on_success_E_returns_failure_with_value_from_error_handler()
+        {
+            ValueTask<UnitResult<E>> sut = UnitResult.Success<E>().AsValueTask();
+
+            UnitResult<E> result = await sut.BindTry(ValueTask_Throwing_E, e => E.Value2);
+
+            AssertFailure(result, E.Value2);
+        }
+        #endregion
+    }
+}

--- a/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/BindTryTests.cs
+++ b/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/BindTryTests.cs
@@ -39,9 +39,8 @@ namespace CSharpFunctionalExtensions.Tests.ResultTests.Extensions
         public void BindTry_execute_throwing_func_on_success_returns_failure_with_exception_message()
         {
             Result sut = Result.Success();
-            System.Func<Result> func = Result () => Throwing();
 
-            Result result = sut.BindTry(func);
+            Result result = sut.BindTry(Throwing);
 
             AssertFailure(result);
         }
@@ -51,9 +50,8 @@ namespace CSharpFunctionalExtensions.Tests.ResultTests.Extensions
         public void BindTry_execute_throwing_func_on_success_with_custom_error_handler_returns_failure_with_custom_message()
         {
             Result sut = Result.Success();
-            System.Func<Result> func = Result () => Throwing();
 
-            Result result = sut.BindTry(func, e => ErrorMessage2);
+            Result result = sut.BindTry(Throwing, e => ErrorMessage2);
 
             AssertFailure(result, ErrorMessage2);
         }

--- a/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/BindTryTests.cs
+++ b/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/BindTryTests.cs
@@ -1,0 +1,461 @@
+﻿using CSharpFunctionalExtensions.Tests.ResultTests.Methods.Try;
+using FluentAssertions;
+using Xunit;
+
+namespace CSharpFunctionalExtensions.Tests.ResultTests.Extensions
+{
+    public sealed class BindTryTests : TryTestBase
+    {
+        #region BindTry for Result with function returning Result
+        [Fact]
+        public void BindTry_execute_func_returning_success_on_success_returns_success()
+        {
+            var sut = Result.Success();
+            var func = Result () => Result.Success(Func_T());
+
+            var result = sut.BindTry(func);
+
+            result.IsSuccess.Should().BeTrue();                        
+            FuncExecuted.Should().BeTrue();
+        }
+        [Fact]
+        public void BindTry_execute_func_returning_success_on_failure_returns_self()
+        {
+            var sut = Result.Failure(ErrorMessage);
+            var func = Result () => Result.Success(Func_T());
+            
+            var result = sut.BindTry(func);
+                        
+            AssertFailure(result);
+            result.Should().Equals(sut);            
+            FuncExecuted.Should().BeFalse();
+        }
+        [Fact]
+        public void BindTry_execute_func_returning_failure_on_success_returns_failure()
+        {
+            var sut = Result.Success();
+            var func = Result () => Result.Failure(ErrorMessage);
+
+            var result = sut.BindTry(func);
+
+            result.IsSuccess.Should().BeFalse();
+            result.Error.Should().Be(ErrorMessage);                        
+        }       
+
+        [Fact]
+        public void BindTry_execute_throwing_func_on_success_returns_failure_with_exception_message()
+        {
+            var sut = Result.Success();
+            var func = Result () => Result.Success(Throwing_Func_T());
+
+            var result = sut.BindTry(func);
+
+            result.IsSuccess.Should().BeFalse();
+            result.Error.Should().Be(ErrorMessage);
+        }
+        [Fact]
+        public void BindTry_execute_throwing_func_on_success_with_custom_error_handler_returns_failure_with_custom_message()
+        {
+            var sut = Result.Success();
+            var func = Result () => Result.Success(Throwing_Func_T());
+         
+            var result = sut.BindTry(func,e => ErrorMessage2);
+
+            AssertFailure(result, ErrorMessage2);
+        }
+        #endregion
+
+        #region BindTry for Result with function returning Result<K>
+        [Fact]
+        public void BindTry_execute_func_K_returning_success_on_success_returns_success()
+        {
+            var sut = Result.Success();
+            var func = Result<K> () => Result.Success(Func_T_K(T.Value));
+
+            var result = sut.BindTry(func);
+
+            result.IsSuccess.Should().BeTrue();
+            result.Value.Should().Be(K.Value);
+            FuncExecuted.Should().BeTrue();            
+        }
+        [Fact]
+        public void BindTry_execute_func_K_returning_success_on_failure_returns_self()
+        {
+            var sut = Result.Failure(ErrorMessage);
+            var func = Result<K> () => Result.Success(Func_T_K(T.Value));
+
+            var result = sut.BindTry(func);
+
+            AssertFailure(result);            
+            result.Should().Equals(sut);
+            FuncExecuted.Should().BeFalse();
+        }
+        [Fact]
+        public void BindTry_execute_func_K_returning_failure_on_success_returns_failure()
+        {
+            var sut = Result.Success();
+            var func = Result<K> () => Result.Failure<K>(ErrorMessage);
+
+            var result = sut.BindTry(func);
+
+            AssertFailure(result);
+        }
+
+        [Fact]
+        public void BindTry_execute_throwing_func_K_on_success_returns_failure_with_exception_message()
+        {
+            var sut = Result.Success();
+            var func = Result<K> () => Result.Success(Throwing_Func_T_K(T.Value));
+
+            var result = sut.BindTry(func);
+
+            AssertFailure(result);            
+        }
+        [Fact]
+        public void BindTry_execute_throwing_func_K_on_success_with_custom_error_handler_returns_failure_with_custom_message()
+        {
+            var sut = Result.Success();
+            var func = Result () => Result.Success(Throwing_Func_T_K(T.Value));
+            
+            var result = sut.BindTry(func, e => ErrorMessage2);
+
+            AssertFailure(result, ErrorMessage2);
+        }
+        #endregion
+
+        #region BindTry for Result<T> with function returning Result
+        [Fact]
+        public void BindTry_execute_func_returning_success_on_success_T_returns_success()
+        {
+            Result<T> sut = Result.Success(T.Value);
+            var func = Result (T t) => Result.Success(Func_T());
+
+            var result = sut.BindTry(func);
+            result.IsSuccess.Should().BeTrue();                
+            FuncExecuted.Should().BeTrue();
+        }
+        [Fact]
+        public void BindTry_execute_func_returning_success_on_failure_T_returns_self()
+        {
+            Result<T> sut = Result.Failure<T>(ErrorMessage);
+            var func = Result (T t) => Result.Success(Func_T_K(t));
+
+            var result = sut.BindTry(func);
+
+            AssertFailure(result);
+            result.Should().Equals(sut);
+            FuncExecuted.Should().BeFalse();
+        }
+        [Fact]
+        public void BindTry_execute_func_returning_failure_on_success_T_returns_failure()
+        {
+            Result<T> sut = Result.Success(T.Value);
+            var func = Result (T _) => Result.Failure<T>(ErrorMessage);
+
+            var result = sut.BindTry(func);
+
+            AssertFailure(result);
+        }
+
+        [Fact]
+        public void BindTry_execute_throwing_func_on_success_T_returns_failure_with_exception_message()
+        {
+            Result<T> sut = Result.Success(T.Value);
+            var func = Result (T t) => Result.Success(Throwing_Func_T());
+
+            var result = sut.BindTry(func);
+
+            AssertFailure(result);
+        }
+        [Fact]
+        public void BindTry_execute_throwing_func_on_success_T_with_custom_error_handler_returns_failure_with_custom_message()
+        {
+            Result<T> sut = Result.Success(T.Value);
+            var func = Result (T _) => Result.Success(Throwing_Func_T());
+
+            var result = sut.BindTry(func, e => ErrorMessage2);
+
+            AssertFailure(result, ErrorMessage2);
+        }
+        #endregion
+
+        #region BindTry for Result<T> with function returning Result<K>
+        [Fact]
+        public void BindTry_execute_func_T_K_returning_success_on_success_T_returns_success_K()
+        {
+            Result<T> sut = Result.Success(T.Value);
+            var func = Result<K> (T t) => Result.Success(Func_T_K(t));
+
+            var result = sut.BindTry(func);
+
+            result.IsSuccess.Should().BeTrue();
+            result.Should().BeOfType<Result<K>>();
+            result.Value.Should().Be(K.Value);
+            FuncExecuted.Should().BeTrue();
+        }
+        [Fact]
+        public void BindTry_execute_func_T_K_returning_success_on_failure_T_returns_failure_K()
+        {
+            Result<T> sut = Result.Failure<T>(ErrorMessage);
+            var func = Result<K> (T t) => Result.Success(Func_T_K(t));
+
+            var result = sut.BindTry(func);
+
+            AssertFailure(result);
+            result.Should().BeOfType<Result<K>>();
+            result.Should().Equals(sut);            
+            FuncExecuted.Should().BeFalse();
+        }
+        [Fact]
+        public void BindTry_execute_func_K_returning_failure_K_on_success_returns_failure_K()
+        {
+            Result<T> sut = Result.Success(T.Value);
+            var func = Result<K> (T _) => Result.Failure<K>(ErrorMessage);
+
+            var result = sut.BindTry(func);
+
+            AssertFailure(result);
+        }
+
+        [Fact]
+        public void BindTry_execute_throwing_func_T_K_on_success_T_returns_failure_K_with_exception_message()
+        {
+            Result<T> sut = Result.Success(T.Value);
+            var func = Result<K> (T t) => Result.Success(Throwing_Func_T_K(T.Value));
+
+            var result = sut.BindTry(func);
+
+            AssertFailure(result);
+        }
+        [Fact]
+        public void BindTry_execute_throwing_func_T_K_on_success_T_with_custom_error_handler_returns_failure_K_with_custom_message()
+        {
+            var sut = Result.Success();
+            var func = Result () => Result.Success(Throwing_Func_T_K(T.Value));
+
+            var result = sut.BindTry(func, e => ErrorMessage2);
+
+            AssertFailure(result, ErrorMessage2);
+        }
+        #endregion
+
+        #region BindTry for Result<T,E> with function returning Result<K,E>
+        [Fact]
+        public void BindTry_execute_func_T_K_E_returning_success_on_success_T_E_returns_success_K_E()
+        {
+            Result<T,E> sut = Result.Success<T,E>(T.Value);
+            var func = Result<K,E> (T t) => Result.Success<K,E>(Func_T_K(t));
+
+            var result = sut.BindTry(func, e => E.Value2);
+
+            result.IsSuccess.Should().BeTrue();
+            result.Should().BeOfType<Result<K,E>>();
+            result.Value.Should().Be(K.Value);
+            FuncExecuted.Should().BeTrue();
+        }
+        [Fact]
+        public void BindTry_execute_func_T_K_E_returning_success_on_failure_T_E_returns_failure_K_E()
+        {
+            Result<T,E> sut = Result.Failure<T,E>(E.Value);
+            var func = Result<K,E> (T t) => Result.Success<K,E>(Func_T_K(t));
+
+            var result = sut.BindTry(func, e => E.Value2);
+
+            result.IsSuccess.Should().BeFalse();
+            result.Error.Should().Be(E.Value);
+            result.Should().BeOfType<Result<K,E>>();            
+            FuncExecuted.Should().BeFalse();
+        }
+        [Fact]
+        public void BindTry_execute_func_T_K_E_returning_failure_on_success_T_E_returns_failure_K_E()
+        {
+            Result<T,E> sut = Result.Success<T,E>(T.Value);
+            var func = Result<K,E> (T _) => Result.Failure<K,E>(E.Value);
+
+            var result = sut.BindTry(func, e => E.Value2);
+
+            result.IsSuccess.Should().BeFalse();
+            result.Error.Should().Be(E.Value);
+            result.Should().BeOfType<Result<K, E>>();
+        }
+
+        [Fact]
+        public void BindTry_execute_throwing_func_T_K_E_on_success_T_E_returns_failure_K_E_with_value_from_error_handler()
+        {
+            Result<T,E> sut = Result.Success<T,E>(T.Value);
+            var func = Result<K,E> (T t) => Result.Success<K,E>(Throwing_Func_T_K(T.Value));
+
+            var result = sut.BindTry(func, e=> E.Value2);
+
+            result.IsSuccess.Should().BeFalse();
+            result.Error.Should().Be(E.Value2);
+            result.Should().BeOfType<Result<K, E>>();
+        }
+        #endregion
+
+        #region BindTry for UnitResult<E> with function returning UnitResult<E>
+        [Fact]
+        public void BindTry_execute_func_E_returning_unitresult_success_on_success_E_returns_success_K_E()
+        {
+            UnitResult<E> sut = UnitResult.Success<E>();
+            var func = UnitResult<E> () => Result.Success(Func_T()).Map(_ => UnitResult.Success<E>()).Value;
+
+            var result = sut.BindTry(func, e => E.Value2    );
+
+            result.IsSuccess.Should().BeTrue();
+            result.Should().BeOfType<UnitResult<E>>();            
+            FuncExecuted.Should().BeTrue();
+        }
+        [Fact]
+        public void BindTry_execute_func_E_returning_success_on_failure_E_returns_failure_E()
+        {
+            UnitResult<E> sut = UnitResult.Failure(E.Value);
+            var func = UnitResult<E> () => Result.Success(Func_T()).Map(_ => UnitResult.Success<E>()).Value;
+
+            var result = sut.BindTry(func, e => E.Value2);
+
+            result.IsSuccess.Should().BeFalse();
+            result.Error.Should().Be(E.Value);
+            result.Should().BeOfType<UnitResult<E>>();
+            FuncExecuted.Should().BeFalse();
+        }
+        [Fact]
+        public void BindTry_execute_func_E_returning_failure_on_success_E_returns_failure_E()
+        {
+            UnitResult<E> sut = UnitResult.Success<E>();
+            var func = UnitResult<E> () => UnitResult.Failure(E.Value);
+
+            var result = sut.BindTry(func, e => E.Value2);
+
+            result.IsSuccess.Should().BeFalse();
+            result.Error.Should().Be(E.Value);
+            result.Should().BeOfType<UnitResult<E>>();
+        }
+
+        [Fact]
+        public void BindTry_execute_throwing_func_E_on_success_E_returns_failure_E_with_value_from_error_handler()
+        {
+            UnitResult<E> sut = UnitResult.Success<E>();
+            var func = UnitResult<E> () => Result.Success<K, E>(Throwing_Func_T_K(T.Value));
+
+            var result = sut.BindTry(func, e=> E.Value2);
+
+            result.IsSuccess.Should().BeFalse();
+            result.Error.Should().Be(E.Value2);
+            result.Should().BeOfType<UnitResult<E>>();
+        }
+        #endregion
+
+        #region BindTry for UnitResult<E> with function returning Result<T,E>
+        [Fact]
+        public void BindTry_execute_func_T_E_returning_success_on_success_E_returns_success_T_E()
+        {
+            UnitResult<E> sut = UnitResult.Success<E>();
+            var func = Result<T,E> () => Result.Success<T,E>(Func_T());
+
+            var result = sut.BindTry(func, e => E.Value2);
+
+            result.IsSuccess.Should().BeTrue();
+            result.Should().BeOfType<Result<T,E>>();
+            FuncExecuted.Should().BeTrue();
+        }
+        [Fact]
+        public void BindTry_execute_func_T_E_returning_success_on_failure_E_returns_failure_T_E()
+        {
+            UnitResult<E> sut = UnitResult.Failure(E.Value);
+            var func = Result<T,E> () => Result.Success<T,E>(Func_T());
+
+            var result = sut.BindTry(func,e => E.Value2);
+
+            result.IsSuccess.Should().BeFalse();
+            result.Error.Should().Be(E.Value);
+            result.Should().BeOfType<Result<T,E>>();
+            FuncExecuted.Should().BeFalse();
+        }
+        [Fact]
+        public void BindTry_execute_func_T_E_returning_failure_on_success_E_returns_failure_T_E()
+        {
+            UnitResult<E> sut = UnitResult.Success<E>();
+            var func = Result<T,E> () => Result.Failure<T,E>(E.Value);
+
+            var result = sut.BindTry(func, e => E.Value2);
+
+            result.IsSuccess.Should().BeFalse();
+            result.Error.Should().Be(E.Value);
+            result.Should().BeOfType<Result<T,E>>();
+        }
+
+        [Fact]
+        public void BindTry_execute_throwing_func_T_E_on_success_E_returns_failure_E_with_value_from_error_handler()
+        {
+            UnitResult<E> sut = UnitResult.Success<E>();
+            var func = Result<T,E> () => Result.Success<T, E>(Throwing_Func_T());
+
+            var result = sut.BindTry(func, e => E.Value2);
+
+            result.IsSuccess.Should().BeFalse();
+            result.Error.Should().Be(E.Value2);
+            result.Should().BeOfType<Result<T,E>>();
+        }
+        #endregion
+
+        #region BindTry for Result<T,E> with function returning UnitResult<E>
+        [Fact]
+        public void BindTry_execute_func_E_returning_success_on_success_T_E_returns_success_E()
+        {
+            Result<T,E> sut = Result.Success<T,E>(T.Value);
+            var func = UnitResult<E> (T _) => Result.Success<T, E>(Func_T());
+
+            var result = sut.BindTry(func, e => E.Value2);
+
+            result.IsSuccess.Should().BeTrue();
+            result.Should().BeOfType<UnitResult<E>>();            
+            FuncExecuted.Should().BeTrue();
+        }
+        [Fact]
+        public void BindTry_execute_func_E_returning_success_on_failure_T_E_returns_failure_E()
+        {
+            Result<T, E> sut = Result.Failure<T, E>(E.Value);
+            var func = UnitResult<E> (T t) => Result.Success<T, E>(Func_T());
+
+            var result = sut.BindTry(func, e => E.Value2);
+
+            result.IsSuccess.Should().BeFalse();
+            result.Error.Should().Be(E.Value);
+            result.Should().BeOfType<UnitResult<E>>();
+            FuncExecuted.Should().BeFalse();
+        }
+        [Fact]
+        public void BindTry_execute_func_E_returning_failure_on_success_T_E_returns_failure_E()
+        {
+            Result<T,E> sut = Result.Success<T,E>(T.Value);
+            var func = UnitResult<E> (T t) => Result.Failure<T, E>(E.Value);
+
+            var result = sut.BindTry(func, e => E.Value2);
+
+            result.IsSuccess.Should().BeFalse();
+            result.Error.Should().Be(E.Value);
+            result.Should().BeOfType<UnitResult<E>>();
+        }
+
+        [Fact]
+        public void BindTry_execute_throwing_func_E_on_success_T_E_returns_failure_E_with_value_from_error_handler()
+        {
+            Result<T,E> sut = Result.Success<T,E>(T.Value);
+            var func = UnitResult<E> (T t) => Result.Success<T, E>(Throwing_Func_T());
+
+            var result = sut.BindTry(func, e => E.Value2);
+
+            result.IsSuccess.Should().BeFalse();
+            result.Error.Should().Be(E.Value2);
+            result.Should().BeOfType<UnitResult<E>>();
+        }
+        #endregion
+
+        private static void AssertFailure(Result result, string errorMessage=ErrorMessage)
+        {
+            result.IsSuccess.Should().BeFalse();
+            result.Error.Should().Be(errorMessage);
+        }
+    }
+}

--- a/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/BindTryTests.cs
+++ b/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/BindTryTests.cs
@@ -1,65 +1,59 @@
-﻿using CSharpFunctionalExtensions.Tests.ResultTests.Methods.Try;
-using FluentAssertions;
+﻿using FluentAssertions;
 using Xunit;
+using System;
 
 namespace CSharpFunctionalExtensions.Tests.ResultTests.Extensions
 {
-    public sealed class BindTryTests : TryTestBase
+    public sealed class BindTryTests : BindTryTestsBase
     {
         #region BindTry for Result with function returning Result
         [Fact]
         public void BindTry_execute_func_returning_success_on_success_returns_success()
         {
-            var sut = Result.Success();
-            var func = Result () => Result.Success(Func_T());
+            Result sut = Result.Success();
 
-            var result = sut.BindTry(func);
+            Result result = sut.BindTry(Success);
 
-            result.IsSuccess.Should().BeTrue();                        
-            FuncExecuted.Should().BeTrue();
+            AssertSuccess(result);
         }
         [Fact]
         public void BindTry_execute_func_returning_success_on_failure_returns_self()
         {
-            var sut = Result.Failure(ErrorMessage);
-            var func = Result () => Result.Success(Func_T());
-            
-            var result = sut.BindTry(func);
-                        
+            Result sut = Result.Failure(ErrorMessage);
+
+            Result result = sut.BindTry(Success);
+
             AssertFailure(result);
-            result.Should().Equals(sut);            
-            FuncExecuted.Should().BeFalse();
         }
         [Fact]
         public void BindTry_execute_func_returning_failure_on_success_returns_failure()
         {
-            var sut = Result.Success();
-            var func = Result () => Result.Failure(ErrorMessage);
+            Result sut = Result.Success();
 
-            var result = sut.BindTry(func);
+            Result result = sut.BindTry(Failure);
 
-            result.IsSuccess.Should().BeFalse();
-            result.Error.Should().Be(ErrorMessage);                        
-        }       
+            AssertFailure(result);
+        }
 
         [Fact]
         public void BindTry_execute_throwing_func_on_success_returns_failure_with_exception_message()
         {
-            var sut = Result.Success();
-            var func = Result () => Result.Success(Throwing_Func_T());
+            Result sut = Result.Success();
+            System.Func<Result> func = Result () => Throwing();
 
-            var result = sut.BindTry(func);
+            Result result = sut.BindTry(func);
 
-            result.IsSuccess.Should().BeFalse();
-            result.Error.Should().Be(ErrorMessage);
+            AssertFailure(result);
         }
+
+
         [Fact]
         public void BindTry_execute_throwing_func_on_success_with_custom_error_handler_returns_failure_with_custom_message()
         {
-            var sut = Result.Success();
-            var func = Result () => Result.Success(Throwing_Func_T());
-         
-            var result = sut.BindTry(func,e => ErrorMessage2);
+            Result sut = Result.Success();
+            System.Func<Result> func = Result () => Throwing();
+
+            Result result = sut.BindTry(func, e => ErrorMessage2);
 
             AssertFailure(result, ErrorMessage2);
         }
@@ -69,34 +63,27 @@ namespace CSharpFunctionalExtensions.Tests.ResultTests.Extensions
         [Fact]
         public void BindTry_execute_func_K_returning_success_on_success_returns_success()
         {
-            var sut = Result.Success();
-            var func = Result<K> () => Result.Success(Func_T_K(T.Value));
+            Result sut = Result.Success();
 
-            var result = sut.BindTry(func);
+            Result<K> result = sut.BindTry(Success_K);
 
-            result.IsSuccess.Should().BeTrue();
-            result.Value.Should().Be(K.Value);
-            FuncExecuted.Should().BeTrue();            
+            AssertSuccess(result);
         }
         [Fact]
         public void BindTry_execute_func_K_returning_success_on_failure_returns_self()
         {
-            var sut = Result.Failure(ErrorMessage);
-            var func = Result<K> () => Result.Success(Func_T_K(T.Value));
+            Result sut = Result.Failure(ErrorMessage);
 
-            var result = sut.BindTry(func);
+            Result<K> result = sut.BindTry(Success_K);
 
-            AssertFailure(result);            
-            result.Should().Equals(sut);
-            FuncExecuted.Should().BeFalse();
+            AssertFailure(result);
         }
         [Fact]
         public void BindTry_execute_func_K_returning_failure_on_success_returns_failure()
         {
-            var sut = Result.Success();
-            var func = Result<K> () => Result.Failure<K>(ErrorMessage);
+            Result sut = Result.Success();
 
-            var result = sut.BindTry(func);
+            Result<K> result = sut.BindTry(Failure_K);
 
             AssertFailure(result);
         }
@@ -104,20 +91,18 @@ namespace CSharpFunctionalExtensions.Tests.ResultTests.Extensions
         [Fact]
         public void BindTry_execute_throwing_func_K_on_success_returns_failure_with_exception_message()
         {
-            var sut = Result.Success();
-            var func = Result<K> () => Result.Success(Throwing_Func_T_K(T.Value));
+            Result sut = Result.Success();
 
-            var result = sut.BindTry(func);
+            Result<K> result = sut.BindTry(Throwing_K);
 
-            AssertFailure(result);            
+            AssertFailure(result);
         }
         [Fact]
         public void BindTry_execute_throwing_func_K_on_success_with_custom_error_handler_returns_failure_with_custom_message()
         {
-            var sut = Result.Success();
-            var func = Result () => Result.Success(Throwing_Func_T_K(T.Value));
-            
-            var result = sut.BindTry(func, e => ErrorMessage2);
+            Result sut = Result.Success();
+
+            Result<K> result = sut.BindTry(Throwing_K, e => ErrorMessage2);
 
             AssertFailure(result, ErrorMessage2);
         }
@@ -128,31 +113,26 @@ namespace CSharpFunctionalExtensions.Tests.ResultTests.Extensions
         public void BindTry_execute_func_returning_success_on_success_T_returns_success()
         {
             Result<T> sut = Result.Success(T.Value);
-            var func = Result (T t) => Result.Success(Func_T());
 
-            var result = sut.BindTry(func);
-            result.IsSuccess.Should().BeTrue();                
-            FuncExecuted.Should().BeTrue();
+            Result result = sut.BindTry(t => Success());
+
+            AssertSuccess(result);
         }
         [Fact]
         public void BindTry_execute_func_returning_success_on_failure_T_returns_self()
         {
             Result<T> sut = Result.Failure<T>(ErrorMessage);
-            var func = Result (T t) => Result.Success(Func_T_K(t));
 
-            var result = sut.BindTry(func);
+            Result result = sut.BindTry(t => Success());
 
             AssertFailure(result);
-            result.Should().Equals(sut);
-            FuncExecuted.Should().BeFalse();
         }
         [Fact]
         public void BindTry_execute_func_returning_failure_on_success_T_returns_failure()
         {
             Result<T> sut = Result.Success(T.Value);
-            var func = Result (T _) => Result.Failure<T>(ErrorMessage);
 
-            var result = sut.BindTry(func);
+            Result result = sut.BindTry(t => Failure());
 
             AssertFailure(result);
         }
@@ -161,9 +141,8 @@ namespace CSharpFunctionalExtensions.Tests.ResultTests.Extensions
         public void BindTry_execute_throwing_func_on_success_T_returns_failure_with_exception_message()
         {
             Result<T> sut = Result.Success(T.Value);
-            var func = Result (T t) => Result.Success(Throwing_Func_T());
 
-            var result = sut.BindTry(func);
+            Result result = sut.BindTry(t => Throwing());
 
             AssertFailure(result);
         }
@@ -171,9 +150,8 @@ namespace CSharpFunctionalExtensions.Tests.ResultTests.Extensions
         public void BindTry_execute_throwing_func_on_success_T_with_custom_error_handler_returns_failure_with_custom_message()
         {
             Result<T> sut = Result.Success(T.Value);
-            var func = Result (T _) => Result.Success(Throwing_Func_T());
 
-            var result = sut.BindTry(func, e => ErrorMessage2);
+            Result result = sut.BindTry(t => Throwing(), e => ErrorMessage2);
 
             AssertFailure(result, ErrorMessage2);
         }
@@ -184,35 +162,27 @@ namespace CSharpFunctionalExtensions.Tests.ResultTests.Extensions
         public void BindTry_execute_func_T_K_returning_success_on_success_T_returns_success_K()
         {
             Result<T> sut = Result.Success(T.Value);
-            var func = Result<K> (T t) => Result.Success(Func_T_K(t));
 
-            var result = sut.BindTry(func);
+            Result<K> result = sut.BindTry(t => Success_K());
 
-            result.IsSuccess.Should().BeTrue();
-            result.Should().BeOfType<Result<K>>();
-            result.Value.Should().Be(K.Value);
-            FuncExecuted.Should().BeTrue();
+            AssertSuccess(result);            
         }
         [Fact]
         public void BindTry_execute_func_T_K_returning_success_on_failure_T_returns_failure_K()
         {
             Result<T> sut = Result.Failure<T>(ErrorMessage);
-            var func = Result<K> (T t) => Result.Success(Func_T_K(t));
 
-            var result = sut.BindTry(func);
+            Result<K> result = sut.BindTry(t => Success_K());
 
             AssertFailure(result);
             result.Should().BeOfType<Result<K>>();
-            result.Should().Equals(sut);            
-            FuncExecuted.Should().BeFalse();
         }
         [Fact]
         public void BindTry_execute_func_K_returning_failure_K_on_success_returns_failure_K()
         {
             Result<T> sut = Result.Success(T.Value);
-            var func = Result<K> (T _) => Result.Failure<K>(ErrorMessage);
 
-            var result = sut.BindTry(func);
+            Result<K> result = sut.BindTry(t => Failure_K());
 
             AssertFailure(result);
         }
@@ -221,19 +191,17 @@ namespace CSharpFunctionalExtensions.Tests.ResultTests.Extensions
         public void BindTry_execute_throwing_func_T_K_on_success_T_returns_failure_K_with_exception_message()
         {
             Result<T> sut = Result.Success(T.Value);
-            var func = Result<K> (T t) => Result.Success(Throwing_Func_T_K(T.Value));
 
-            var result = sut.BindTry(func);
+            Result<K> result = sut.BindTry(t => Throwing_K());
 
             AssertFailure(result);
         }
         [Fact]
         public void BindTry_execute_throwing_func_T_K_on_success_T_with_custom_error_handler_returns_failure_K_with_custom_message()
         {
-            var sut = Result.Success();
-            var func = Result () => Result.Success(Throwing_Func_T_K(T.Value));
+            Result sut = Result.Success();
 
-            var result = sut.BindTry(func, e => ErrorMessage2);
+            Result<K> result = sut.BindTry(() => Throwing_K(), e => ErrorMessage2);
 
             AssertFailure(result, ErrorMessage2);
         }
@@ -243,49 +211,41 @@ namespace CSharpFunctionalExtensions.Tests.ResultTests.Extensions
         [Fact]
         public void BindTry_execute_func_T_K_E_returning_success_on_success_T_E_returns_success_K_E()
         {
-            Result<T,E> sut = Result.Success<T,E>(T.Value);
-            var func = Result<K,E> (T t) => Result.Success<K,E>(Func_T_K(t));
+            Result<T, E> sut = Result.Success<T, E>(T.Value);
 
-            var result = sut.BindTry(func, e => E.Value2);
+            Result<K, E> result = sut.BindTry(Success_T_E_Func_K, e => E.Value);
 
-            result.IsSuccess.Should().BeTrue();
-            result.Should().BeOfType<Result<K,E>>();
-            result.Value.Should().Be(K.Value);
-            FuncExecuted.Should().BeTrue();
+            AssertSuccess(result);
+            result.Should().BeOfType<Result<K, E>>();
         }
         [Fact]
         public void BindTry_execute_func_T_K_E_returning_success_on_failure_T_E_returns_failure_K_E()
         {
-            Result<T,E> sut = Result.Failure<T,E>(E.Value);
-            var func = Result<K,E> (T t) => Result.Success<K,E>(Func_T_K(t));
+            Result<T, E> sut = Result.Failure<T, E>(E.Value);
 
-            var result = sut.BindTry(func, e => E.Value2);
+            Result<K, E> result = sut.BindTry(Success_T_E_Func_K, e => E.Value);
 
-            result.IsSuccess.Should().BeFalse();
-            result.Error.Should().Be(E.Value);
-            result.Should().BeOfType<Result<K,E>>();            
-            FuncExecuted.Should().BeFalse();
+            AssertFailure(result);
+            result.Should().BeOfType<Result<K, E>>();
         }
         [Fact]
         public void BindTry_execute_func_T_K_E_returning_failure_on_success_T_E_returns_failure_K_E()
         {
-            Result<T,E> sut = Result.Success<T,E>(T.Value);
-            var func = Result<K,E> (T _) => Result.Failure<K,E>(E.Value);
+            Result<T, E> sut = Result.Success<T, E>(T.Value);
+            System.Func<T, Result<K, E>> func = Result<K, E> (T _) => Result.Failure<K, E>(E.Value);
 
-            var result = sut.BindTry(func, e => E.Value2);
+            Result<K, E> result = sut.BindTry(func, e => E.Value2);
 
-            result.IsSuccess.Should().BeFalse();
-            result.Error.Should().Be(E.Value);
+            AssertFailure(result);
             result.Should().BeOfType<Result<K, E>>();
         }
 
         [Fact]
         public void BindTry_execute_throwing_func_T_K_E_on_success_T_E_returns_failure_K_E_with_value_from_error_handler()
         {
-            Result<T,E> sut = Result.Success<T,E>(T.Value);
-            var func = Result<K,E> (T t) => Result.Success<K,E>(Throwing_Func_T_K(T.Value));
+            Result<T, E> sut = Result.Success<T, E>(T.Value);
 
-            var result = sut.BindTry(func, e=> E.Value2);
+            Result<K, E> result = sut.BindTry(t => Throwing_K_E(), e => E.Value2);
 
             result.IsSuccess.Should().BeFalse();
             result.Error.Should().Be(E.Value2);
@@ -295,54 +255,41 @@ namespace CSharpFunctionalExtensions.Tests.ResultTests.Extensions
 
         #region BindTry for UnitResult<E> with function returning UnitResult<E>
         [Fact]
-        public void BindTry_execute_func_E_returning_unitresult_success_on_success_E_returns_success_K_E()
+        public void BindTry_execute_func_E_returning_unitresult_success_on_success_E_returns_success_E()
         {
             UnitResult<E> sut = UnitResult.Success<E>();
-            var func = UnitResult<E> () => Result.Success(Func_T()).Map(_ => UnitResult.Success<E>()).Value;
 
-            var result = sut.BindTry(func, e => E.Value2    );
+            UnitResult<E> result = sut.BindTry(UnitResult_Success_E, e => E.Value2);
 
-            result.IsSuccess.Should().BeTrue();
-            result.Should().BeOfType<UnitResult<E>>();            
-            FuncExecuted.Should().BeTrue();
+            AssertSuccess(result);
         }
         [Fact]
         public void BindTry_execute_func_E_returning_success_on_failure_E_returns_failure_E()
         {
             UnitResult<E> sut = UnitResult.Failure(E.Value);
-            var func = UnitResult<E> () => Result.Success(Func_T()).Map(_ => UnitResult.Success<E>()).Value;
 
-            var result = sut.BindTry(func, e => E.Value2);
+            UnitResult<E> result = sut.BindTry(UnitResult_Success_E, e => E.Value2);
 
-            result.IsSuccess.Should().BeFalse();
-            result.Error.Should().Be(E.Value);
-            result.Should().BeOfType<UnitResult<E>>();
-            FuncExecuted.Should().BeFalse();
+            AssertFailure(result);
         }
         [Fact]
         public void BindTry_execute_func_E_returning_failure_on_success_E_returns_failure_E()
         {
             UnitResult<E> sut = UnitResult.Success<E>();
-            var func = UnitResult<E> () => UnitResult.Failure(E.Value);
 
-            var result = sut.BindTry(func, e => E.Value2);
+            UnitResult<E> result = sut.BindTry(UnitResult_Failure_E, e => E.Value2);
 
-            result.IsSuccess.Should().BeFalse();
-            result.Error.Should().Be(E.Value);
-            result.Should().BeOfType<UnitResult<E>>();
+            AssertFailure(result);
         }
 
         [Fact]
         public void BindTry_execute_throwing_func_E_on_success_E_returns_failure_E_with_value_from_error_handler()
         {
             UnitResult<E> sut = UnitResult.Success<E>();
-            var func = UnitResult<E> () => Result.Success<K, E>(Throwing_Func_T_K(T.Value));
 
-            var result = sut.BindTry(func, e=> E.Value2);
+            UnitResult<E> result = sut.BindTry(Throwing_K_E, e => E.Value2);
 
-            result.IsSuccess.Should().BeFalse();
-            result.Error.Should().Be(E.Value2);
-            result.Should().BeOfType<UnitResult<E>>();
+            AssertFailure(result, E.Value2);            
         }
         #endregion
 
@@ -351,51 +298,38 @@ namespace CSharpFunctionalExtensions.Tests.ResultTests.Extensions
         public void BindTry_execute_func_T_E_returning_success_on_success_E_returns_success_T_E()
         {
             UnitResult<E> sut = UnitResult.Success<E>();
-            var func = Result<T,E> () => Result.Success<T,E>(Func_T());
 
-            var result = sut.BindTry(func, e => E.Value2);
+            Result<T, E> result = sut.BindTry(Success_T_E, e => E.Value2);
 
-            result.IsSuccess.Should().BeTrue();
-            result.Should().BeOfType<Result<T,E>>();
-            FuncExecuted.Should().BeTrue();
+            AssertSuccess(result);            
         }
         [Fact]
         public void BindTry_execute_func_T_E_returning_success_on_failure_E_returns_failure_T_E()
         {
             UnitResult<E> sut = UnitResult.Failure(E.Value);
-            var func = Result<T,E> () => Result.Success<T,E>(Func_T());
 
-            var result = sut.BindTry(func,e => E.Value2);
+            Result<T, E> result = sut.BindTry(Success_T_E, e => E.Value2);
 
-            result.IsSuccess.Should().BeFalse();
-            result.Error.Should().Be(E.Value);
-            result.Should().BeOfType<Result<T,E>>();
-            FuncExecuted.Should().BeFalse();
+            AssertFailure(result);
         }
         [Fact]
         public void BindTry_execute_func_T_E_returning_failure_on_success_E_returns_failure_T_E()
         {
             UnitResult<E> sut = UnitResult.Success<E>();
-            var func = Result<T,E> () => Result.Failure<T,E>(E.Value);
 
-            var result = sut.BindTry(func, e => E.Value2);
+            Result<T, E> result = sut.BindTry(Failure_T_E, e => E.Value2);
 
-            result.IsSuccess.Should().BeFalse();
-            result.Error.Should().Be(E.Value);
-            result.Should().BeOfType<Result<T,E>>();
+            AssertFailure(result);            
         }
 
         [Fact]
         public void BindTry_execute_throwing_func_T_E_on_success_E_returns_failure_E_with_value_from_error_handler()
         {
             UnitResult<E> sut = UnitResult.Success<E>();
-            var func = Result<T,E> () => Result.Success<T, E>(Throwing_Func_T());
 
-            var result = sut.BindTry(func, e => E.Value2);
+            Result<T, E> result = sut.BindTry(Throwing_T_E, e => E.Value2);
 
-            result.IsSuccess.Should().BeFalse();
-            result.Error.Should().Be(E.Value2);
-            result.Should().BeOfType<Result<T,E>>();
+            AssertFailure(result, E.Value2);            
         }
         #endregion
 
@@ -403,59 +337,41 @@ namespace CSharpFunctionalExtensions.Tests.ResultTests.Extensions
         [Fact]
         public void BindTry_execute_func_E_returning_success_on_success_T_E_returns_success_E()
         {
-            Result<T,E> sut = Result.Success<T,E>(T.Value);
-            var func = UnitResult<E> (T _) => Result.Success<T, E>(Func_T());
+            Result<T, E> sut = Result.Success<T, E>(T.Value);
 
-            var result = sut.BindTry(func, e => E.Value2);
+            UnitResult<E> result = sut.BindTry(UnitResult_E_T, e => E.Value2);
 
-            result.IsSuccess.Should().BeTrue();
-            result.Should().BeOfType<UnitResult<E>>();            
-            FuncExecuted.Should().BeTrue();
+            AssertSuccess(result);            
         }
         [Fact]
         public void BindTry_execute_func_E_returning_success_on_failure_T_E_returns_failure_E()
         {
-            Result<T, E> sut = Result.Failure<T, E>(E.Value);
-            var func = UnitResult<E> (T t) => Result.Success<T, E>(Func_T());
+            Result<T, E> sut = Result.Failure<T, E>(E.Value);            
 
-            var result = sut.BindTry(func, e => E.Value2);
+            UnitResult<E> result = sut.BindTry(UnitResult_E_T, e => E.Value2);
 
-            result.IsSuccess.Should().BeFalse();
-            result.Error.Should().Be(E.Value);
-            result.Should().BeOfType<UnitResult<E>>();
-            FuncExecuted.Should().BeFalse();
+            AssertFailure(result);            
         }
         [Fact]
         public void BindTry_execute_func_E_returning_failure_on_success_T_E_returns_failure_E()
         {
-            Result<T,E> sut = Result.Success<T,E>(T.Value);
-            var func = UnitResult<E> (T t) => Result.Failure<T, E>(E.Value);
+            Result<T, E> sut = Result.Success<T, E>(T.Value);
 
-            var result = sut.BindTry(func, e => E.Value2);
+            UnitResult<E> result = sut.BindTry(t=> UnitResult_Failure_E(), e => E.Value2);
 
-            result.IsSuccess.Should().BeFalse();
-            result.Error.Should().Be(E.Value);
-            result.Should().BeOfType<UnitResult<E>>();
+            AssertFailure(result);            
         }
 
         [Fact]
         public void BindTry_execute_throwing_func_E_on_success_T_E_returns_failure_E_with_value_from_error_handler()
         {
-            Result<T,E> sut = Result.Success<T,E>(T.Value);
-            var func = UnitResult<E> (T t) => Result.Success<T, E>(Throwing_Func_T());
+            Result<T, E> sut = Result.Success<T, E>(T.Value);
 
-            var result = sut.BindTry(func, e => E.Value2);
+            UnitResult<E> result = sut.BindTry(t => Throwing_E(), e => E.Value2);
 
-            result.IsSuccess.Should().BeFalse();
-            result.Error.Should().Be(E.Value2);
-            result.Should().BeOfType<UnitResult<E>>();
+            AssertFailure(result, E.Value2);
         }
         #endregion
 
-        private static void AssertFailure(Result result, string errorMessage=ErrorMessage)
-        {
-            result.IsSuccess.Should().BeFalse();
-            result.Error.Should().Be(errorMessage);
-        }
     }
 }

--- a/CSharpFunctionalExtensions/CSharpFunctionalExtensions.csproj
+++ b/CSharpFunctionalExtensions/CSharpFunctionalExtensions.csproj
@@ -523,5 +523,25 @@
       <DependentUpon>Try.cs</DependentUpon>
     </Compile>
   </ItemGroup>
+  <ItemGroup Label="BindTry">
+	<Compile Update="Result\Methods\Extensions\BindTry.Task.cs">
+	  <DependentUpon>BindTry.cs</DependentUpon>
+	</Compile>
+	<Compile Update="Result\Methods\Extensions\BindTry.ValueTask.cs">
+	  <DependentUpon>BindTry.cs</DependentUpon>
+	</Compile>
+	<Compile Update="Result\Methods\Extensions\BindTry.Task.Left.cs">
+	  <DependentUpon>BindTry.Task.cs</DependentUpon>
+	</Compile>
+	<Compile Update="Result\Methods\Extensions\BindTry.Task.Right.cs">
+	  <DependentUpon>BindTry.Task.cs</DependentUpon>
+	</Compile>
+	<Compile Update="Result\Methods\Extensions\BindTry.ValueTask.Left.cs">
+	  <DependentUpon>BindTry.ValueTask.cs</DependentUpon>
+	</Compile>
+	<Compile Update="Result\Methods\Extensions\BindTry.ValueTask.Right.cs">
+	  <DependentUpon>BindTry.ValueTask.cs</DependentUpon>
+	</Compile>
+  </ItemGroup>
   
 </Project>

--- a/CSharpFunctionalExtensions/CSharpFunctionalExtensions.csproj
+++ b/CSharpFunctionalExtensions/CSharpFunctionalExtensions.csproj
@@ -522,26 +522,23 @@
     <Compile Update="Result\Methods\Try.Task.cs">
       <DependentUpon>Try.cs</DependentUpon>
     </Compile>
-  </ItemGroup>
-  <ItemGroup Label="BindTry">
 	<Compile Update="Result\Methods\Extensions\BindTry.Task.cs">
-	  <DependentUpon>BindTry.cs</DependentUpon>
+		<DependentUpon>BindTry.cs</DependentUpon>
 	</Compile>
 	<Compile Update="Result\Methods\Extensions\BindTry.ValueTask.cs">
-	  <DependentUpon>BindTry.cs</DependentUpon>
+		<DependentUpon>BindTry.cs</DependentUpon>
 	</Compile>
 	<Compile Update="Result\Methods\Extensions\BindTry.Task.Left.cs">
-	  <DependentUpon>BindTry.Task.cs</DependentUpon>
+		<DependentUpon>BindTry.Task.cs</DependentUpon>
 	</Compile>
 	<Compile Update="Result\Methods\Extensions\BindTry.Task.Right.cs">
-	  <DependentUpon>BindTry.Task.cs</DependentUpon>
+		<DependentUpon>BindTry.Task.cs</DependentUpon>
 	</Compile>
 	<Compile Update="Result\Methods\Extensions\BindTry.ValueTask.Left.cs">
-	  <DependentUpon>BindTry.ValueTask.cs</DependentUpon>
+		<DependentUpon>BindTry.ValueTask.cs</DependentUpon>
 	</Compile>
 	<Compile Update="Result\Methods\Extensions\BindTry.ValueTask.Right.cs">
-	  <DependentUpon>BindTry.ValueTask.cs</DependentUpon>
+		<DependentUpon>BindTry.ValueTask.cs</DependentUpon>
 	</Compile>
-  </ItemGroup>
-  
+  </ItemGroup> 
 </Project>

--- a/CSharpFunctionalExtensions/Result/Methods/Extensions/BindTry.Task.Left.cs
+++ b/CSharpFunctionalExtensions/Result/Methods/Extensions/BindTry.Task.Left.cs
@@ -8,7 +8,11 @@ namespace CSharpFunctionalExtensions
         /// <summary>
         ///     Selects result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.
         ///     If a given function throws an exception, an error is returned from the given (or default) error handler
-        /// </summary>
+        /// </summary>        
+        /// <param name="resultTask">Extended result</param>
+        /// <param name="func">Function returning result to to bind</param>
+        /// <param name="errorHandler">Error handling function</param>        
+        /// <returns>Binding result</returns>
         public static async Task<Result> BindTry(this Task<Result> resultTask, Func<Result> func,
             Func<Exception, string> errorHandler = null)
         {
@@ -19,7 +23,12 @@ namespace CSharpFunctionalExtensions
         /// <summary>
         ///     Selects result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.
         ///     If a given function throws an exception, an error is returned from the given (or default) error handler
-        /// </summary>
+        /// </summary>        
+        /// <typeparam name="K"><paramref name="func" /> Result Type parameter</typeparam>        
+        /// <param name="resultTask">Extended result</param>
+        /// <param name="func">Function returning result to to bind</param>
+        /// <param name="errorHandler">Error handling function</param>        
+        /// <returns>Binding result</returns>
         public static async Task<Result<K>> BindTry<K>(this Task<Result> resultTask, Func<Result<K>> func,
             Func<Exception, string> errorHandler = null)
         {
@@ -31,6 +40,11 @@ namespace CSharpFunctionalExtensions
         ///     Selects result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.
         ///     If a given function throws an exception, an error is returned from the given (or default) error handler
         /// </summary>
+        /// <typeparam name="T">Result Type parameter</typeparam>        
+        /// <param name="resultTask">Extended result</param>
+        /// <param name="func">Function returning result to to bind</param>
+        /// <param name="errorHandler">Error handling function</param>        
+        /// <returns>Binding result</returns>
         public static async Task<Result> BindTry<T>(this Task<Result<T>> resultTask, Func<T, Result> func,
             Func<Exception, string> errorHandler = null)
         {
@@ -42,6 +56,12 @@ namespace CSharpFunctionalExtensions
         ///     Selects result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.
         ///     If a given function throws an exception, an error is returned from the given (or default) error handler
         /// </summary>
+        /// <typeparam name="T">Result Type parameter</typeparam>
+        /// <typeparam name="K"><paramref name="func" /> Result Type parameter</typeparam>        
+        /// <param name="resultTask">Extended result</param>
+        /// <param name="func">Function returning result to to bind</param>
+        /// <param name="errorHandler">Error handling function</param>        
+        /// <returns>Binding result</returns>
         public static async Task<Result<K>> BindTry<T, K>(this Task<Result<T>> resultTask, Func<T, Result<K>> func,
             Func<Exception, string> errorHandler = null)
         {
@@ -53,6 +73,12 @@ namespace CSharpFunctionalExtensions
         ///     Selects result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.
         ///     If a given function throws an exception, an error is returned from the given error handler
         /// </summary>
+        /// <typeparam name="T">Result Type parameter</typeparam>        
+        /// <typeparam name="E">Error Type parameter</typeparam>
+        /// <param name="resultTask">Extended result</param>
+        /// <param name="func">Function returning result to to bind</param>
+        /// <param name="errorHandler">Error handling function</param>        
+        /// <returns>Binding result</returns>
         public static async Task<UnitResult<E>> BindTry<T, E>(this Task<Result<T, E>> resultTask, Func<T, UnitResult<E>> func,
             Func<Exception, E> errorHandler)
         {
@@ -64,6 +90,13 @@ namespace CSharpFunctionalExtensions
         ///     Selects result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.
         ///     If a given function throws an exception, an error is returned from the given (or default) error handler
         /// </summary>
+        /// <typeparam name="T">Result Type parameter</typeparam>
+        /// <typeparam name="K"><paramref name="func" /> Result Type parameter</typeparam>
+        /// <typeparam name="E">Error Type parameter</typeparam>
+        /// <param name="resultTask">Extended result</param>
+        /// <param name="func">Function returning result to to bind</param>
+        /// <param name="errorHandler">Error handling function</param>        
+        /// <returns>Binding result</returns>
         public static async Task<Result<K, E>> BindTry<T, K, E>(this Task<Result<T, E>> resultTask, Func<T, Result<K, E>> func,
             Func<Exception, E> errorHandler)
         {
@@ -74,7 +107,12 @@ namespace CSharpFunctionalExtensions
         /// <summary>
         ///     Selects result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.
         ///     If a given function throws an exception, an error is returned from the given error handler
-        /// </summary>
+        /// </summary>        
+        /// <typeparam name="E">Error Type parameter</typeparam>
+        /// <param name="resultTask">Extended result</param>
+        /// <param name="func">Function returning result to to bind</param>
+        /// <param name="errorHandler">Error handling function</param>        
+        /// <returns>Binding result</returns>
         public static async Task<UnitResult<E>> BindTry<E>(this Task<UnitResult<E>> resultTask, Func<UnitResult<E>> func,
             Func<Exception, E> errorHandler)
         {
@@ -86,6 +124,12 @@ namespace CSharpFunctionalExtensions
         ///     Selects result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.
         ///     If a given function throws an exception, an error is returned from the given error handler
         /// </summary>
+        /// <typeparam name="T">Result Type parameter</typeparam>        
+        /// <typeparam name="E">Error Type parameter</typeparam>
+        /// <param name="resultTask">Extended result</param>
+        /// <param name="func">Function returning result to to bind</param>
+        /// <param name="errorHandler">Error handling function</param>        
+        /// <returns>Binding result</returns>
         public static async Task<Result<T, E>> BindTry<T, E>(this Task<UnitResult<E>> resultTask, Func<Result<T, E>> func,
             Func<Exception, E> errorHandler)
         {

--- a/CSharpFunctionalExtensions/Result/Methods/Extensions/BindTry.Task.Left.cs
+++ b/CSharpFunctionalExtensions/Result/Methods/Extensions/BindTry.Task.Left.cs
@@ -7,10 +7,10 @@ namespace CSharpFunctionalExtensions
     {
         /// <summary>
         ///     Selects result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.
-        ///     If a given function throws an exception, an error is returned from the given (or default) error handler
+        ///     If a given function throws an exception, an error is returned from the given error handler
         /// </summary>        
         /// <param name="resultTask">Extended result</param>
-        /// <param name="func">Function returning result to to bind</param>
+        /// <param name="func">Function returning result to bind</param>
         /// <param name="errorHandler">Error handling function</param>        
         /// <returns>Binding result</returns>
         public static async Task<Result> BindTry(this Task<Result> resultTask, Func<Result> func,
@@ -22,11 +22,11 @@ namespace CSharpFunctionalExtensions
 
         /// <summary>
         ///     Selects result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.
-        ///     If a given function throws an exception, an error is returned from the given (or default) error handler
+        ///     If a given function throws an exception, an error is returned from the given error handler
         /// </summary>        
         /// <typeparam name="K"><paramref name="func" /> Result Type parameter</typeparam>        
         /// <param name="resultTask">Extended result</param>
-        /// <param name="func">Function returning result to to bind</param>
+        /// <param name="func">Function returning result to bind</param>
         /// <param name="errorHandler">Error handling function</param>        
         /// <returns>Binding result</returns>
         public static async Task<Result<K>> BindTry<K>(this Task<Result> resultTask, Func<Result<K>> func,
@@ -38,11 +38,11 @@ namespace CSharpFunctionalExtensions
 
         /// <summary>
         ///     Selects result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.
-        ///     If a given function throws an exception, an error is returned from the given (or default) error handler
+        ///     If a given function throws an exception, an error is returned from the given error handler
         /// </summary>
         /// <typeparam name="T">Result Type parameter</typeparam>        
         /// <param name="resultTask">Extended result</param>
-        /// <param name="func">Function returning result to to bind</param>
+        /// <param name="func">Function returning result to bind</param>
         /// <param name="errorHandler">Error handling function</param>        
         /// <returns>Binding result</returns>
         public static async Task<Result> BindTry<T>(this Task<Result<T>> resultTask, Func<T, Result> func,
@@ -54,12 +54,12 @@ namespace CSharpFunctionalExtensions
 
         /// <summary>
         ///     Selects result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.
-        ///     If a given function throws an exception, an error is returned from the given (or default) error handler
+        ///     If a given function throws an exception, an error is returned from the given error handler
         /// </summary>
         /// <typeparam name="T">Result Type parameter</typeparam>
         /// <typeparam name="K"><paramref name="func" /> Result Type parameter</typeparam>        
         /// <param name="resultTask">Extended result</param>
-        /// <param name="func">Function returning result to to bind</param>
+        /// <param name="func">Function returning result to bind</param>
         /// <param name="errorHandler">Error handling function</param>        
         /// <returns>Binding result</returns>
         public static async Task<Result<K>> BindTry<T, K>(this Task<Result<T>> resultTask, Func<T, Result<K>> func,
@@ -76,7 +76,7 @@ namespace CSharpFunctionalExtensions
         /// <typeparam name="T">Result Type parameter</typeparam>        
         /// <typeparam name="E">Error Type parameter</typeparam>
         /// <param name="resultTask">Extended result</param>
-        /// <param name="func">Function returning result to to bind</param>
+        /// <param name="func">Function returning result to bind</param>
         /// <param name="errorHandler">Error handling function</param>        
         /// <returns>Binding result</returns>
         public static async Task<UnitResult<E>> BindTry<T, E>(this Task<Result<T, E>> resultTask, Func<T, UnitResult<E>> func,
@@ -88,13 +88,13 @@ namespace CSharpFunctionalExtensions
 
         /// <summary>
         ///     Selects result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.
-        ///     If a given function throws an exception, an error is returned from the given (or default) error handler
+        ///     If a given function throws an exception, an error is returned from the given error handler
         /// </summary>
         /// <typeparam name="T">Result Type parameter</typeparam>
         /// <typeparam name="K"><paramref name="func" /> Result Type parameter</typeparam>
         /// <typeparam name="E">Error Type parameter</typeparam>
         /// <param name="resultTask">Extended result</param>
-        /// <param name="func">Function returning result to to bind</param>
+        /// <param name="func">Function returning result to bind</param>
         /// <param name="errorHandler">Error handling function</param>        
         /// <returns>Binding result</returns>
         public static async Task<Result<K, E>> BindTry<T, K, E>(this Task<Result<T, E>> resultTask, Func<T, Result<K, E>> func,
@@ -110,7 +110,7 @@ namespace CSharpFunctionalExtensions
         /// </summary>        
         /// <typeparam name="E">Error Type parameter</typeparam>
         /// <param name="resultTask">Extended result</param>
-        /// <param name="func">Function returning result to to bind</param>
+        /// <param name="func">Function returning result to bind</param>
         /// <param name="errorHandler">Error handling function</param>        
         /// <returns>Binding result</returns>
         public static async Task<UnitResult<E>> BindTry<E>(this Task<UnitResult<E>> resultTask, Func<UnitResult<E>> func,
@@ -127,7 +127,7 @@ namespace CSharpFunctionalExtensions
         /// <typeparam name="T">Result Type parameter</typeparam>        
         /// <typeparam name="E">Error Type parameter</typeparam>
         /// <param name="resultTask">Extended result</param>
-        /// <param name="func">Function returning result to to bind</param>
+        /// <param name="func">Function returning result to bind</param>
         /// <param name="errorHandler">Error handling function</param>        
         /// <returns>Binding result</returns>
         public static async Task<Result<T, E>> BindTry<T, E>(this Task<UnitResult<E>> resultTask, Func<Result<T, E>> func,

--- a/CSharpFunctionalExtensions/Result/Methods/Extensions/BindTry.Task.Left.cs
+++ b/CSharpFunctionalExtensions/Result/Methods/Extensions/BindTry.Task.Left.cs
@@ -9,19 +9,8 @@ namespace CSharpFunctionalExtensions
         ///     Selects result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.
         ///     If a given function throws an exception, an error is returned from the given (or default) error handler
         /// </summary>
-        public static async Task<Result<K, E>> BindTry<T, K, E>(this Task<Result<T, E>> resultTask, Func<T, Result<K, E>> func,
-            Func<Exception, E> errorHandler)
-        {
-            var result = await resultTask.DefaultAwait();
-            return result.BindTry(func, errorHandler);
-        }
-
-        /// <summary>
-        ///     Selects result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.
-        ///     If a given function throws an exception, an error is returned from the given (or default) error handler
-        /// </summary>
-        public static async Task<Result<K>> BindTry<T, K>(this Task<Result<T>> resultTask, Func<T, Result<K>> func,
-            Func<Exception, string> errorHandler)
+        public static async Task<Result> BindTry(this Task<Result> resultTask, Func<Result> func,
+            Func<Exception, string> errorHandler = null)
         {
             var result = await resultTask.DefaultAwait();
             return result.BindTry(func, errorHandler);
@@ -32,7 +21,7 @@ namespace CSharpFunctionalExtensions
         ///     If a given function throws an exception, an error is returned from the given (or default) error handler
         /// </summary>
         public static async Task<Result<K>> BindTry<K>(this Task<Result> resultTask, Func<Result<K>> func,
-            Func<Exception, string> errorHandler)
+            Func<Exception, string> errorHandler = null)
         {
             var result = await resultTask.DefaultAwait();
             return result.BindTry(func, errorHandler);
@@ -53,8 +42,30 @@ namespace CSharpFunctionalExtensions
         ///     Selects result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.
         ///     If a given function throws an exception, an error is returned from the given (or default) error handler
         /// </summary>
-        public static async Task<Result> BindTry(this Task<Result> resultTask, Func<Result> func,
+        public static async Task<Result<K>> BindTry<T, K>(this Task<Result<T>> resultTask, Func<T, Result<K>> func,
             Func<Exception, string> errorHandler = null)
+        {
+            var result = await resultTask.DefaultAwait();
+            return result.BindTry(func, errorHandler);
+        }
+
+        /// <summary>
+        ///     Selects result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.
+        ///     If a given function throws an exception, an error is returned from the given error handler
+        /// </summary>
+        public static async Task<UnitResult<E>> BindTry<T, E>(this Task<Result<T, E>> resultTask, Func<T, UnitResult<E>> func,
+            Func<Exception, E> errorHandler)
+        {
+            var result = await resultTask.DefaultAwait();
+            return result.BindTry(func, errorHandler);
+        }
+
+        /// <summary>
+        ///     Selects result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.
+        ///     If a given function throws an exception, an error is returned from the given (or default) error handler
+        /// </summary>
+        public static async Task<Result<K, E>> BindTry<T, K, E>(this Task<Result<T, E>> resultTask, Func<T, Result<K, E>> func,
+            Func<Exception, E> errorHandler)
         {
             var result = await resultTask.DefaultAwait();
             return result.BindTry(func, errorHandler);
@@ -80,17 +91,6 @@ namespace CSharpFunctionalExtensions
         {
             var result = await resultTask.DefaultAwait();
             return result.BindTry(func, errorHandler);
-        }
-
-        /// <summary>
-        ///     Selects result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.
-        ///     If a given function throws an exception, an error is returned from the given error handler
-        /// </summary>
-        public static async Task<UnitResult<E>> BindTry<T, E>(this Task<Result<T, E>> resultTask, Func<T, UnitResult<E>> func,
-            Func<Exception, E> errorHandler)
-        {
-            var result = await resultTask.DefaultAwait();
-            return result.BindTry(func, errorHandler);
-        }
+        }        
     }
 }

--- a/CSharpFunctionalExtensions/Result/Methods/Extensions/BindTry.Task.Left.cs
+++ b/CSharpFunctionalExtensions/Result/Methods/Extensions/BindTry.Task.Left.cs
@@ -1,0 +1,96 @@
+﻿using System.Threading.Tasks;
+using System;
+
+namespace CSharpFunctionalExtensions
+{
+    public static partial class AsyncResultExtensionsLeftOperand
+    {
+        /// <summary>
+        ///     Selects result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.
+        ///     If a given function throws an exception, an error is returned from the given (or default) error handler
+        /// </summary>
+        public static async Task<Result<K, E>> BindTry<T, K, E>(this Task<Result<T, E>> resultTask, Func<T, Result<K, E>> func,
+            Func<Exception, E> errorHandler)
+        {
+            var result = await resultTask.DefaultAwait();
+            return result.BindTry(func, errorHandler);
+        }
+
+        /// <summary>
+        ///     Selects result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.
+        ///     If a given function throws an exception, an error is returned from the given (or default) error handler
+        /// </summary>
+        public static async Task<Result<K>> BindTry<T, K>(this Task<Result<T>> resultTask, Func<T, Result<K>> func,
+            Func<Exception, string> errorHandler)
+        {
+            var result = await resultTask.DefaultAwait();
+            return result.BindTry(func, errorHandler);
+        }
+
+        /// <summary>
+        ///     Selects result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.
+        ///     If a given function throws an exception, an error is returned from the given (or default) error handler
+        /// </summary>
+        public static async Task<Result<K>> BindTry<K>(this Task<Result> resultTask, Func<Result<K>> func,
+            Func<Exception, string> errorHandler)
+        {
+            var result = await resultTask.DefaultAwait();
+            return result.BindTry(func, errorHandler);
+        }
+
+        /// <summary>
+        ///     Selects result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.
+        ///     If a given function throws an exception, an error is returned from the given (or default) error handler
+        /// </summary>
+        public static async Task<Result> BindTry<T>(this Task<Result<T>> resultTask, Func<T, Result> func,
+            Func<Exception, string> errorHandler = null)
+        {
+            var result = await resultTask.DefaultAwait();
+            return result.BindTry(func, errorHandler);
+        }
+
+        /// <summary>
+        ///     Selects result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.
+        ///     If a given function throws an exception, an error is returned from the given (or default) error handler
+        /// </summary>
+        public static async Task<Result> BindTry(this Task<Result> resultTask, Func<Result> func,
+            Func<Exception, string> errorHandler = null)
+        {
+            var result = await resultTask.DefaultAwait();
+            return result.BindTry(func, errorHandler);
+        }
+
+        /// <summary>
+        ///     Selects result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.
+        ///     If a given function throws an exception, an error is returned from the given error handler
+        /// </summary>
+        public static async Task<UnitResult<E>> BindTry<E>(this Task<UnitResult<E>> resultTask, Func<UnitResult<E>> func,
+            Func<Exception, E> errorHandler)
+        {
+            var result = await resultTask.DefaultAwait();
+            return result.BindTry(func, errorHandler);
+        }
+
+        /// <summary>
+        ///     Selects result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.
+        ///     If a given function throws an exception, an error is returned from the given error handler
+        /// </summary>
+        public static async Task<Result<T, E>> BindTry<T, E>(this Task<UnitResult<E>> resultTask, Func<Result<T, E>> func,
+            Func<Exception, E> errorHandler)
+        {
+            var result = await resultTask.DefaultAwait();
+            return result.BindTry(func, errorHandler);
+        }
+
+        /// <summary>
+        ///     Selects result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.
+        ///     If a given function throws an exception, an error is returned from the given error handler
+        /// </summary>
+        public static async Task<UnitResult<E>> BindTry<T, E>(this Task<Result<T, E>> resultTask, Func<T, UnitResult<E>> func,
+            Func<Exception, E> errorHandler)
+        {
+            var result = await resultTask.DefaultAwait();
+            return result.BindTry(func, errorHandler);
+        }
+    }
+}

--- a/CSharpFunctionalExtensions/Result/Methods/Extensions/BindTry.Task.Right.cs
+++ b/CSharpFunctionalExtensions/Result/Methods/Extensions/BindTry.Task.Right.cs
@@ -7,13 +7,13 @@ namespace CSharpFunctionalExtensions
     {
         /// <summary>
         ///     Selects result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.
-        ///     If a given function throws an exception, an error is returned from the given (or default) error handler
+        ///     If a given function throws an exception, an error is returned from the given error handler
         /// </summary>
         /// <typeparam name="T">Result Type parameter</typeparam>
         /// <typeparam name="K"><paramref name="func" /> Result Type parameter</typeparam>
         /// <typeparam name="E">Error Type parameter</typeparam>
         /// <param name="result">Extended result</param>
-        /// <param name="func">Function returning result to to bind</param>
+        /// <param name="func">Function returning result to bind</param>
         /// <param name="errorHandler">Error handling function</param>        
         /// <returns>Binding result</returns>
         public static async Task<Result<K, E>> BindTry<T, K, E>(this Result<T, E> result, Func<T, Task<Result<K, E>>> func,
@@ -26,12 +26,12 @@ namespace CSharpFunctionalExtensions
 
         /// <summary>
         ///     Selects result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.
-        ///     If a given function throws an exception, an error is returned from the given (or default) error handler
+        ///     If a given function throws an exception, an error is returned from the given error handler
         /// </summary>
         /// <typeparam name="T">Result Type parameter</typeparam>
         /// <typeparam name="K"><paramref name="func" /> Result Type parameter</typeparam>        
         /// <param name="result">Extended result</param>
-        /// <param name="func">Function returning result to to bind</param>
+        /// <param name="func">Function returning result to bind</param>
         /// <param name="errorHandler">Error handling function</param>        
         /// <returns>Binding result</returns>
         public static async Task<Result<K>> BindTry<T, K>(this Result<T> result, Func<T, Task<Result<K>>> func,
@@ -44,11 +44,11 @@ namespace CSharpFunctionalExtensions
 
         /// <summary>
         ///     Selects result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.
-        ///     If a given function throws an exception, an error is returned from the given (or default) error handler
+        ///     If a given function throws an exception, an error is returned from the given error handler
         /// </summary>        
         /// <typeparam name="K"><paramref name="func" /> Result Type parameter</typeparam>        
         /// <param name="result">Extended result</param>
-        /// <param name="func">Function returning result to to bind</param>
+        /// <param name="func">Function returning result to bind</param>
         /// <param name="errorHandler">Error handling function</param>        
         /// <returns>Binding result</returns>
         public static async Task<Result<K>> BindTry<K>(this Result result, Func<Task<Result<K>>> func,
@@ -61,11 +61,11 @@ namespace CSharpFunctionalExtensions
 
         /// <summary>
         ///     Selects result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.
-        ///     If a given function throws an exception, an error is returned from the given (or default) error handler
+        ///     If a given function throws an exception, an error is returned from the given error handler
         /// </summary>
         /// <typeparam name="T">Result Type parameter</typeparam>        
         /// <param name="result">Extended result</param>
-        /// <param name="func">Function returning result to to bind</param>
+        /// <param name="func">Function returning result to bind</param>
         /// <param name="errorHandler">Error handling function</param>        
         /// <returns>Binding result</returns>
         public static async Task<Result> BindTry<T>(this Result<T> result, Func<T, Task<Result>> func,
@@ -78,10 +78,10 @@ namespace CSharpFunctionalExtensions
 
         /// <summary>
         ///     Selects result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.
-        ///     If a given function throws an exception, an error is returned from the given (or default) error handler
+        ///     If a given function throws an exception, an error is returned from the given error handler
         /// </summary>        
         /// <param name="result">Extended result</param>
-        /// <param name="func">Function returning result to to bind</param>
+        /// <param name="func">Function returning result to bind</param>
         /// <param name="errorHandler">Error handling function</param>        
         /// <returns>Binding result</returns>
         public static async Task<Result> BindTry(this Result result, Func<Task<Result>> func,
@@ -94,11 +94,11 @@ namespace CSharpFunctionalExtensions
 
         /// <summary>
         ///     Selects result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.
-        ///     If a given function throws an exception, an error is returned from the given (or default) error handler
+        ///     If a given function throws an exception, an error is returned from the given error handler
         /// </summary>        
         /// <typeparam name="E">Error Type parameter</typeparam>
         /// <param name="result">Extended result</param>
-        /// <param name="func">Function returning result to to bind</param>
+        /// <param name="func">Function returning result to bind</param>
         /// <param name="errorHandler">Error handling function</param>        
         /// <returns>Binding result</returns>
         public static async Task<UnitResult<E>> BindTry<E>(this UnitResult<E> result, Func<Task<UnitResult<E>>> func,
@@ -111,12 +111,12 @@ namespace CSharpFunctionalExtensions
 
         /// <summary>
         ///     Selects result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.
-        ///     If a given function throws an exception, an error is returned from the given (or default) error handler
+        ///     If a given function throws an exception, an error is returned from the given error handler
         /// </summary>
         /// <typeparam name="T">Result Type parameter</typeparam>        
         /// <typeparam name="E">Error Type parameter</typeparam>
         /// <param name="result">Extended result</param>
-        /// <param name="func">Function returning result to to bind</param>
+        /// <param name="func">Function returning result to bind</param>
         /// <param name="errorHandler">Error handling function</param>        
         /// <returns>Binding result</returns>
         public static async Task<Result<T, E>> BindTry<T, E>(this UnitResult<E> result, Func<Task<Result<T, E>>> func,
@@ -129,12 +129,12 @@ namespace CSharpFunctionalExtensions
 
         /// <summary>
         ///     Selects result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.
-        ///     If a given function throws an exception, an error is returned from the given (or default) error handler
+        ///     If a given function throws an exception, an error is returned from the given error handler
         /// </summary>
         /// <typeparam name="T">Result Type parameter</typeparam>        
         /// <typeparam name="E">Error Type parameter</typeparam>
         /// <param name="result">Extended result</param>
-        /// <param name="func">Function returning result to to bind</param>
+        /// <param name="func">Function returning result to bind</param>
         /// <param name="errorHandler">Error handling function</param>        
         /// <returns>Binding result</returns>
         public static async Task<UnitResult<E>> BindTry<T, E>(this Result<T, E> result, Func<T, Task<UnitResult<E>>> func,

--- a/CSharpFunctionalExtensions/Result/Methods/Extensions/BindTry.Task.Right.cs
+++ b/CSharpFunctionalExtensions/Result/Methods/Extensions/BindTry.Task.Right.cs
@@ -1,106 +1,104 @@
-﻿using System;
+﻿using System.Threading.Tasks;
+using System;
 
 namespace CSharpFunctionalExtensions
 {
-    public static partial class ResultExtensions
+    public static partial class AsyncResultExtensionsRightOperand
     {
-        
         /// <summary>
         ///     Selects result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.
         ///     If a given function throws an exception, an error is returned from the given (or default) error handler
         /// </summary>
-        public static Result BindTry(this Result result, Func<Result> func,
-            Func<Exception, string> errorHandler = null)
+        public static async Task<Result<K, E>> BindTry<T, K, E>(this Result<T, E> result, Func<T, Task<Result<K, E>>> func,
+            Func<Exception, E> errorHandler)
         {
             return result.IsFailure
-                ? Result.Failure(result.Error)
-                : Result.Try(() => func(), errorHandler).Bind(r => r);
+                ? Result.Failure<K, E>(result.Error)
+                : await Result.Try(() => func(result.Value),errorHandler).Bind(r => r).DefaultAwait();
         }
 
         /// <summary>
         ///     Selects result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.
         ///     If a given function throws an exception, an error is returned from the given (or default) error handler
         /// </summary>
-        public static Result<K> BindTry<K>(this Result result, Func<Result<K>> func,
-            Func<Exception, string> errorHandler = null)
-        {
-            return result.IsFailure
-                ? Result.Failure<K>(result.Error)
-                : Result.Try(() => func(), errorHandler).Bind(r => r);
-        }
-
-
-        /// <summary>
-        ///     Selects result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.
-        ///     If a given function throws an exception, an error is returned from the given (or default) error handler
-        /// </summary>
-        public static Result BindTry<T>(this Result<T> result, Func<T, Result> func,
-            Func<Exception, string> errorHandler = null)
-        {
-            return result.IsFailure
-                ? Result.Failure(result.Error)
-                : Result.Try(() => func(result.Value), errorHandler).Bind(r => r);
-        }
-
-        /// <summary>
-        ///     Selects result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.
-        ///     If a given function throws an exception, an error is returned from the given (or default) error handler
-        /// </summary>
-        public static Result<K> BindTry<T, K>(this Result<T> result, Func<T, Result<K>> func,
+        public static async Task<Result<K>> BindTry<T, K>(this Result<T> result, Func<T, Task<Result<K>>> func,
             Func<Exception, string> errorHandler = null)
         {
             return result.IsFailure
                 ? Result.Failure<K>(result.Error)
-                : Result.Try(() => func(result.Value), errorHandler).Bind(r => r);
+                : await Result.Try(() => func(result.Value), errorHandler).Bind(r => r).DefaultAwait();
         }
 
         /// <summary>
-        ///    Selects result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.        
-        ///    If a given function throws an exception, an error is returned from the given (or default) error handler
+        ///     Selects result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.
+        ///     If a given function throws an exception, an error is returned from the given (or default) error handler
         /// </summary>
-        public static Result<K, E> BindTry<T, K, E>(this Result<T, E> result, Func<T, Result<K, E>> func,
+        public static async Task<Result<K>> BindTry<K>(this Result result, Func<Task<Result<K>>> func,
+            Func<Exception, string> errorHandler = null)
+        {
+            return result.IsFailure
+                ? Result.Failure<K>(result.Error)
+                : await Result.Try(() => func(), errorHandler).Bind(r => r).DefaultAwait();
+        }
+
+        /// <summary>
+        ///     Selects result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.
+        ///     If a given function throws an exception, an error is returned from the given (or default) error handler
+        /// </summary>
+        public static async Task<Result> BindTry<T>(this Result<T> result, Func<T, Task<Result>> func,
+            Func<Exception, string> errorHandler = null)
+        {
+            return result.IsFailure
+                ? Result.Failure(result.Error)
+                : await Result.Try(() => func(result.Value), errorHandler).Bind(r => r).DefaultAwait();
+        }
+
+        /// <summary>
+        ///     Selects result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.
+        ///     If a given function throws an exception, an error is returned from the given (or default) error handler
+        /// </summary>
+        public static async Task<Result> BindTry(this Result result, Func<Task<Result>> func,
+            Func<Exception, string> errorHandler = null)
+        {
+            return result.IsFailure
+                ? Result.Failure(result.Error)
+                : await Result.Try(() => func(), errorHandler).Bind(r => r).DefaultAwait();
+        }
+
+        /// <summary>
+        ///     Selects result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.
+        ///     If a given function throws an exception, an error is returned from the given (or default) error handler
+        /// </summary>
+        public static async Task<UnitResult<E>> BindTry<E>(this UnitResult<E> result, Func<Task<UnitResult<E>>> func,
             Func<Exception, E> errorHandler)
         {            
             return result.IsFailure
-                ? Result.Failure<K,E>(result.Error)
-                : Result.Try(() => func(result.Value), errorHandler).Bind(r => r);           
+                ? UnitResult.Failure(result.Error)
+                : await Result.Try(() => func(), errorHandler).Bind(r => r).DefaultAwait();
         }
 
-
         /// <summary>
-        ///     Selects result from the return value of a given function. If the calling UnitResult is a failure, a new failure result is returned instead.
+        ///     Selects result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.
         ///     If a given function throws an exception, an error is returned from the given (or default) error handler
         /// </summary>
-        public static UnitResult<E> BindTry<E>(this UnitResult<E> result, Func<UnitResult<E>> func,
+        public static async Task<Result<T, E>> BindTry<T, E>(this UnitResult<E> result, Func<Task<Result<T, E>>> func,
+            Func<Exception, E> errorHandler)
+        {
+            return result.IsFailure
+                ? Result.Failure<T,E>(result.Error)
+                : await Result.Try(() => func(), errorHandler).Bind(r => r).DefaultAwait();
+        }
+
+        /// <summary>
+        ///     Selects result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.
+        ///     If a given function throws an exception, an error is returned from the given (or default) error handler
+        /// </summary>
+        public static async Task<UnitResult<E>> BindTry<T, E>(this Result<T, E> result, Func<T, Task<UnitResult<E>>> func,
             Func<Exception, E> errorHandler)
         {
             return result.IsFailure
                 ? UnitResult.Failure(result.Error)
-                : Result.Try(() => func(), errorHandler).Bind(r => r);
-        }
-
-        /// <summary>
-        ///     Selects result from the return value of a given function. If the calling UnitResult is a failure, a new failure result is returned instead.
-        ///     If a given function throws an exception, an error is returned from the given (or default) error handler
-        /// </summary>
-        public static Result<T, E> BindTry<T, E>(this UnitResult<E> result, Func<Result<T, E>> func,
-            Func<Exception, E> errorHandler)
-        {
-            return result.IsFailure
-                ? Result.Failure<T, E>(result.Error)
-                : Result.Try(() => func(), errorHandler).Bind(r => r);
-        }
-
-        /// <summary>
-        ///     Selects result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.
-        ///     If a given function throws an exception, an error is returned from the given (or default) error handler
-        /// </summary>
-        public static UnitResult<E> BindTry<T, E>(this Result<T, E> result, Func<T, UnitResult<E>> func,
-            Func<Exception, E> errorHandler)
-        {
-            return result.IsFailure
-                ? Result.Failure<T, E>(result.Error)
-                : Result.Try(() => func(result.Value), errorHandler).Bind(r => r);
+                : await Result.Try(() => func(result.Value), errorHandler).Bind(r => r).DefaultAwait();           
         }
     }
 }

--- a/CSharpFunctionalExtensions/Result/Methods/Extensions/BindTry.Task.Right.cs
+++ b/CSharpFunctionalExtensions/Result/Methods/Extensions/BindTry.Task.Right.cs
@@ -9,6 +9,13 @@ namespace CSharpFunctionalExtensions
         ///     Selects result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.
         ///     If a given function throws an exception, an error is returned from the given (or default) error handler
         /// </summary>
+        /// <typeparam name="T">Result Type parameter</typeparam>
+        /// <typeparam name="K"><paramref name="func" /> Result Type parameter</typeparam>
+        /// <typeparam name="E">Error Type parameter</typeparam>
+        /// <param name="result">Extended result</param>
+        /// <param name="func">Function returning result to to bind</param>
+        /// <param name="errorHandler">Error handling function</param>        
+        /// <returns>Binding result</returns>
         public static async Task<Result<K, E>> BindTry<T, K, E>(this Result<T, E> result, Func<T, Task<Result<K, E>>> func,
             Func<Exception, E> errorHandler)
         {
@@ -21,6 +28,12 @@ namespace CSharpFunctionalExtensions
         ///     Selects result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.
         ///     If a given function throws an exception, an error is returned from the given (or default) error handler
         /// </summary>
+        /// <typeparam name="T">Result Type parameter</typeparam>
+        /// <typeparam name="K"><paramref name="func" /> Result Type parameter</typeparam>        
+        /// <param name="result">Extended result</param>
+        /// <param name="func">Function returning result to to bind</param>
+        /// <param name="errorHandler">Error handling function</param>        
+        /// <returns>Binding result</returns>
         public static async Task<Result<K>> BindTry<T, K>(this Result<T> result, Func<T, Task<Result<K>>> func,
             Func<Exception, string> errorHandler = null)
         {
@@ -32,7 +45,12 @@ namespace CSharpFunctionalExtensions
         /// <summary>
         ///     Selects result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.
         ///     If a given function throws an exception, an error is returned from the given (or default) error handler
-        /// </summary>
+        /// </summary>        
+        /// <typeparam name="K"><paramref name="func" /> Result Type parameter</typeparam>        
+        /// <param name="result">Extended result</param>
+        /// <param name="func">Function returning result to to bind</param>
+        /// <param name="errorHandler">Error handling function</param>        
+        /// <returns>Binding result</returns>
         public static async Task<Result<K>> BindTry<K>(this Result result, Func<Task<Result<K>>> func,
             Func<Exception, string> errorHandler = null)
         {
@@ -45,6 +63,11 @@ namespace CSharpFunctionalExtensions
         ///     Selects result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.
         ///     If a given function throws an exception, an error is returned from the given (or default) error handler
         /// </summary>
+        /// <typeparam name="T">Result Type parameter</typeparam>        
+        /// <param name="result">Extended result</param>
+        /// <param name="func">Function returning result to to bind</param>
+        /// <param name="errorHandler">Error handling function</param>        
+        /// <returns>Binding result</returns>
         public static async Task<Result> BindTry<T>(this Result<T> result, Func<T, Task<Result>> func,
             Func<Exception, string> errorHandler = null)
         {
@@ -56,7 +79,11 @@ namespace CSharpFunctionalExtensions
         /// <summary>
         ///     Selects result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.
         ///     If a given function throws an exception, an error is returned from the given (or default) error handler
-        /// </summary>
+        /// </summary>        
+        /// <param name="result">Extended result</param>
+        /// <param name="func">Function returning result to to bind</param>
+        /// <param name="errorHandler">Error handling function</param>        
+        /// <returns>Binding result</returns>
         public static async Task<Result> BindTry(this Result result, Func<Task<Result>> func,
             Func<Exception, string> errorHandler = null)
         {
@@ -68,7 +95,12 @@ namespace CSharpFunctionalExtensions
         /// <summary>
         ///     Selects result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.
         ///     If a given function throws an exception, an error is returned from the given (or default) error handler
-        /// </summary>
+        /// </summary>        
+        /// <typeparam name="E">Error Type parameter</typeparam>
+        /// <param name="result">Extended result</param>
+        /// <param name="func">Function returning result to to bind</param>
+        /// <param name="errorHandler">Error handling function</param>        
+        /// <returns>Binding result</returns>
         public static async Task<UnitResult<E>> BindTry<E>(this UnitResult<E> result, Func<Task<UnitResult<E>>> func,
             Func<Exception, E> errorHandler)
         {            
@@ -81,6 +113,12 @@ namespace CSharpFunctionalExtensions
         ///     Selects result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.
         ///     If a given function throws an exception, an error is returned from the given (or default) error handler
         /// </summary>
+        /// <typeparam name="T">Result Type parameter</typeparam>        
+        /// <typeparam name="E">Error Type parameter</typeparam>
+        /// <param name="result">Extended result</param>
+        /// <param name="func">Function returning result to to bind</param>
+        /// <param name="errorHandler">Error handling function</param>        
+        /// <returns>Binding result</returns>
         public static async Task<Result<T, E>> BindTry<T, E>(this UnitResult<E> result, Func<Task<Result<T, E>>> func,
             Func<Exception, E> errorHandler)
         {
@@ -93,6 +131,12 @@ namespace CSharpFunctionalExtensions
         ///     Selects result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.
         ///     If a given function throws an exception, an error is returned from the given (or default) error handler
         /// </summary>
+        /// <typeparam name="T">Result Type parameter</typeparam>        
+        /// <typeparam name="E">Error Type parameter</typeparam>
+        /// <param name="result">Extended result</param>
+        /// <param name="func">Function returning result to to bind</param>
+        /// <param name="errorHandler">Error handling function</param>        
+        /// <returns>Binding result</returns>
         public static async Task<UnitResult<E>> BindTry<T, E>(this Result<T, E> result, Func<T, Task<UnitResult<E>>> func,
             Func<Exception, E> errorHandler)
         {

--- a/CSharpFunctionalExtensions/Result/Methods/Extensions/BindTry.Task.cs
+++ b/CSharpFunctionalExtensions/Result/Methods/Extensions/BindTry.Task.cs
@@ -1,0 +1,96 @@
+﻿using System.Threading.Tasks;
+using System;
+
+namespace CSharpFunctionalExtensions
+{
+	public static partial class AsyncResultExtensionsBothOperands
+	{
+		/// <summary>
+		///     Selects result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.
+		///     If a given function throws an exception, an error is returned from the given (or default) error handler
+		/// </summary>
+		public static async Task<Result> BindTry(this Task<Result> resultTask, Func<Task<Result>> func,
+			Func<Exception, string> errorHandler = null)
+		{
+			var result = await resultTask.DefaultAwait();
+			return await result.BindTry(func, errorHandler).DefaultAwait();
+		}
+
+		/// <summary>
+		///     Selects result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.
+		///     If a given function throws an exception, an error is returned from the given (or default) error handler
+		/// </summary>
+		public static async Task<Result> BindTry<T>(this Task<Result<T>> resultTask, Func<T, Task<Result>> func,
+			Func<Exception, string> errorHandler = null)
+		{
+			var result = await resultTask.DefaultAwait();
+			return await result.BindTry(func, errorHandler).DefaultAwait();
+		}
+
+		/// <summary>
+		///     Selects result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.
+		///     If a given function throws an exception, an error is returned from the given (or default) error handler
+		/// </summary>
+		public static async Task<Result<K>> BindTry<K>(this Task<Result> resultTask, Func<Task<Result<K>>> func,
+			Func<Exception, string> errorHandler = null)
+		{
+			var result = await resultTask.DefaultAwait();
+			return await result.BindTry(func, errorHandler).DefaultAwait();
+		}
+
+		/// <summary>
+		///     Selects result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.
+		///     If a given function throws an exception, an error is returned from the given error handler
+		/// </summary>
+		public static async Task<Result<K, E>> BindTry<T, K, E>(this Task<Result<T, E>> resultTask, Func<T, Task<Result<K, E>>> func,
+			Func<Exception, E> errorHandler)
+		{
+			var result = await resultTask.DefaultAwait();
+			return await result.BindTry(func, errorHandler).DefaultAwait();
+		}
+
+		/// <summary>
+		///     Selects result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.
+		///     If a given function throws an exception, an error is returned from the given (or default) error handler
+		/// </summary>
+		public static async Task<Result<K>> BindTry<T, K>(this Task<Result<T>> resultTask, Func<T, Task<Result<K>>> func,
+			Func<Exception, string> errorHandler = null)
+		{
+			var result = await resultTask.DefaultAwait();
+			return await result.BindTry(func, errorHandler).DefaultAwait();
+		}
+
+		/// <summary>
+		///     Selects result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.
+		///     If a given function throws an exception, an error is returned from the given error handler
+		/// </summary>
+		public static async Task<UnitResult<E>> BindTry<E>(this Task<UnitResult<E>> resultTask, Func<Task<UnitResult<E>>> func,
+			Func<Exception, E> errorHandler)
+		{
+			var result = await resultTask.DefaultAwait();
+			return await result.BindTry(func, errorHandler).DefaultAwait();
+		}
+
+		/// <summary>
+		///     Selects result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.
+		///     If a given function throws an exception, an error is returned from the given error handler
+		/// </summary>
+		public static async Task<Result<T, E>> BindTry<T, E>(this Task<UnitResult<E>> resultTask, Func<Task<Result<T, E>>> func,
+			Func<Exception, E> errorHandler)
+		{
+			var result = await resultTask.DefaultAwait();
+			return await result.BindTry(func, errorHandler).DefaultAwait();
+		}
+
+		/// <summary>
+		///     Selects result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.
+		///     If a given function throws an exception, an error is returned from the given error handler
+		/// </summary>
+		public static async Task<UnitResult<E>> BindTry<T, E>(this Task<Result<T, E>> resultTask, Func<T, Task<UnitResult<E>>> func,
+			Func<Exception, E> errorHandler)
+		{
+			var result = await resultTask.DefaultAwait();
+			return await result.BindTry(func, errorHandler).DefaultAwait();
+		}
+	}
+}

--- a/CSharpFunctionalExtensions/Result/Methods/Extensions/BindTry.Task.cs
+++ b/CSharpFunctionalExtensions/Result/Methods/Extensions/BindTry.Task.cs
@@ -7,10 +7,10 @@ namespace CSharpFunctionalExtensions
 	{
         /// <summary>
         ///     Selects result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.
-        ///     If a given function throws an exception, an error is returned from the given (or default) error handler
+        ///     If a given function throws an exception, an error is returned from the given error handler
         /// </summary>        
         /// <param name="resultTask">Extended result</param>
-        /// <param name="func">Function returning result to to bind</param>
+        /// <param name="func">Function returning result to bind</param>
         /// <param name="errorHandler">Error handling function</param>        
         /// <returns>Binding result</returns>
         public static async Task<Result> BindTry(this Task<Result> resultTask, Func<Task<Result>> func,
@@ -22,11 +22,11 @@ namespace CSharpFunctionalExtensions
 
         /// <summary>
         ///     Selects result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.
-        ///     If a given function throws an exception, an error is returned from the given (or default) error handler
+        ///     If a given function throws an exception, an error is returned from the given error handler
         /// </summary>        
         /// <typeparam name="K"><paramref name="func" /> Result Type parameter</typeparam>        
         /// <param name="resultTask">Extended result</param>
-        /// <param name="func">Function returning result to to bind</param>
+        /// <param name="func">Function returning result to bind</param>
         /// <param name="errorHandler">Error handling function</param>        
         /// <returns>Binding result</returns>
         public static async Task<Result<K>> BindTry<K>(this Task<Result> resultTask, Func<Task<Result<K>>> func,
@@ -38,11 +38,11 @@ namespace CSharpFunctionalExtensions
 
         /// <summary>
         ///     Selects result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.
-        ///     If a given function throws an exception, an error is returned from the given (or default) error handler
+        ///     If a given function throws an exception, an error is returned from the given error handler
         /// </summary>
         /// <typeparam name="T">Result Type parameter</typeparam>        
         /// <param name="resultTask">Extended result</param>
-        /// <param name="func">Function returning result to to bind</param>
+        /// <param name="func">Function returning result to bind</param>
         /// <param name="errorHandler">Error handling function</param>        
         /// <returns>Binding result</returns>
         public static async Task<Result> BindTry<T>(this Task<Result<T>> resultTask, Func<T, Task<Result>> func,
@@ -54,12 +54,12 @@ namespace CSharpFunctionalExtensions
 
         /// <summary>
         ///     Selects result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.
-        ///     If a given function throws an exception, an error is returned from the given (or default) error handler
+        ///     If a given function throws an exception, an error is returned from the given error handler
         /// </summary>
         /// <typeparam name="T">Result Type parameter</typeparam>
         /// <typeparam name="K"><paramref name="func" /> Result Type parameter</typeparam>        
         /// <param name="resultTask">Extended result</param>
-        /// <param name="func">Function returning result to to bind</param>
+        /// <param name="func">Function returning result to bind</param>
         /// <param name="errorHandler">Error handling function</param>        
         /// <returns>Binding result</returns>
         public static async Task<Result<K>> BindTry<T, K>(this Task<Result<T>> resultTask, Func<T, Task<Result<K>>> func,
@@ -76,7 +76,7 @@ namespace CSharpFunctionalExtensions
         /// <typeparam name="T">Result Type parameter</typeparam>        
         /// <typeparam name="E">Error Type parameter</typeparam>
         /// <param name="resultTask">Extended result</param>
-        /// <param name="func">Function returning result to to bind</param>
+        /// <param name="func">Function returning result to bind</param>
         /// <param name="errorHandler">Error handling function</param>        
         /// <returns>Binding result</returns>
         public static async Task<UnitResult<E>> BindTry<T, E>(this Task<Result<T, E>> resultTask, Func<T, Task<UnitResult<E>>> func,
@@ -94,7 +94,7 @@ namespace CSharpFunctionalExtensions
         /// <typeparam name="K"><paramref name="func" /> Result Type parameter</typeparam>
         /// <typeparam name="E">Error Type parameter</typeparam>
         /// <param name="resultTask">Extended result</param>
-        /// <param name="func">Function returning result to to bind</param>
+        /// <param name="func">Function returning result to bind</param>
         /// <param name="errorHandler">Error handling function</param>        
         /// <returns>Binding result</returns>
         public static async Task<Result<K, E>> BindTry<T, K, E>(this Task<Result<T, E>> resultTask, Func<T, Task<Result<K, E>>> func,
@@ -111,7 +111,7 @@ namespace CSharpFunctionalExtensions
         /// <typeparam name="T">Result Type parameter</typeparam>        
         /// <typeparam name="E">Error Type parameter</typeparam>
         /// <param name="resultTask">Extended result</param>
-        /// <param name="func">Function returning result to to bind</param>
+        /// <param name="func">Function returning result to bind</param>
         /// <param name="errorHandler">Error handling function</param>        
         /// <returns>Binding result</returns>
 		public static async Task<Result<T, E>> BindTry<T, E>(this Task<UnitResult<E>> resultTask, Func<Task<Result<T, E>>> func,
@@ -127,7 +127,7 @@ namespace CSharpFunctionalExtensions
         /// </summary>        
         /// <typeparam name="E">Error Type parameter</typeparam>
         /// <param name="resultTask">Extended result</param>
-        /// <param name="func">Function returning result to to bind</param>
+        /// <param name="func">Function returning result to bind</param>
         /// <param name="errorHandler">Error handling function</param>        
         /// <returns>Binding result</returns>
         public static async Task<UnitResult<E>> BindTry<E>(this Task<UnitResult<E>> resultTask, Func<Task<UnitResult<E>>> func,

--- a/CSharpFunctionalExtensions/Result/Methods/Extensions/BindTry.Task.cs
+++ b/CSharpFunctionalExtensions/Result/Methods/Extensions/BindTry.Task.cs
@@ -16,81 +16,81 @@ namespace CSharpFunctionalExtensions
 			return await result.BindTry(func, errorHandler).DefaultAwait();
 		}
 
-		/// <summary>
-		///     Selects result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.
-		///     If a given function throws an exception, an error is returned from the given (or default) error handler
-		/// </summary>
-		public static async Task<Result> BindTry<T>(this Task<Result<T>> resultTask, Func<T, Task<Result>> func,
+        /// <summary>
+        ///     Selects result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.
+        ///     If a given function throws an exception, an error is returned from the given (or default) error handler
+        /// </summary>
+        public static async Task<Result<K>> BindTry<K>(this Task<Result> resultTask, Func<Task<Result<K>>> func,
+            Func<Exception, string> errorHandler = null)
+        {
+            var result = await resultTask.DefaultAwait();
+            return await result.BindTry(func, errorHandler).DefaultAwait();
+        }
+
+        /// <summary>
+        ///     Selects result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.
+        ///     If a given function throws an exception, an error is returned from the given (or default) error handler
+        /// </summary>
+        public static async Task<Result> BindTry<T>(this Task<Result<T>> resultTask, Func<T, Task<Result>> func,
 			Func<Exception, string> errorHandler = null)
 		{
 			var result = await resultTask.DefaultAwait();
 			return await result.BindTry(func, errorHandler).DefaultAwait();
 		}
 
-		/// <summary>
-		///     Selects result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.
-		///     If a given function throws an exception, an error is returned from the given (or default) error handler
-		/// </summary>
-		public static async Task<Result<K>> BindTry<K>(this Task<Result> resultTask, Func<Task<Result<K>>> func,
-			Func<Exception, string> errorHandler = null)
-		{
-			var result = await resultTask.DefaultAwait();
-			return await result.BindTry(func, errorHandler).DefaultAwait();
-		}
+        /// <summary>
+        ///     Selects result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.
+        ///     If a given function throws an exception, an error is returned from the given (or default) error handler
+        /// </summary>
+        public static async Task<Result<K>> BindTry<T, K>(this Task<Result<T>> resultTask, Func<T, Task<Result<K>>> func,
+            Func<Exception, string> errorHandler = null)
+        {
+            var result = await resultTask.DefaultAwait();
+            return await result.BindTry(func, errorHandler).DefaultAwait();
+        }
 
-		/// <summary>
-		///     Selects result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.
-		///     If a given function throws an exception, an error is returned from the given error handler
-		/// </summary>
-		public static async Task<Result<K, E>> BindTry<T, K, E>(this Task<Result<T, E>> resultTask, Func<T, Task<Result<K, E>>> func,
+        /// <summary>
+        ///     Selects result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.
+        ///     If a given function throws an exception, an error is returned from the given error handler
+        /// </summary>
+        public static async Task<UnitResult<E>> BindTry<T, E>(this Task<Result<T, E>> resultTask, Func<T, Task<UnitResult<E>>> func,
+            Func<Exception, E> errorHandler)
+        {
+            var result = await resultTask.DefaultAwait();
+            return await result.BindTry(func, errorHandler).DefaultAwait();
+        }
+
+        /// <summary>
+        ///     Selects result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.
+        ///     If a given function throws an exception, an error is returned from the given error handler
+        /// </summary>
+        public static async Task<Result<K, E>> BindTry<T, K, E>(this Task<Result<T, E>> resultTask, Func<T, Task<Result<K, E>>> func,
 			Func<Exception, E> errorHandler)
 		{
 			var result = await resultTask.DefaultAwait();
 			return await result.BindTry(func, errorHandler).DefaultAwait();
 		}
 
-		/// <summary>
-		///     Selects result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.
-		///     If a given function throws an exception, an error is returned from the given (or default) error handler
-		/// </summary>
-		public static async Task<Result<K>> BindTry<T, K>(this Task<Result<T>> resultTask, Func<T, Task<Result<K>>> func,
-			Func<Exception, string> errorHandler = null)
-		{
-			var result = await resultTask.DefaultAwait();
-			return await result.BindTry(func, errorHandler).DefaultAwait();
-		}
-
-		/// <summary>
-		///     Selects result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.
-		///     If a given function throws an exception, an error is returned from the given error handler
-		/// </summary>
-		public static async Task<UnitResult<E>> BindTry<E>(this Task<UnitResult<E>> resultTask, Func<Task<UnitResult<E>>> func,
-			Func<Exception, E> errorHandler)
-		{
-			var result = await resultTask.DefaultAwait();
-			return await result.BindTry(func, errorHandler).DefaultAwait();
-		}
-
-		/// <summary>
+        /// <summary>
 		///     Selects result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.
 		///     If a given function throws an exception, an error is returned from the given error handler
 		/// </summary>
 		public static async Task<Result<T, E>> BindTry<T, E>(this Task<UnitResult<E>> resultTask, Func<Task<Result<T, E>>> func,
-			Func<Exception, E> errorHandler)
-		{
-			var result = await resultTask.DefaultAwait();
-			return await result.BindTry(func, errorHandler).DefaultAwait();
-		}
+            Func<Exception, E> errorHandler)
+        {
+            var result = await resultTask.DefaultAwait();
+            return await result.BindTry(func, errorHandler).DefaultAwait();
+        }
 
-		/// <summary>
-		///     Selects result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.
-		///     If a given function throws an exception, an error is returned from the given error handler
-		/// </summary>
-		public static async Task<UnitResult<E>> BindTry<T, E>(this Task<Result<T, E>> resultTask, Func<T, Task<UnitResult<E>>> func,
+        /// <summary>
+        ///     Selects result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.
+        ///     If a given function throws an exception, an error is returned from the given error handler
+        /// </summary>
+        public static async Task<UnitResult<E>> BindTry<E>(this Task<UnitResult<E>> resultTask, Func<Task<UnitResult<E>>> func,
 			Func<Exception, E> errorHandler)
 		{
 			var result = await resultTask.DefaultAwait();
 			return await result.BindTry(func, errorHandler).DefaultAwait();
-		}
+		}			
 	}
 }

--- a/CSharpFunctionalExtensions/Result/Methods/Extensions/BindTry.Task.cs
+++ b/CSharpFunctionalExtensions/Result/Methods/Extensions/BindTry.Task.cs
@@ -5,11 +5,15 @@ namespace CSharpFunctionalExtensions
 {
 	public static partial class AsyncResultExtensionsBothOperands
 	{
-		/// <summary>
-		///     Selects result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.
-		///     If a given function throws an exception, an error is returned from the given (or default) error handler
-		/// </summary>
-		public static async Task<Result> BindTry(this Task<Result> resultTask, Func<Task<Result>> func,
+        /// <summary>
+        ///     Selects result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.
+        ///     If a given function throws an exception, an error is returned from the given (or default) error handler
+        /// </summary>        
+        /// <param name="resultTask">Extended result</param>
+        /// <param name="func">Function returning result to to bind</param>
+        /// <param name="errorHandler">Error handling function</param>        
+        /// <returns>Binding result</returns>
+        public static async Task<Result> BindTry(this Task<Result> resultTask, Func<Task<Result>> func,
 			Func<Exception, string> errorHandler = null)
 		{
 			var result = await resultTask.DefaultAwait();
@@ -19,7 +23,12 @@ namespace CSharpFunctionalExtensions
         /// <summary>
         ///     Selects result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.
         ///     If a given function throws an exception, an error is returned from the given (or default) error handler
-        /// </summary>
+        /// </summary>        
+        /// <typeparam name="K"><paramref name="func" /> Result Type parameter</typeparam>        
+        /// <param name="resultTask">Extended result</param>
+        /// <param name="func">Function returning result to to bind</param>
+        /// <param name="errorHandler">Error handling function</param>        
+        /// <returns>Binding result</returns>
         public static async Task<Result<K>> BindTry<K>(this Task<Result> resultTask, Func<Task<Result<K>>> func,
             Func<Exception, string> errorHandler = null)
         {
@@ -31,6 +40,11 @@ namespace CSharpFunctionalExtensions
         ///     Selects result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.
         ///     If a given function throws an exception, an error is returned from the given (or default) error handler
         /// </summary>
+        /// <typeparam name="T">Result Type parameter</typeparam>        
+        /// <param name="resultTask">Extended result</param>
+        /// <param name="func">Function returning result to to bind</param>
+        /// <param name="errorHandler">Error handling function</param>        
+        /// <returns>Binding result</returns>
         public static async Task<Result> BindTry<T>(this Task<Result<T>> resultTask, Func<T, Task<Result>> func,
 			Func<Exception, string> errorHandler = null)
 		{
@@ -42,6 +56,12 @@ namespace CSharpFunctionalExtensions
         ///     Selects result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.
         ///     If a given function throws an exception, an error is returned from the given (or default) error handler
         /// </summary>
+        /// <typeparam name="T">Result Type parameter</typeparam>
+        /// <typeparam name="K"><paramref name="func" /> Result Type parameter</typeparam>        
+        /// <param name="resultTask">Extended result</param>
+        /// <param name="func">Function returning result to to bind</param>
+        /// <param name="errorHandler">Error handling function</param>        
+        /// <returns>Binding result</returns>
         public static async Task<Result<K>> BindTry<T, K>(this Task<Result<T>> resultTask, Func<T, Task<Result<K>>> func,
             Func<Exception, string> errorHandler = null)
         {
@@ -53,6 +73,12 @@ namespace CSharpFunctionalExtensions
         ///     Selects result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.
         ///     If a given function throws an exception, an error is returned from the given error handler
         /// </summary>
+        /// <typeparam name="T">Result Type parameter</typeparam>        
+        /// <typeparam name="E">Error Type parameter</typeparam>
+        /// <param name="resultTask">Extended result</param>
+        /// <param name="func">Function returning result to to bind</param>
+        /// <param name="errorHandler">Error handling function</param>        
+        /// <returns>Binding result</returns>
         public static async Task<UnitResult<E>> BindTry<T, E>(this Task<Result<T, E>> resultTask, Func<T, Task<UnitResult<E>>> func,
             Func<Exception, E> errorHandler)
         {
@@ -64,6 +90,13 @@ namespace CSharpFunctionalExtensions
         ///     Selects result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.
         ///     If a given function throws an exception, an error is returned from the given error handler
         /// </summary>
+        /// <typeparam name="T">Result Type parameter</typeparam>
+        /// <typeparam name="K"><paramref name="func" /> Result Type parameter</typeparam>
+        /// <typeparam name="E">Error Type parameter</typeparam>
+        /// <param name="resultTask">Extended result</param>
+        /// <param name="func">Function returning result to to bind</param>
+        /// <param name="errorHandler">Error handling function</param>        
+        /// <returns>Binding result</returns>
         public static async Task<Result<K, E>> BindTry<T, K, E>(this Task<Result<T, E>> resultTask, Func<T, Task<Result<K, E>>> func,
 			Func<Exception, E> errorHandler)
 		{
@@ -75,6 +108,12 @@ namespace CSharpFunctionalExtensions
 		///     Selects result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.
 		///     If a given function throws an exception, an error is returned from the given error handler
 		/// </summary>
+        /// <typeparam name="T">Result Type parameter</typeparam>        
+        /// <typeparam name="E">Error Type parameter</typeparam>
+        /// <param name="resultTask">Extended result</param>
+        /// <param name="func">Function returning result to to bind</param>
+        /// <param name="errorHandler">Error handling function</param>        
+        /// <returns>Binding result</returns>
 		public static async Task<Result<T, E>> BindTry<T, E>(this Task<UnitResult<E>> resultTask, Func<Task<Result<T, E>>> func,
             Func<Exception, E> errorHandler)
         {
@@ -85,7 +124,12 @@ namespace CSharpFunctionalExtensions
         /// <summary>
         ///     Selects result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.
         ///     If a given function throws an exception, an error is returned from the given error handler
-        /// </summary>
+        /// </summary>        
+        /// <typeparam name="E">Error Type parameter</typeparam>
+        /// <param name="resultTask">Extended result</param>
+        /// <param name="func">Function returning result to to bind</param>
+        /// <param name="errorHandler">Error handling function</param>        
+        /// <returns>Binding result</returns>
         public static async Task<UnitResult<E>> BindTry<E>(this Task<UnitResult<E>> resultTask, Func<Task<UnitResult<E>>> func,
 			Func<Exception, E> errorHandler)
 		{

--- a/CSharpFunctionalExtensions/Result/Methods/Extensions/BindTry.ValueTask.Left.cs
+++ b/CSharpFunctionalExtensions/Result/Methods/Extensions/BindTry.ValueTask.Left.cs
@@ -2,21 +2,20 @@
 using System.Threading.Tasks;
 using System;
 
-namespace CSharpFunctionalExtensions
+namespace CSharpFunctionalExtensions.ValueTasks
 {
     public static partial class AsyncResultExtensionsLeftOperand
     {
         /// <summary>
         ///     Selects result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.
-        ///     If a given function throws an exception, an error is returned from the given (or default) error handler
+        ///     If a given function throws an exception, an error is returned from the given error handler
         /// </summary>        
         /// <param name="resultValueTask">Extended result</param>
-        /// <param name="func">Function returning result to to bind</param>
+        /// <param name="func">Function returning result to bind</param>
         /// <param name="errorHandler">Error handling function</param>
-        /// <param name="_">Set this parameter if you want to use ValueTask extension for async lambda</param>
         /// <returns>Binding result</returns>
         public static async ValueTask<Result> BindTry(this ValueTask<Result> resultValueTask, Func<Result> func,
-            Func<Exception, string> errorHandler = null, bool _ = default)
+            Func<Exception, string> errorHandler = null)
         {
             var result = await resultValueTask;
             return result.BindTry(func, errorHandler);
@@ -24,16 +23,15 @@ namespace CSharpFunctionalExtensions
 
         /// <summary>
         ///     Selects result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.
-        ///     If a given function throws an exception, an error is returned from the given (or default) error handler
+        ///     If a given function throws an exception, an error is returned from the given error handler
         /// </summary>        
         /// <typeparam name="K"><paramref name="func" /> Result Type parameter</typeparam>        
         /// <param name="resultValueTask">Extended result</param>
-        /// <param name="func">Function returning result to to bind</param>
+        /// <param name="func">Function returning result to bind</param>
         /// <param name="errorHandler">Error handling function</param>
-        /// <param name="_">Set this parameter if you want to use ValueTask extension for async lambda</param>
         /// <returns>Binding result</returns>
         public static async ValueTask<Result<K>> BindTry<K>(this ValueTask<Result> resultValueTask, Func<Result<K>> func,
-            Func<Exception, string> errorHandler = null, bool _ = default)
+            Func<Exception, string> errorHandler = null)
         {
             var result = await resultValueTask;
             return result.BindTry(func, errorHandler);
@@ -41,16 +39,15 @@ namespace CSharpFunctionalExtensions
 
         /// <summary>
         ///     Selects result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.
-        ///     If a given function throws an exception, an error is returned from the given (or default) error handler
+        ///     If a given function throws an exception, an error is returned from the given error handler
         /// </summary>
         /// <typeparam name="T">Result Type parameter</typeparam>        
         /// <param name="resultValueTask">Extended result</param>
-        /// <param name="func">Function returning result to to bind</param>
+        /// <param name="func">Function returning result to bind</param>
         /// <param name="errorHandler">Error handling function</param>
-        /// <param name="_">Set this parameter if you want to use ValueTask extension for async lambda</param>
         /// <returns>Binding result</returns>
         public static async ValueTask<Result> BindTry<T>(this ValueTask<Result<T>> resultValueTask, Func<T, Result> func,
-            Func<Exception, string> errorHandler = null, bool _ = default)
+            Func<Exception, string> errorHandler = null)
         {
             var result = await resultValueTask;
             return result.BindTry(func, errorHandler);
@@ -58,17 +55,16 @@ namespace CSharpFunctionalExtensions
 
         /// <summary>
         ///     Selects result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.
-        ///     If a given function throws an exception, an error is returned from the given (or default) error handler
+        ///     If a given function throws an exception, an error is returned from the given error handler
         /// </summary>
         /// <typeparam name="T">Result Type parameter</typeparam>
         /// <typeparam name="K"><paramref name="func" /> Result Type parameter</typeparam>        
         /// <param name="resultValueTask">Extended result</param>
-        /// <param name="func">Function returning result to to bind</param>
+        /// <param name="func">Function returning result to bind</param>
         /// <param name="errorHandler">Error handling function</param>
-        /// <param name="_">Set this parameter if you want to use ValueTask extension for async lambda</param>
         /// <returns>Binding result</returns>
         public static async ValueTask<Result<K>> BindTry<T, K>(this ValueTask<Result<T>> resultValueTask, Func<T, Result<K>> func,
-            Func<Exception, string> errorHandler = null, bool _ = default)
+            Func<Exception, string> errorHandler = null)
         {
             var result = await resultValueTask;
             return result.BindTry(func, errorHandler);
@@ -81,12 +77,11 @@ namespace CSharpFunctionalExtensions
         /// <typeparam name="T">Result Type parameter</typeparam>        
         /// <typeparam name="E">Error Type parameter</typeparam>
         /// <param name="resultValueTask">Extended result</param>
-        /// <param name="func">Function returning result to to bind</param>
+        /// <param name="func">Function returning result to bind</param>
         /// <param name="errorHandler">Error handling function</param>
-        /// <param name="_">Set this parameter if you want to use ValueTask extension for async lambda</param>
         /// <returns>Binding result</returns>
         public static async ValueTask<UnitResult<E>> BindTry<T, E>(this ValueTask<Result<T, E>> resultValueTask, Func<T, UnitResult<E>> func,
-            Func<Exception, E> errorHandler, bool _ = default)
+            Func<Exception, E> errorHandler)
         {
             var result = await resultValueTask;
             return result.BindTry(func, errorHandler);
@@ -94,18 +89,17 @@ namespace CSharpFunctionalExtensions
 
         /// <summary>
         ///     Selects result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.
-        ///     If a given function throws an exception, an error is returned from the given (or default) error handler
+        ///     If a given function throws an exception, an error is returned from the given error handler
         /// </summary>
         /// <typeparam name="T">Result Type parameter</typeparam>
         /// <typeparam name="K"><paramref name="func" /> Result Type parameter</typeparam>
         /// <typeparam name="E">Error Type parameter</typeparam>
         /// <param name="resultValueTask">Extended result</param>
-        /// <param name="func">Function returning result to to bind</param>
+        /// <param name="func">Function returning result to bind</param>
         /// <param name="errorHandler">Error handling function</param>
-        /// <param name="_">Set this parameter if you want to use ValueTask extension for async lambda</param>
         /// <returns>Binding result</returns>
         public static async ValueTask<Result<K, E>> BindTry<T, K, E>(this ValueTask<Result<T, E>> resultValueTask, Func<T, Result<K, E>> func,
-            Func<Exception, E> errorHandler, bool _ = default)
+            Func<Exception, E> errorHandler)
         {
             var result = await resultValueTask;
             return result.BindTry(func, errorHandler);
@@ -117,12 +111,11 @@ namespace CSharpFunctionalExtensions
         /// </summary>        
         /// <typeparam name="E">Error Type parameter</typeparam>
         /// <param name="resultValueTask">Extended result</param>
-        /// <param name="func">Function returning result to to bind</param>
+        /// <param name="func">Function returning result to bind</param>
         /// <param name="errorHandler">Error handling function</param>
-        /// <param name="_">Set this parameter if you want to use ValueTask extension for async lambda</param>
         /// <returns>Binding result</returns>
         public static async ValueTask<UnitResult<E>> BindTry<E>(this ValueTask<UnitResult<E>> resultValueTask, Func<UnitResult<E>> func,
-            Func<Exception, E> errorHandler, bool _ = default)
+            Func<Exception, E> errorHandler)
         {
             var result = await resultValueTask;
             return result.BindTry(func, errorHandler);
@@ -135,12 +128,11 @@ namespace CSharpFunctionalExtensions
         /// <typeparam name="T">Result Type parameter</typeparam>        
         /// <typeparam name="E">Error Type parameter</typeparam>
         /// <param name="resultValueTask">Extended result</param>
-        /// <param name="func">Function returning result to to bind</param>
+        /// <param name="func">Function returning result to bind</param>
         /// <param name="errorHandler">Error handling function</param>
-        /// <param name="_">Set this parameter if you want to use ValueTask extension for async lambda</param>
         /// <returns>Binding result</returns>
         public static async ValueTask<Result<T, E>> BindTry<T, E>(this ValueTask<UnitResult<E>> resultValueTask, Func<Result<T, E>> func,
-            Func<Exception, E> errorHandler, bool _ = default)
+            Func<Exception, E> errorHandler)
         {
             var result = await resultValueTask;
             return result.BindTry(func, errorHandler);

--- a/CSharpFunctionalExtensions/Result/Methods/Extensions/BindTry.ValueTask.Left.cs
+++ b/CSharpFunctionalExtensions/Result/Methods/Extensions/BindTry.ValueTask.Left.cs
@@ -1,0 +1,98 @@
+﻿#if NET5_0_OR_GREATER
+using System.Threading.Tasks;
+using System;
+
+namespace CSharpFunctionalExtensions
+{
+    public static partial class AsyncResultExtensionsLeftOperand
+    {
+        /// <summary>
+        ///     Selects result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.
+        ///     If a given function throws an exception, an error is returned from the given (or default) error handler
+        /// </summary>
+        public static async ValueTask<Result> BindTry(this ValueTask<Result> resultValueTask, Func<Result> func,
+            Func<Exception, string> errorHandler = null)
+        {
+            var result = await resultValueTask;
+            return result.BindTry(func, errorHandler);
+        }
+
+        /// <summary>
+        ///     Selects result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.
+        ///     If a given function throws an exception, an error is returned from the given (or default) error handler
+        /// </summary>
+        public static async ValueTask<Result<K>> BindTry<K>(this ValueTask<Result> resultValueTask, Func<Result<K>> func,
+            Func<Exception, string> errorHandler = null)
+        {
+            var result = await resultValueTask;
+            return result.BindTry(func, errorHandler);
+        }
+
+        /// <summary>
+        ///     Selects result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.
+        ///     If a given function throws an exception, an error is returned from the given (or default) error handler
+        /// </summary>
+        public static async ValueTask<Result> BindTry<T>(this ValueTask<Result<T>> resultValueTask, Func<T, Result> func,
+            Func<Exception, string> errorHandler = null)
+        {
+            var result = await resultValueTask;
+            return result.BindTry(func, errorHandler);
+        }
+
+        /// <summary>
+        ///     Selects result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.
+        ///     If a given function throws an exception, an error is returned from the given (or default) error handler
+        /// </summary>
+        public static async ValueTask<Result<K>> BindTry<T, K>(this ValueTask<Result<T>> resultValueTask, Func<T, Result<K>> func,
+            Func<Exception, string> errorHandler = null)
+        {
+            var result = await resultValueTask;
+            return result.BindTry(func, errorHandler);
+        }
+
+        /// <summary>
+        ///     Selects result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.
+        ///     If a given function throws an exception, an error is returned from the given error handler
+        /// </summary>
+        public static async ValueTask<UnitResult<E>> BindTry<T, E>(this ValueTask<Result<T, E>> resultValueTask, Func<T, UnitResult<E>> func,
+            Func<Exception, E> errorHandler)
+        {
+            var result = await resultValueTask;
+            return result.BindTry(func, errorHandler);
+        }
+
+        /// <summary>
+        ///     Selects result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.
+        ///     If a given function throws an exception, an error is returned from the given (or default) error handler
+        /// </summary>
+        public static async ValueTask<Result<K, E>> BindTry<T, K, E>(this ValueTask<Result<T, E>> resultValueTask, Func<T, Result<K, E>> func,
+            Func<Exception, E> errorHandler)
+        {
+            var result = await resultValueTask;
+            return result.BindTry(func, errorHandler);
+        }
+
+        /// <summary>
+        ///     Selects result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.
+        ///     If a given function throws an exception, an error is returned from the given error handler
+        /// </summary>
+        public static async ValueTask<UnitResult<E>> BindTry<E>(this ValueTask<UnitResult<E>> resultValueTask, Func<UnitResult<E>> func,
+            Func<Exception, E> errorHandler)
+        {
+            var result = await resultValueTask;
+            return result.BindTry(func, errorHandler);
+        }
+
+        /// <summary>
+        ///     Selects result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.
+        ///     If a given function throws an exception, an error is returned from the given error handler
+        /// </summary>
+        public static async ValueTask<Result<T, E>> BindTry<T, E>(this ValueTask<UnitResult<E>> resultValueTask, Func<Result<T, E>> func,
+            Func<Exception, E> errorHandler)
+        {
+            var result = await resultValueTask;
+            return result.BindTry(func, errorHandler);
+        }        
+    }
+}
+#endif

--- a/CSharpFunctionalExtensions/Result/Methods/Extensions/BindTry.ValueTask.Left.cs
+++ b/CSharpFunctionalExtensions/Result/Methods/Extensions/BindTry.ValueTask.Left.cs
@@ -9,7 +9,12 @@ namespace CSharpFunctionalExtensions
         /// <summary>
         ///     Selects result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.
         ///     If a given function throws an exception, an error is returned from the given (or default) error handler
-        /// </summary>
+        /// </summary>        
+        /// <param name="resultValueTask">Extended result</param>
+        /// <param name="func">Function returning result to to bind</param>
+        /// <param name="errorHandler">Error handling function</param>
+        /// <param name="_">Set this parameter if you want to use ValueTask extension for async lambda</param>
+        /// <returns>Binding result</returns>
         public static async ValueTask<Result> BindTry(this ValueTask<Result> resultValueTask, Func<Result> func,
             Func<Exception, string> errorHandler = null, bool _ = default)
         {
@@ -20,7 +25,13 @@ namespace CSharpFunctionalExtensions
         /// <summary>
         ///     Selects result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.
         ///     If a given function throws an exception, an error is returned from the given (or default) error handler
-        /// </summary>
+        /// </summary>        
+        /// <typeparam name="K"><paramref name="func" /> Result Type parameter</typeparam>        
+        /// <param name="resultValueTask">Extended result</param>
+        /// <param name="func">Function returning result to to bind</param>
+        /// <param name="errorHandler">Error handling function</param>
+        /// <param name="_">Set this parameter if you want to use ValueTask extension for async lambda</param>
+        /// <returns>Binding result</returns>
         public static async ValueTask<Result<K>> BindTry<K>(this ValueTask<Result> resultValueTask, Func<Result<K>> func,
             Func<Exception, string> errorHandler = null, bool _ = default)
         {
@@ -32,6 +43,12 @@ namespace CSharpFunctionalExtensions
         ///     Selects result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.
         ///     If a given function throws an exception, an error is returned from the given (or default) error handler
         /// </summary>
+        /// <typeparam name="T">Result Type parameter</typeparam>        
+        /// <param name="resultValueTask">Extended result</param>
+        /// <param name="func">Function returning result to to bind</param>
+        /// <param name="errorHandler">Error handling function</param>
+        /// <param name="_">Set this parameter if you want to use ValueTask extension for async lambda</param>
+        /// <returns>Binding result</returns>
         public static async ValueTask<Result> BindTry<T>(this ValueTask<Result<T>> resultValueTask, Func<T, Result> func,
             Func<Exception, string> errorHandler = null, bool _ = default)
         {
@@ -43,6 +60,13 @@ namespace CSharpFunctionalExtensions
         ///     Selects result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.
         ///     If a given function throws an exception, an error is returned from the given (or default) error handler
         /// </summary>
+        /// <typeparam name="T">Result Type parameter</typeparam>
+        /// <typeparam name="K"><paramref name="func" /> Result Type parameter</typeparam>        
+        /// <param name="resultValueTask">Extended result</param>
+        /// <param name="func">Function returning result to to bind</param>
+        /// <param name="errorHandler">Error handling function</param>
+        /// <param name="_">Set this parameter if you want to use ValueTask extension for async lambda</param>
+        /// <returns>Binding result</returns>
         public static async ValueTask<Result<K>> BindTry<T, K>(this ValueTask<Result<T>> resultValueTask, Func<T, Result<K>> func,
             Func<Exception, string> errorHandler = null, bool _ = default)
         {
@@ -54,6 +78,13 @@ namespace CSharpFunctionalExtensions
         ///     Selects result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.
         ///     If a given function throws an exception, an error is returned from the given error handler
         /// </summary>
+        /// <typeparam name="T">Result Type parameter</typeparam>        
+        /// <typeparam name="E">Error Type parameter</typeparam>
+        /// <param name="resultValueTask">Extended result</param>
+        /// <param name="func">Function returning result to to bind</param>
+        /// <param name="errorHandler">Error handling function</param>
+        /// <param name="_">Set this parameter if you want to use ValueTask extension for async lambda</param>
+        /// <returns>Binding result</returns>
         public static async ValueTask<UnitResult<E>> BindTry<T, E>(this ValueTask<Result<T, E>> resultValueTask, Func<T, UnitResult<E>> func,
             Func<Exception, E> errorHandler, bool _ = default)
         {
@@ -65,6 +96,14 @@ namespace CSharpFunctionalExtensions
         ///     Selects result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.
         ///     If a given function throws an exception, an error is returned from the given (or default) error handler
         /// </summary>
+        /// <typeparam name="T">Result Type parameter</typeparam>
+        /// <typeparam name="K"><paramref name="func" /> Result Type parameter</typeparam>
+        /// <typeparam name="E">Error Type parameter</typeparam>
+        /// <param name="resultValueTask">Extended result</param>
+        /// <param name="func">Function returning result to to bind</param>
+        /// <param name="errorHandler">Error handling function</param>
+        /// <param name="_">Set this parameter if you want to use ValueTask extension for async lambda</param>
+        /// <returns>Binding result</returns>
         public static async ValueTask<Result<K, E>> BindTry<T, K, E>(this ValueTask<Result<T, E>> resultValueTask, Func<T, Result<K, E>> func,
             Func<Exception, E> errorHandler, bool _ = default)
         {
@@ -75,7 +114,13 @@ namespace CSharpFunctionalExtensions
         /// <summary>
         ///     Selects result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.
         ///     If a given function throws an exception, an error is returned from the given error handler
-        /// </summary>
+        /// </summary>        
+        /// <typeparam name="E">Error Type parameter</typeparam>
+        /// <param name="resultValueTask">Extended result</param>
+        /// <param name="func">Function returning result to to bind</param>
+        /// <param name="errorHandler">Error handling function</param>
+        /// <param name="_">Set this parameter if you want to use ValueTask extension for async lambda</param>
+        /// <returns>Binding result</returns>
         public static async ValueTask<UnitResult<E>> BindTry<E>(this ValueTask<UnitResult<E>> resultValueTask, Func<UnitResult<E>> func,
             Func<Exception, E> errorHandler, bool _ = default)
         {
@@ -87,6 +132,13 @@ namespace CSharpFunctionalExtensions
         ///     Selects result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.
         ///     If a given function throws an exception, an error is returned from the given error handler
         /// </summary>
+        /// <typeparam name="T">Result Type parameter</typeparam>        
+        /// <typeparam name="E">Error Type parameter</typeparam>
+        /// <param name="resultValueTask">Extended result</param>
+        /// <param name="func">Function returning result to to bind</param>
+        /// <param name="errorHandler">Error handling function</param>
+        /// <param name="_">Set this parameter if you want to use ValueTask extension for async lambda</param>
+        /// <returns>Binding result</returns>
         public static async ValueTask<Result<T, E>> BindTry<T, E>(this ValueTask<UnitResult<E>> resultValueTask, Func<Result<T, E>> func,
             Func<Exception, E> errorHandler, bool _ = default)
         {

--- a/CSharpFunctionalExtensions/Result/Methods/Extensions/BindTry.ValueTask.Left.cs
+++ b/CSharpFunctionalExtensions/Result/Methods/Extensions/BindTry.ValueTask.Left.cs
@@ -11,7 +11,7 @@ namespace CSharpFunctionalExtensions
         ///     If a given function throws an exception, an error is returned from the given (or default) error handler
         /// </summary>
         public static async ValueTask<Result> BindTry(this ValueTask<Result> resultValueTask, Func<Result> func,
-            Func<Exception, string> errorHandler = null)
+            Func<Exception, string> errorHandler = null, bool _ = default)
         {
             var result = await resultValueTask;
             return result.BindTry(func, errorHandler);
@@ -22,7 +22,7 @@ namespace CSharpFunctionalExtensions
         ///     If a given function throws an exception, an error is returned from the given (or default) error handler
         /// </summary>
         public static async ValueTask<Result<K>> BindTry<K>(this ValueTask<Result> resultValueTask, Func<Result<K>> func,
-            Func<Exception, string> errorHandler = null)
+            Func<Exception, string> errorHandler = null, bool _ = default)
         {
             var result = await resultValueTask;
             return result.BindTry(func, errorHandler);
@@ -33,7 +33,7 @@ namespace CSharpFunctionalExtensions
         ///     If a given function throws an exception, an error is returned from the given (or default) error handler
         /// </summary>
         public static async ValueTask<Result> BindTry<T>(this ValueTask<Result<T>> resultValueTask, Func<T, Result> func,
-            Func<Exception, string> errorHandler = null)
+            Func<Exception, string> errorHandler = null, bool _ = default)
         {
             var result = await resultValueTask;
             return result.BindTry(func, errorHandler);
@@ -44,7 +44,7 @@ namespace CSharpFunctionalExtensions
         ///     If a given function throws an exception, an error is returned from the given (or default) error handler
         /// </summary>
         public static async ValueTask<Result<K>> BindTry<T, K>(this ValueTask<Result<T>> resultValueTask, Func<T, Result<K>> func,
-            Func<Exception, string> errorHandler = null)
+            Func<Exception, string> errorHandler = null, bool _ = default)
         {
             var result = await resultValueTask;
             return result.BindTry(func, errorHandler);
@@ -55,7 +55,7 @@ namespace CSharpFunctionalExtensions
         ///     If a given function throws an exception, an error is returned from the given error handler
         /// </summary>
         public static async ValueTask<UnitResult<E>> BindTry<T, E>(this ValueTask<Result<T, E>> resultValueTask, Func<T, UnitResult<E>> func,
-            Func<Exception, E> errorHandler)
+            Func<Exception, E> errorHandler, bool _ = default)
         {
             var result = await resultValueTask;
             return result.BindTry(func, errorHandler);
@@ -66,7 +66,7 @@ namespace CSharpFunctionalExtensions
         ///     If a given function throws an exception, an error is returned from the given (or default) error handler
         /// </summary>
         public static async ValueTask<Result<K, E>> BindTry<T, K, E>(this ValueTask<Result<T, E>> resultValueTask, Func<T, Result<K, E>> func,
-            Func<Exception, E> errorHandler)
+            Func<Exception, E> errorHandler, bool _ = default)
         {
             var result = await resultValueTask;
             return result.BindTry(func, errorHandler);
@@ -77,7 +77,7 @@ namespace CSharpFunctionalExtensions
         ///     If a given function throws an exception, an error is returned from the given error handler
         /// </summary>
         public static async ValueTask<UnitResult<E>> BindTry<E>(this ValueTask<UnitResult<E>> resultValueTask, Func<UnitResult<E>> func,
-            Func<Exception, E> errorHandler)
+            Func<Exception, E> errorHandler, bool _ = default)
         {
             var result = await resultValueTask;
             return result.BindTry(func, errorHandler);
@@ -88,7 +88,7 @@ namespace CSharpFunctionalExtensions
         ///     If a given function throws an exception, an error is returned from the given error handler
         /// </summary>
         public static async ValueTask<Result<T, E>> BindTry<T, E>(this ValueTask<UnitResult<E>> resultValueTask, Func<Result<T, E>> func,
-            Func<Exception, E> errorHandler)
+            Func<Exception, E> errorHandler, bool _ = default)
         {
             var result = await resultValueTask;
             return result.BindTry(func, errorHandler);

--- a/CSharpFunctionalExtensions/Result/Methods/Extensions/BindTry.ValueTask.Right.cs
+++ b/CSharpFunctionalExtensions/Result/Methods/Extensions/BindTry.ValueTask.Right.cs
@@ -2,24 +2,23 @@
 using System.Threading.Tasks;
 using System;
 
-namespace CSharpFunctionalExtensions
+namespace CSharpFunctionalExtensions.ValueTasks
 {
     public static partial class AsyncResultExtensionsRightOperand
     {
         /// <summary>
         ///     Selects result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.
-        ///     If a given function throws an exception, an error is returned from the given (or default) error handler
+        ///     If a given function throws an exception, an error is returned from the given error handler
         /// </summary>
         /// <typeparam name="T">Result Type parameter</typeparam>
         /// <typeparam name="K"><paramref name="func" /> Result Type parameter</typeparam>
         /// <typeparam name="E">Error Type parameter</typeparam>
         /// <param name="result">Extended result</param>
-        /// <param name="func">Function returning result to to bind</param>
+        /// <param name="func">Function returning result to bind</param>
         /// <param name="errorHandler">Error handling function</param>
-        /// <param name="_">Set this parameter if you want to use ValueTask extension for async lambda</param>
         /// <returns>Binding result</returns>
         public static async ValueTask<Result<K, E>> BindTry<T, K, E>(this Result<T, E> result, Func<T, ValueTask<Result<K, E>>> func,
-            Func<Exception, E> errorHandler, bool _ = default)
+            Func<Exception, E> errorHandler)
         {
             return result.IsFailure
                 ? Result.Failure<K, E>(result.Error)
@@ -28,17 +27,16 @@ namespace CSharpFunctionalExtensions
 
         /// <summary>
         ///     Selects result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.
-        ///     If a given function throws an exception, an error is returned from the given (or default) error handler
+        ///     If a given function throws an exception, an error is returned from the given error handler
         /// </summary>
         /// <typeparam name="T">Result Type parameter</typeparam>
         /// <typeparam name="K"><paramref name="func" /> Result Type parameter</typeparam>        
         /// <param name="result">Extended result</param>
-        /// <param name="func">Function returning result to to bind</param>
+        /// <param name="func">Function returning result to bind</param>
         /// <param name="errorHandler">Error handling function</param>
-        /// <param name="_">Set this parameter if you want to use ValueTask extension for async lambda</param>
         /// <returns>Binding result</returns>
         public static async ValueTask<Result<K>> BindTry<T, K>(this Result<T> result, Func<T, ValueTask<Result<K>>> func,
-            Func<Exception, string> errorHandler = null, bool _ = default)
+            Func<Exception, string> errorHandler = null)
         {
             return result.IsFailure
                 ? Result.Failure<K>(result.Error)
@@ -47,16 +45,15 @@ namespace CSharpFunctionalExtensions
 
         /// <summary>
         ///     Selects result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.
-        ///     If a given function throws an exception, an error is returned from the given (or default) error handler
+        ///     If a given function throws an exception, an error is returned from the given error handler
         /// </summary>        
         /// <typeparam name="K"><paramref name="func" /> Result Type parameter</typeparam>        
         /// <param name="result">Extended result</param>
-        /// <param name="func">Function returning result to to bind</param>
+        /// <param name="func">Function returning result to bind</param>
         /// <param name="errorHandler">Error handling function</param>
-        /// <param name="_">Set this parameter if you want to use ValueTask extension for async lambda</param>
         /// <returns>Binding result</returns>
         public static async ValueTask<Result<K>> BindTry<K>(this Result result, Func<ValueTask<Result<K>>> func,
-            Func<Exception, string> errorHandler = null, bool _ = default)
+            Func<Exception, string> errorHandler = null)
         {
             return result.IsFailure
                 ? Result.Failure<K>(result.Error)
@@ -65,16 +62,15 @@ namespace CSharpFunctionalExtensions
 
         /// <summary>
         ///     Selects result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.
-        ///     If a given function throws an exception, an error is returned from the given (or default) error handler
+        ///     If a given function throws an exception, an error is returned from the given error handler
         /// </summary>
         /// <typeparam name="T">Result Type parameter</typeparam>        
         /// <param name="result">Extended result</param>
-        /// <param name="func">Function returning result to to bind</param>
+        /// <param name="func">Function returning result to bind</param>
         /// <param name="errorHandler">Error handling function</param>
-        /// <param name="_">Set this parameter if you want to use ValueTask extension for async lambda</param>
         /// <returns>Binding result</returns>
         public static async ValueTask<Result> BindTry<T>(this Result<T> result, Func<T, ValueTask<Result>> func,
-            Func<Exception, string> errorHandler = null, bool _ = default)
+            Func<Exception, string> errorHandler = null)
         {
             return result.IsFailure
                 ? Result.Failure(result.Error)
@@ -83,15 +79,14 @@ namespace CSharpFunctionalExtensions
 
         /// <summary>
         ///     Selects result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.
-        ///     If a given function throws an exception, an error is returned from the given (or default) error handler
+        ///     If a given function throws an exception, an error is returned from the given error handler
         /// </summary>        
         /// <param name="result">Extended result</param>
-        /// <param name="func">Function returning result to to bind</param>
+        /// <param name="func">Function returning result to bind</param>
         /// <param name="errorHandler">Error handling function</param>
-        /// <param name="_">Set this parameter if you want to use ValueTask extension for async lambda</param>
         /// <returns>Binding result</returns>
         public static async ValueTask<Result> BindTry(this Result result, Func<ValueTask<Result>> func,
-            Func<Exception, string> errorHandler = null, bool _ = default)
+            Func<Exception, string> errorHandler = null)
         {
             return result.IsFailure
                 ? Result.Failure(result.Error)
@@ -100,16 +95,15 @@ namespace CSharpFunctionalExtensions
 
         /// <summary>
         ///     Selects result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.
-        ///     If a given function throws an exception, an error is returned from the given (or default) error handler
+        ///     If a given function throws an exception, an error is returned from the given error handler
         /// </summary>        
         /// <typeparam name="E">Error Type parameter</typeparam>
         /// <param name="result">Extended result</param>
-        /// <param name="func">Function returning result to to bind</param>
+        /// <param name="func">Function returning result to bind</param>
         /// <param name="errorHandler">Error handling function</param>
-        /// <param name="_">Set this parameter if you want to use ValueTask extension for async lambda</param>
         /// <returns>Binding result</returns>
         public static async ValueTask<UnitResult<E>> BindTry<E>(this UnitResult<E> result, Func<ValueTask<UnitResult<E>>> func,
-            Func<Exception, E> errorHandler, bool _ = default)
+            Func<Exception, E> errorHandler)
         {            
             return result.IsFailure
                 ? UnitResult.Failure(result.Error)
@@ -118,17 +112,16 @@ namespace CSharpFunctionalExtensions
 
         /// <summary>
         ///     Selects result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.
-        ///     If a given function throws an exception, an error is returned from the given (or default) error handler
+        ///     If a given function throws an exception, an error is returned from the given error handler
         /// </summary>
         /// <typeparam name="T">Result Type parameter</typeparam>        
         /// <typeparam name="E">Error Type parameter</typeparam>
         /// <param name="result">Extended result</param>
-        /// <param name="func">Function returning result to to bind</param>
+        /// <param name="func">Function returning result to bind</param>
         /// <param name="errorHandler">Error handling function</param>
-        /// <param name="_">Set this parameter if you want to use ValueTask extension for async lambda</param>
         /// <returns>Binding result</returns>
         public static async ValueTask<Result<T, E>> BindTry<T, E>(this UnitResult<E> result, Func<ValueTask<Result<T, E>>> func,
-            Func<Exception, E> errorHandler, bool _ = default)
+            Func<Exception, E> errorHandler)
         {
             return result.IsFailure
                 ? Result.Failure<T,E>(result.Error)
@@ -137,17 +130,16 @@ namespace CSharpFunctionalExtensions
 
         /// <summary>
         ///     Selects result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.
-        ///     If a given function throws an exception, an error is returned from the given (or default) error handler
+        ///     If a given function throws an exception, an error is returned from the given error handler
         /// </summary>
         /// <typeparam name="T">Result Type parameter</typeparam>        
         /// <typeparam name="E">Error Type parameter</typeparam>
         /// <param name="result">Extended result</param>
-        /// <param name="func">Function returning result to to bind</param>
+        /// <param name="func">Function returning result to bind</param>
         /// <param name="errorHandler">Error handling function</param>
-        /// <param name="_">Set this parameter if you want to use ValueTask extension for async lambda</param>
         /// <returns>Binding result</returns>
         public static async ValueTask<UnitResult<E>> BindTry<T, E>(this Result<T, E> result, Func<T, ValueTask<UnitResult<E>>> func,
-            Func<Exception, E> errorHandler, bool _ = default)
+            Func<Exception, E> errorHandler)
         {
             return result.IsFailure
                 ? UnitResult.Failure(result.Error)

--- a/CSharpFunctionalExtensions/Result/Methods/Extensions/BindTry.ValueTask.Right.cs
+++ b/CSharpFunctionalExtensions/Result/Methods/Extensions/BindTry.ValueTask.Right.cs
@@ -1,0 +1,106 @@
+﻿#if NET5_0_OR_GREATER
+using System.Threading.Tasks;
+using System;
+
+namespace CSharpFunctionalExtensions
+{
+    public static partial class AsyncResultExtensionsRightOperand
+    {
+        /// <summary>
+        ///     Selects result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.
+        ///     If a given function throws an exception, an error is returned from the given (or default) error handler
+        /// </summary>
+        public static async ValueTask<Result<K, E>> BindTry<T, K, E>(this Result<T, E> result, Func<T, ValueTask<Result<K, E>>> func,
+            Func<Exception, E> errorHandler)
+        {
+            return result.IsFailure
+                ? Result.Failure<K, E>(result.Error)
+                : await Result.Try(() => func(result.Value),errorHandler).Bind(r => r);
+        }
+
+        /// <summary>
+        ///     Selects result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.
+        ///     If a given function throws an exception, an error is returned from the given (or default) error handler
+        /// </summary>
+        public static async ValueTask<Result<K>> BindTry<T, K>(this Result<T> result, Func<T, ValueTask<Result<K>>> func,
+            Func<Exception, string> errorHandler = null)
+        {
+            return result.IsFailure
+                ? Result.Failure<K>(result.Error)
+                : await Result.Try(() => func(result.Value), errorHandler).Bind(r => r);
+        }
+
+        /// <summary>
+        ///     Selects result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.
+        ///     If a given function throws an exception, an error is returned from the given (or default) error handler
+        /// </summary>
+        public static async ValueTask<Result<K>> BindTry<K>(this Result result, Func<ValueTask<Result<K>>> func,
+            Func<Exception, string> errorHandler = null)
+        {
+            return result.IsFailure
+                ? Result.Failure<K>(result.Error)
+                : await Result.Try(() => func(), errorHandler).Bind(r => r);
+        }
+
+        /// <summary>
+        ///     Selects result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.
+        ///     If a given function throws an exception, an error is returned from the given (or default) error handler
+        /// </summary>
+        public static async ValueTask<Result> BindTry<T>(this Result<T> result, Func<T, ValueTask<Result>> func,
+            Func<Exception, string> errorHandler = null)
+        {
+            return result.IsFailure
+                ? Result.Failure(result.Error)
+                : await Result.Try(() => func(result.Value), errorHandler).Bind(r => r);
+        }
+
+        /// <summary>
+        ///     Selects result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.
+        ///     If a given function throws an exception, an error is returned from the given (or default) error handler
+        /// </summary>
+        public static async ValueTask<Result> BindTry(this Result result, Func<ValueTask<Result>> func,
+            Func<Exception, string> errorHandler = null)
+        {
+            return result.IsFailure
+                ? Result.Failure(result.Error)
+                : await Result.Try(() => func(), errorHandler).Bind(r => r);
+        }
+
+        /// <summary>
+        ///     Selects result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.
+        ///     If a given function throws an exception, an error is returned from the given (or default) error handler
+        /// </summary>
+        public static async ValueTask<UnitResult<E>> BindTry<E>(this UnitResult<E> result, Func<ValueTask<UnitResult<E>>> func,
+            Func<Exception, E> errorHandler)
+        {            
+            return result.IsFailure
+                ? UnitResult.Failure(result.Error)
+                : await Result.Try(() => func(), errorHandler).Bind(r => r);
+        }
+
+        /// <summary>
+        ///     Selects result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.
+        ///     If a given function throws an exception, an error is returned from the given (or default) error handler
+        /// </summary>
+        public static async ValueTask<Result<T, E>> BindTry<T, E>(this UnitResult<E> result, Func<ValueTask<Result<T, E>>> func,
+            Func<Exception, E> errorHandler)
+        {
+            return result.IsFailure
+                ? Result.Failure<T,E>(result.Error)
+                : await Result.Try(() => func(), errorHandler).Bind(r => r);
+        }
+
+        /// <summary>
+        ///     Selects result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.
+        ///     If a given function throws an exception, an error is returned from the given (or default) error handler
+        /// </summary>
+        public static async ValueTask<UnitResult<E>> BindTry<T, E>(this Result<T, E> result, Func<T, ValueTask<UnitResult<E>>> func,
+            Func<Exception, E> errorHandler)
+        {
+            return result.IsFailure
+                ? UnitResult.Failure(result.Error)
+                : await Result.Try(() => func(result.Value), errorHandler).Bind(r => r);           
+        }
+    }
+}
+#endif

--- a/CSharpFunctionalExtensions/Result/Methods/Extensions/BindTry.ValueTask.Right.cs
+++ b/CSharpFunctionalExtensions/Result/Methods/Extensions/BindTry.ValueTask.Right.cs
@@ -10,6 +10,14 @@ namespace CSharpFunctionalExtensions
         ///     Selects result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.
         ///     If a given function throws an exception, an error is returned from the given (or default) error handler
         /// </summary>
+        /// <typeparam name="T">Result Type parameter</typeparam>
+        /// <typeparam name="K"><paramref name="func" /> Result Type parameter</typeparam>
+        /// <typeparam name="E">Error Type parameter</typeparam>
+        /// <param name="result">Extended result</param>
+        /// <param name="func">Function returning result to to bind</param>
+        /// <param name="errorHandler">Error handling function</param>
+        /// <param name="_">Set this parameter if you want to use ValueTask extension for async lambda</param>
+        /// <returns>Binding result</returns>
         public static async ValueTask<Result<K, E>> BindTry<T, K, E>(this Result<T, E> result, Func<T, ValueTask<Result<K, E>>> func,
             Func<Exception, E> errorHandler, bool _ = default)
         {
@@ -22,6 +30,13 @@ namespace CSharpFunctionalExtensions
         ///     Selects result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.
         ///     If a given function throws an exception, an error is returned from the given (or default) error handler
         /// </summary>
+        /// <typeparam name="T">Result Type parameter</typeparam>
+        /// <typeparam name="K"><paramref name="func" /> Result Type parameter</typeparam>        
+        /// <param name="result">Extended result</param>
+        /// <param name="func">Function returning result to to bind</param>
+        /// <param name="errorHandler">Error handling function</param>
+        /// <param name="_">Set this parameter if you want to use ValueTask extension for async lambda</param>
+        /// <returns>Binding result</returns>
         public static async ValueTask<Result<K>> BindTry<T, K>(this Result<T> result, Func<T, ValueTask<Result<K>>> func,
             Func<Exception, string> errorHandler = null, bool _ = default)
         {
@@ -33,7 +48,13 @@ namespace CSharpFunctionalExtensions
         /// <summary>
         ///     Selects result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.
         ///     If a given function throws an exception, an error is returned from the given (or default) error handler
-        /// </summary>
+        /// </summary>        
+        /// <typeparam name="K"><paramref name="func" /> Result Type parameter</typeparam>        
+        /// <param name="result">Extended result</param>
+        /// <param name="func">Function returning result to to bind</param>
+        /// <param name="errorHandler">Error handling function</param>
+        /// <param name="_">Set this parameter if you want to use ValueTask extension for async lambda</param>
+        /// <returns>Binding result</returns>
         public static async ValueTask<Result<K>> BindTry<K>(this Result result, Func<ValueTask<Result<K>>> func,
             Func<Exception, string> errorHandler = null, bool _ = default)
         {
@@ -46,6 +67,12 @@ namespace CSharpFunctionalExtensions
         ///     Selects result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.
         ///     If a given function throws an exception, an error is returned from the given (or default) error handler
         /// </summary>
+        /// <typeparam name="T">Result Type parameter</typeparam>        
+        /// <param name="result">Extended result</param>
+        /// <param name="func">Function returning result to to bind</param>
+        /// <param name="errorHandler">Error handling function</param>
+        /// <param name="_">Set this parameter if you want to use ValueTask extension for async lambda</param>
+        /// <returns>Binding result</returns>
         public static async ValueTask<Result> BindTry<T>(this Result<T> result, Func<T, ValueTask<Result>> func,
             Func<Exception, string> errorHandler = null, bool _ = default)
         {
@@ -57,7 +84,12 @@ namespace CSharpFunctionalExtensions
         /// <summary>
         ///     Selects result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.
         ///     If a given function throws an exception, an error is returned from the given (or default) error handler
-        /// </summary>
+        /// </summary>        
+        /// <param name="result">Extended result</param>
+        /// <param name="func">Function returning result to to bind</param>
+        /// <param name="errorHandler">Error handling function</param>
+        /// <param name="_">Set this parameter if you want to use ValueTask extension for async lambda</param>
+        /// <returns>Binding result</returns>
         public static async ValueTask<Result> BindTry(this Result result, Func<ValueTask<Result>> func,
             Func<Exception, string> errorHandler = null, bool _ = default)
         {
@@ -69,7 +101,13 @@ namespace CSharpFunctionalExtensions
         /// <summary>
         ///     Selects result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.
         ///     If a given function throws an exception, an error is returned from the given (or default) error handler
-        /// </summary>
+        /// </summary>        
+        /// <typeparam name="E">Error Type parameter</typeparam>
+        /// <param name="result">Extended result</param>
+        /// <param name="func">Function returning result to to bind</param>
+        /// <param name="errorHandler">Error handling function</param>
+        /// <param name="_">Set this parameter if you want to use ValueTask extension for async lambda</param>
+        /// <returns>Binding result</returns>
         public static async ValueTask<UnitResult<E>> BindTry<E>(this UnitResult<E> result, Func<ValueTask<UnitResult<E>>> func,
             Func<Exception, E> errorHandler, bool _ = default)
         {            
@@ -82,6 +120,13 @@ namespace CSharpFunctionalExtensions
         ///     Selects result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.
         ///     If a given function throws an exception, an error is returned from the given (or default) error handler
         /// </summary>
+        /// <typeparam name="T">Result Type parameter</typeparam>        
+        /// <typeparam name="E">Error Type parameter</typeparam>
+        /// <param name="result">Extended result</param>
+        /// <param name="func">Function returning result to to bind</param>
+        /// <param name="errorHandler">Error handling function</param>
+        /// <param name="_">Set this parameter if you want to use ValueTask extension for async lambda</param>
+        /// <returns>Binding result</returns>
         public static async ValueTask<Result<T, E>> BindTry<T, E>(this UnitResult<E> result, Func<ValueTask<Result<T, E>>> func,
             Func<Exception, E> errorHandler, bool _ = default)
         {
@@ -94,6 +139,13 @@ namespace CSharpFunctionalExtensions
         ///     Selects result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.
         ///     If a given function throws an exception, an error is returned from the given (or default) error handler
         /// </summary>
+        /// <typeparam name="T">Result Type parameter</typeparam>        
+        /// <typeparam name="E">Error Type parameter</typeparam>
+        /// <param name="result">Extended result</param>
+        /// <param name="func">Function returning result to to bind</param>
+        /// <param name="errorHandler">Error handling function</param>
+        /// <param name="_">Set this parameter if you want to use ValueTask extension for async lambda</param>
+        /// <returns>Binding result</returns>
         public static async ValueTask<UnitResult<E>> BindTry<T, E>(this Result<T, E> result, Func<T, ValueTask<UnitResult<E>>> func,
             Func<Exception, E> errorHandler, bool _ = default)
         {

--- a/CSharpFunctionalExtensions/Result/Methods/Extensions/BindTry.ValueTask.Right.cs
+++ b/CSharpFunctionalExtensions/Result/Methods/Extensions/BindTry.ValueTask.Right.cs
@@ -11,7 +11,7 @@ namespace CSharpFunctionalExtensions
         ///     If a given function throws an exception, an error is returned from the given (or default) error handler
         /// </summary>
         public static async ValueTask<Result<K, E>> BindTry<T, K, E>(this Result<T, E> result, Func<T, ValueTask<Result<K, E>>> func,
-            Func<Exception, E> errorHandler)
+            Func<Exception, E> errorHandler, bool _ = default)
         {
             return result.IsFailure
                 ? Result.Failure<K, E>(result.Error)
@@ -23,7 +23,7 @@ namespace CSharpFunctionalExtensions
         ///     If a given function throws an exception, an error is returned from the given (or default) error handler
         /// </summary>
         public static async ValueTask<Result<K>> BindTry<T, K>(this Result<T> result, Func<T, ValueTask<Result<K>>> func,
-            Func<Exception, string> errorHandler = null)
+            Func<Exception, string> errorHandler = null, bool _ = default)
         {
             return result.IsFailure
                 ? Result.Failure<K>(result.Error)
@@ -35,7 +35,7 @@ namespace CSharpFunctionalExtensions
         ///     If a given function throws an exception, an error is returned from the given (or default) error handler
         /// </summary>
         public static async ValueTask<Result<K>> BindTry<K>(this Result result, Func<ValueTask<Result<K>>> func,
-            Func<Exception, string> errorHandler = null)
+            Func<Exception, string> errorHandler = null, bool _ = default)
         {
             return result.IsFailure
                 ? Result.Failure<K>(result.Error)
@@ -47,7 +47,7 @@ namespace CSharpFunctionalExtensions
         ///     If a given function throws an exception, an error is returned from the given (or default) error handler
         /// </summary>
         public static async ValueTask<Result> BindTry<T>(this Result<T> result, Func<T, ValueTask<Result>> func,
-            Func<Exception, string> errorHandler = null)
+            Func<Exception, string> errorHandler = null, bool _ = default)
         {
             return result.IsFailure
                 ? Result.Failure(result.Error)
@@ -59,7 +59,7 @@ namespace CSharpFunctionalExtensions
         ///     If a given function throws an exception, an error is returned from the given (or default) error handler
         /// </summary>
         public static async ValueTask<Result> BindTry(this Result result, Func<ValueTask<Result>> func,
-            Func<Exception, string> errorHandler = null)
+            Func<Exception, string> errorHandler = null, bool _ = default)
         {
             return result.IsFailure
                 ? Result.Failure(result.Error)
@@ -71,7 +71,7 @@ namespace CSharpFunctionalExtensions
         ///     If a given function throws an exception, an error is returned from the given (or default) error handler
         /// </summary>
         public static async ValueTask<UnitResult<E>> BindTry<E>(this UnitResult<E> result, Func<ValueTask<UnitResult<E>>> func,
-            Func<Exception, E> errorHandler)
+            Func<Exception, E> errorHandler, bool _ = default)
         {            
             return result.IsFailure
                 ? UnitResult.Failure(result.Error)
@@ -83,7 +83,7 @@ namespace CSharpFunctionalExtensions
         ///     If a given function throws an exception, an error is returned from the given (or default) error handler
         /// </summary>
         public static async ValueTask<Result<T, E>> BindTry<T, E>(this UnitResult<E> result, Func<ValueTask<Result<T, E>>> func,
-            Func<Exception, E> errorHandler)
+            Func<Exception, E> errorHandler, bool _ = default)
         {
             return result.IsFailure
                 ? Result.Failure<T,E>(result.Error)
@@ -95,7 +95,7 @@ namespace CSharpFunctionalExtensions
         ///     If a given function throws an exception, an error is returned from the given (or default) error handler
         /// </summary>
         public static async ValueTask<UnitResult<E>> BindTry<T, E>(this Result<T, E> result, Func<T, ValueTask<UnitResult<E>>> func,
-            Func<Exception, E> errorHandler)
+            Func<Exception, E> errorHandler, bool _ = default)
         {
             return result.IsFailure
                 ? UnitResult.Failure(result.Error)

--- a/CSharpFunctionalExtensions/Result/Methods/Extensions/BindTry.ValueTask.cs
+++ b/CSharpFunctionalExtensions/Result/Methods/Extensions/BindTry.ValueTask.cs
@@ -11,8 +11,8 @@ namespace CSharpFunctionalExtensions
 		///     If a given function throws an exception, an error is returned from the given (or default) error handler
 		/// </summary>
 		public static async ValueTask<Result> BindTry(this ValueTask<Result> resultTask, Func<ValueTask<Result>> func,
-			Func<Exception, string> errorHandler = null)
-		{
+			Func<Exception, string> errorHandler = null, bool _ = default)
+		{            
 			var result = await resultTask;
 			return await result.BindTry(func, errorHandler);
 		}
@@ -22,7 +22,7 @@ namespace CSharpFunctionalExtensions
         ///     If a given function throws an exception, an error is returned from the given (or default) error handler
         /// </summary>
         public static async ValueTask<Result<K>> BindTry<K>(this ValueTask<Result> resultTask, Func<ValueTask<Result<K>>> func,
-            Func<Exception, string> errorHandler = null)
+            Func<Exception, string> errorHandler = null, bool _ = default)
         {
             var result = await resultTask;
             return await result.BindTry(func, errorHandler);
@@ -33,7 +33,7 @@ namespace CSharpFunctionalExtensions
         ///     If a given function throws an exception, an error is returned from the given (or default) error handler
         /// </summary>
         public static async ValueTask<Result> BindTry<T>(this ValueTask<Result<T>> resultTask, Func<T, ValueTask<Result>> func,
-			Func<Exception, string> errorHandler = null)
+			Func<Exception, string> errorHandler = null, bool _ = default)
 		{
 			var result = await resultTask;
 			return await result.BindTry(func, errorHandler);
@@ -44,7 +44,7 @@ namespace CSharpFunctionalExtensions
         ///     If a given function throws an exception, an error is returned from the given (or default) error handler
         /// </summary>
         public static async ValueTask<Result<K>> BindTry<T, K>(this ValueTask<Result<T>> resultTask, Func<T, ValueTask<Result<K>>> func,
-            Func<Exception, string> errorHandler = null)
+            Func<Exception, string> errorHandler = null, bool _ = default)
         {
             var result = await resultTask;
             return await result.BindTry(func, errorHandler);
@@ -55,7 +55,7 @@ namespace CSharpFunctionalExtensions
         ///     If a given function throws an exception, an error is returned from the given error handler
         /// </summary>
         public static async ValueTask<UnitResult<E>> BindTry<T, E>(this ValueTask<Result<T, E>> resultTask, Func<T, ValueTask<UnitResult<E>>> func,
-            Func<Exception, E> errorHandler)
+            Func<Exception, E> errorHandler, bool _ = default)
         {
             var result = await resultTask;
             return await result.BindTry(func, errorHandler);
@@ -66,7 +66,7 @@ namespace CSharpFunctionalExtensions
         ///     If a given function throws an exception, an error is returned from the given error handler
         /// </summary>
         public static async ValueTask<Result<K, E>> BindTry<T, K, E>(this ValueTask<Result<T, E>> resultTask, Func<T, ValueTask<Result<K, E>>> func,
-			Func<Exception, E> errorHandler)
+			Func<Exception, E> errorHandler, bool _ = default)
 		{
 			var result = await resultTask;
 			return await result.BindTry(func, errorHandler);
@@ -77,18 +77,25 @@ namespace CSharpFunctionalExtensions
 		///     If a given function throws an exception, an error is returned from the given error handler
 		/// </summary>
 		public static async ValueTask<Result<T, E>> BindTry<T, E>(this ValueTask<UnitResult<E>> resultTask, Func<ValueTask<Result<T, E>>> func,
-            Func<Exception, E> errorHandler)
+            Func<Exception, E> errorHandler, bool _ = default)
         {
             var result = await resultTask;
             return await result.BindTry(func, errorHandler);
         }
 
+
         /// <summary>
         ///     Selects result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.
-        ///     If a given function throws an exception, an error is returned from the given error handler
-        /// </summary>
+        ///     If a given function throws an exception, an error is returned from the given error handler        ///             ///     
+        /// </summary>        
+        /// <typeparam name="E">Error Type parameter</typeparam>
+        /// <param name="resultTask">Task returnnign {ref } UnitResult</param>
+        /// <param name="func"></param>
+        /// <param name="errorHandler"></param>
+        /// <param name="_">Set this parameter if you prefer using this overload for async lambda</param>
+        /// <returns></returns>
         public static async ValueTask<UnitResult<E>> BindTry<E>(this ValueTask<UnitResult<E>> resultTask, Func<ValueTask<UnitResult<E>>> func,
-			Func<Exception, E> errorHandler)
+			Func<Exception, E> errorHandler, bool _ = default)
 		{
 			var result = await resultTask;
 			return await result.BindTry(func, errorHandler);

--- a/CSharpFunctionalExtensions/Result/Methods/Extensions/BindTry.ValueTask.cs
+++ b/CSharpFunctionalExtensions/Result/Methods/Extensions/BindTry.ValueTask.cs
@@ -6,11 +6,16 @@ namespace CSharpFunctionalExtensions
 {
 	public static partial class AsyncResultExtensionsBothOperands
 	{
-		/// <summary>
-		///     Selects result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.
-		///     If a given function throws an exception, an error is returned from the given (or default) error handler
-		/// </summary>
-		public static async ValueTask<Result> BindTry(this ValueTask<Result> resultTask, Func<ValueTask<Result>> func,
+        /// <summary>
+        ///     Selects result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.
+        ///     If a given function throws an exception, an error is returned from the given (or default) error handler
+        /// </summary>        
+        /// <param name="resultTask">Extended result</param>
+        /// <param name="func">Function returning result to to bind</param>
+        /// <param name="errorHandler">Error handling function</param>
+        /// <param name="_">Set this parameter if you want to use ValueTask extension for async lambda</param>
+        /// <returns>Binding result</returns>
+        public static async ValueTask<Result> BindTry(this ValueTask<Result> resultTask, Func<ValueTask<Result>> func,
 			Func<Exception, string> errorHandler = null, bool _ = default)
 		{            
 			var result = await resultTask;
@@ -20,7 +25,13 @@ namespace CSharpFunctionalExtensions
         /// <summary>
         ///     Selects result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.
         ///     If a given function throws an exception, an error is returned from the given (or default) error handler
-        /// </summary>
+        /// </summary>        
+        /// <typeparam name="K"><paramref name="func" /> Result Type parameter</typeparam>        
+        /// <param name="resultTask">Extended result</param>
+        /// <param name="func">Function returning result to to bind</param>
+        /// <param name="errorHandler">Error handling function</param>
+        /// <param name="_">Set this parameter if you want to use ValueTask extension for async lambda</param>
+        /// <returns>Binding result</returns>
         public static async ValueTask<Result<K>> BindTry<K>(this ValueTask<Result> resultTask, Func<ValueTask<Result<K>>> func,
             Func<Exception, string> errorHandler = null, bool _ = default)
         {
@@ -32,6 +43,12 @@ namespace CSharpFunctionalExtensions
         ///     Selects result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.
         ///     If a given function throws an exception, an error is returned from the given (or default) error handler
         /// </summary>
+        /// <typeparam name="T">Result Type parameter</typeparam>        
+        /// <param name="resultTask">Extended result</param>
+        /// <param name="func">Function returning result to to bind</param>
+        /// <param name="errorHandler">Error handling function</param>
+        /// <param name="_">Set this parameter if you want to use ValueTask extension for async lambda</param>
+        /// <returns>Binding result</returns>
         public static async ValueTask<Result> BindTry<T>(this ValueTask<Result<T>> resultTask, Func<T, ValueTask<Result>> func,
 			Func<Exception, string> errorHandler = null, bool _ = default)
 		{
@@ -42,7 +59,14 @@ namespace CSharpFunctionalExtensions
         /// <summary>
         ///     Selects result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.
         ///     If a given function throws an exception, an error is returned from the given (or default) error handler
-        /// </summary>
+        /// </summary>    
+        /// <typeparam name="T">Result Type parameter</typeparam>
+        /// <typeparam name="K"><paramref name="func" /> Result Type parameter</typeparam>        
+        /// <param name="resultTask">Extended result</param>
+        /// <param name="func">Function returning result to to bind</param>
+        /// <param name="errorHandler">Error handling function</param>
+        /// <param name="_">Set this parameter if you want to use ValueTask extension for async lambda</param>
+        /// <returns>Binding result</returns>
         public static async ValueTask<Result<K>> BindTry<T, K>(this ValueTask<Result<T>> resultTask, Func<T, ValueTask<Result<K>>> func,
             Func<Exception, string> errorHandler = null, bool _ = default)
         {
@@ -54,6 +78,13 @@ namespace CSharpFunctionalExtensions
         ///     Selects result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.
         ///     If a given function throws an exception, an error is returned from the given error handler
         /// </summary>
+        /// <typeparam name="T">Result Type parameter</typeparam>
+        /// <typeparam name="E">Error Type parameter</typeparam>
+        /// <param name="resultTask">Extended result</param>
+        /// <param name="func">Function returning result to to bind</param>
+        /// <param name="errorHandler">Error handling function</param>
+        /// <param name="_">Set this parameter if you want to use ValueTask extension for async lambda</param>
+        /// <returns>Binding result</returns>
         public static async ValueTask<UnitResult<E>> BindTry<T, E>(this ValueTask<Result<T, E>> resultTask, Func<T, ValueTask<UnitResult<E>>> func,
             Func<Exception, E> errorHandler, bool _ = default)
         {
@@ -65,6 +96,14 @@ namespace CSharpFunctionalExtensions
         ///     Selects result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.
         ///     If a given function throws an exception, an error is returned from the given error handler
         /// </summary>
+        /// <typeparam name="T">Result Type parameter</typeparam>
+        /// <typeparam name="K"><paramref name="func" /> Result Type parameter</typeparam>
+        /// <typeparam name="E">Error Type parameter</typeparam>
+        /// <param name="resultTask">Extended result</param>
+        /// <param name="func">Function returning result to to bind</param>
+        /// <param name="errorHandler">Error handling function</param>
+        /// <param name="_">Set this parameter if you want to use ValueTask extension for async lambda</param>
+        /// <returns>Binding result</returns>
         public static async ValueTask<Result<K, E>> BindTry<T, K, E>(this ValueTask<Result<T, E>> resultTask, Func<T, ValueTask<Result<K, E>>> func,
 			Func<Exception, E> errorHandler, bool _ = default)
 		{
@@ -76,6 +115,13 @@ namespace CSharpFunctionalExtensions
 		///     Selects result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.
 		///     If a given function throws an exception, an error is returned from the given error handler
 		/// </summary>
+        /// <typeparam name="T">Result Type parameter</typeparam>
+        /// <typeparam name="E">Error Type parameter</typeparam>
+        /// <param name="resultTask">Extended result</param>
+        /// <param name="func">Function returning result to to bind</param>
+        /// <param name="errorHandler">Error handling function</param>
+        /// <param name="_">Set this parameter if you want to use ValueTask extension for async lambda</param>
+        /// <returns>Binding result</returns>
 		public static async ValueTask<Result<T, E>> BindTry<T, E>(this ValueTask<UnitResult<E>> resultTask, Func<ValueTask<Result<T, E>>> func,
             Func<Exception, E> errorHandler, bool _ = default)
         {
@@ -89,11 +135,11 @@ namespace CSharpFunctionalExtensions
         ///     If a given function throws an exception, an error is returned from the given error handler        ///             ///     
         /// </summary>        
         /// <typeparam name="E">Error Type parameter</typeparam>
-        /// <param name="resultTask">Task returnnign {ref } UnitResult</param>
-        /// <param name="func"></param>
-        /// <param name="errorHandler"></param>
-        /// <param name="_">Set this parameter if you prefer using this overload for async lambda</param>
-        /// <returns></returns>
+        /// <param name="resultTask">Extended result</param>
+        /// <param name="func">Function returning result to to bind</param>
+        /// <param name="errorHandler">Error handling function</param>
+        /// <param name="_">Set this parameter if you want to use ValueTask extension for async lambda</param>
+        /// <returns>Binding result</returns>
         public static async ValueTask<UnitResult<E>> BindTry<E>(this ValueTask<UnitResult<E>> resultTask, Func<ValueTask<UnitResult<E>>> func,
 			Func<Exception, E> errorHandler, bool _ = default)
 		{

--- a/CSharpFunctionalExtensions/Result/Methods/Extensions/BindTry.ValueTask.cs
+++ b/CSharpFunctionalExtensions/Result/Methods/Extensions/BindTry.ValueTask.cs
@@ -2,21 +2,20 @@
 using System.Threading.Tasks;
 using System;
 
-namespace CSharpFunctionalExtensions
+namespace CSharpFunctionalExtensions.ValueTasks
 {
 	public static partial class AsyncResultExtensionsBothOperands
 	{
         /// <summary>
         ///     Selects result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.
-        ///     If a given function throws an exception, an error is returned from the given (or default) error handler
+        ///     If a given function throws an exception, an error is returned from the given error handler
         /// </summary>        
         /// <param name="resultTask">Extended result</param>
-        /// <param name="func">Function returning result to to bind</param>
+        /// <param name="func">Function returning result to bind</param>
         /// <param name="errorHandler">Error handling function</param>
-        /// <param name="_">Set this parameter if you want to use ValueTask extension for async lambda</param>
         /// <returns>Binding result</returns>
         public static async ValueTask<Result> BindTry(this ValueTask<Result> resultTask, Func<ValueTask<Result>> func,
-			Func<Exception, string> errorHandler = null, bool _ = default)
+			Func<Exception, string> errorHandler = null)
 		{            
 			var result = await resultTask;
 			return await result.BindTry(func, errorHandler);
@@ -24,16 +23,15 @@ namespace CSharpFunctionalExtensions
 
         /// <summary>
         ///     Selects result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.
-        ///     If a given function throws an exception, an error is returned from the given (or default) error handler
+        ///     If a given function throws an exception, an error is returned from the given error handler
         /// </summary>        
         /// <typeparam name="K"><paramref name="func" /> Result Type parameter</typeparam>        
         /// <param name="resultTask">Extended result</param>
-        /// <param name="func">Function returning result to to bind</param>
+        /// <param name="func">Function returning result to bind</param>
         /// <param name="errorHandler">Error handling function</param>
-        /// <param name="_">Set this parameter if you want to use ValueTask extension for async lambda</param>
         /// <returns>Binding result</returns>
         public static async ValueTask<Result<K>> BindTry<K>(this ValueTask<Result> resultTask, Func<ValueTask<Result<K>>> func,
-            Func<Exception, string> errorHandler = null, bool _ = default)
+            Func<Exception, string> errorHandler = null)
         {
             var result = await resultTask;
             return await result.BindTry(func, errorHandler);
@@ -41,16 +39,15 @@ namespace CSharpFunctionalExtensions
 
         /// <summary>
         ///     Selects result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.
-        ///     If a given function throws an exception, an error is returned from the given (or default) error handler
+        ///     If a given function throws an exception, an error is returned from the given error handler
         /// </summary>
         /// <typeparam name="T">Result Type parameter</typeparam>        
         /// <param name="resultTask">Extended result</param>
-        /// <param name="func">Function returning result to to bind</param>
+        /// <param name="func">Function returning result to bind</param>
         /// <param name="errorHandler">Error handling function</param>
-        /// <param name="_">Set this parameter if you want to use ValueTask extension for async lambda</param>
         /// <returns>Binding result</returns>
         public static async ValueTask<Result> BindTry<T>(this ValueTask<Result<T>> resultTask, Func<T, ValueTask<Result>> func,
-			Func<Exception, string> errorHandler = null, bool _ = default)
+			Func<Exception, string> errorHandler = null)
 		{
 			var result = await resultTask;
 			return await result.BindTry(func, errorHandler);
@@ -58,17 +55,16 @@ namespace CSharpFunctionalExtensions
 
         /// <summary>
         ///     Selects result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.
-        ///     If a given function throws an exception, an error is returned from the given (or default) error handler
+        ///     If a given function throws an exception, an error is returned from the given error handler
         /// </summary>    
         /// <typeparam name="T">Result Type parameter</typeparam>
         /// <typeparam name="K"><paramref name="func" /> Result Type parameter</typeparam>        
         /// <param name="resultTask">Extended result</param>
-        /// <param name="func">Function returning result to to bind</param>
+        /// <param name="func">Function returning result to bind</param>
         /// <param name="errorHandler">Error handling function</param>
-        /// <param name="_">Set this parameter if you want to use ValueTask extension for async lambda</param>
         /// <returns>Binding result</returns>
         public static async ValueTask<Result<K>> BindTry<T, K>(this ValueTask<Result<T>> resultTask, Func<T, ValueTask<Result<K>>> func,
-            Func<Exception, string> errorHandler = null, bool _ = default)
+            Func<Exception, string> errorHandler = null)
         {
             var result = await resultTask;
             return await result.BindTry(func, errorHandler);
@@ -81,12 +77,11 @@ namespace CSharpFunctionalExtensions
         /// <typeparam name="T">Result Type parameter</typeparam>
         /// <typeparam name="E">Error Type parameter</typeparam>
         /// <param name="resultTask">Extended result</param>
-        /// <param name="func">Function returning result to to bind</param>
+        /// <param name="func">Function returning result to bind</param>
         /// <param name="errorHandler">Error handling function</param>
-        /// <param name="_">Set this parameter if you want to use ValueTask extension for async lambda</param>
         /// <returns>Binding result</returns>
         public static async ValueTask<UnitResult<E>> BindTry<T, E>(this ValueTask<Result<T, E>> resultTask, Func<T, ValueTask<UnitResult<E>>> func,
-            Func<Exception, E> errorHandler, bool _ = default)
+            Func<Exception, E> errorHandler)
         {
             var result = await resultTask;
             return await result.BindTry(func, errorHandler);
@@ -100,12 +95,11 @@ namespace CSharpFunctionalExtensions
         /// <typeparam name="K"><paramref name="func" /> Result Type parameter</typeparam>
         /// <typeparam name="E">Error Type parameter</typeparam>
         /// <param name="resultTask">Extended result</param>
-        /// <param name="func">Function returning result to to bind</param>
+        /// <param name="func">Function returning result to bind</param>
         /// <param name="errorHandler">Error handling function</param>
-        /// <param name="_">Set this parameter if you want to use ValueTask extension for async lambda</param>
         /// <returns>Binding result</returns>
         public static async ValueTask<Result<K, E>> BindTry<T, K, E>(this ValueTask<Result<T, E>> resultTask, Func<T, ValueTask<Result<K, E>>> func,
-			Func<Exception, E> errorHandler, bool _ = default)
+			Func<Exception, E> errorHandler)
 		{
 			var result = await resultTask;
 			return await result.BindTry(func, errorHandler);
@@ -118,12 +112,11 @@ namespace CSharpFunctionalExtensions
         /// <typeparam name="T">Result Type parameter</typeparam>
         /// <typeparam name="E">Error Type parameter</typeparam>
         /// <param name="resultTask">Extended result</param>
-        /// <param name="func">Function returning result to to bind</param>
+        /// <param name="func">Function returning result to bind</param>
         /// <param name="errorHandler">Error handling function</param>
-        /// <param name="_">Set this parameter if you want to use ValueTask extension for async lambda</param>
         /// <returns>Binding result</returns>
 		public static async ValueTask<Result<T, E>> BindTry<T, E>(this ValueTask<UnitResult<E>> resultTask, Func<ValueTask<Result<T, E>>> func,
-            Func<Exception, E> errorHandler, bool _ = default)
+            Func<Exception, E> errorHandler)
         {
             var result = await resultTask;
             return await result.BindTry(func, errorHandler);
@@ -136,12 +129,11 @@ namespace CSharpFunctionalExtensions
         /// </summary>        
         /// <typeparam name="E">Error Type parameter</typeparam>
         /// <param name="resultTask">Extended result</param>
-        /// <param name="func">Function returning result to to bind</param>
+        /// <param name="func">Function returning result to bind</param>
         /// <param name="errorHandler">Error handling function</param>
-        /// <param name="_">Set this parameter if you want to use ValueTask extension for async lambda</param>
         /// <returns>Binding result</returns>
         public static async ValueTask<UnitResult<E>> BindTry<E>(this ValueTask<UnitResult<E>> resultTask, Func<ValueTask<UnitResult<E>>> func,
-			Func<Exception, E> errorHandler, bool _ = default)
+			Func<Exception, E> errorHandler)
 		{
 			var result = await resultTask;
 			return await result.BindTry(func, errorHandler);

--- a/CSharpFunctionalExtensions/Result/Methods/Extensions/BindTry.ValueTask.cs
+++ b/CSharpFunctionalExtensions/Result/Methods/Extensions/BindTry.ValueTask.cs
@@ -1,0 +1,98 @@
+﻿#if NET5_0_OR_GREATER
+using System.Threading.Tasks;
+using System;
+
+namespace CSharpFunctionalExtensions
+{
+	public static partial class AsyncResultExtensionsBothOperands
+	{
+		/// <summary>
+		///     Selects result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.
+		///     If a given function throws an exception, an error is returned from the given (or default) error handler
+		/// </summary>
+		public static async ValueTask<Result> BindTry(this ValueTask<Result> resultTask, Func<ValueTask<Result>> func,
+			Func<Exception, string> errorHandler = null)
+		{
+			var result = await resultTask;
+			return await result.BindTry(func, errorHandler);
+		}
+
+        /// <summary>
+        ///     Selects result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.
+        ///     If a given function throws an exception, an error is returned from the given (or default) error handler
+        /// </summary>
+        public static async ValueTask<Result<K>> BindTry<K>(this ValueTask<Result> resultTask, Func<ValueTask<Result<K>>> func,
+            Func<Exception, string> errorHandler = null)
+        {
+            var result = await resultTask;
+            return await result.BindTry(func, errorHandler);
+        }
+
+        /// <summary>
+        ///     Selects result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.
+        ///     If a given function throws an exception, an error is returned from the given (or default) error handler
+        /// </summary>
+        public static async ValueTask<Result> BindTry<T>(this ValueTask<Result<T>> resultTask, Func<T, ValueTask<Result>> func,
+			Func<Exception, string> errorHandler = null)
+		{
+			var result = await resultTask;
+			return await result.BindTry(func, errorHandler);
+		}
+
+        /// <summary>
+        ///     Selects result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.
+        ///     If a given function throws an exception, an error is returned from the given (or default) error handler
+        /// </summary>
+        public static async ValueTask<Result<K>> BindTry<T, K>(this ValueTask<Result<T>> resultTask, Func<T, ValueTask<Result<K>>> func,
+            Func<Exception, string> errorHandler = null)
+        {
+            var result = await resultTask;
+            return await result.BindTry(func, errorHandler);
+        }
+
+        /// <summary>
+        ///     Selects result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.
+        ///     If a given function throws an exception, an error is returned from the given error handler
+        /// </summary>
+        public static async ValueTask<UnitResult<E>> BindTry<T, E>(this ValueTask<Result<T, E>> resultTask, Func<T, ValueTask<UnitResult<E>>> func,
+            Func<Exception, E> errorHandler)
+        {
+            var result = await resultTask;
+            return await result.BindTry(func, errorHandler);
+        }
+
+        /// <summary>
+        ///     Selects result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.
+        ///     If a given function throws an exception, an error is returned from the given error handler
+        /// </summary>
+        public static async ValueTask<Result<K, E>> BindTry<T, K, E>(this ValueTask<Result<T, E>> resultTask, Func<T, ValueTask<Result<K, E>>> func,
+			Func<Exception, E> errorHandler)
+		{
+			var result = await resultTask;
+			return await result.BindTry(func, errorHandler);
+		}
+
+        /// <summary>
+		///     Selects result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.
+		///     If a given function throws an exception, an error is returned from the given error handler
+		/// </summary>
+		public static async ValueTask<Result<T, E>> BindTry<T, E>(this ValueTask<UnitResult<E>> resultTask, Func<ValueTask<Result<T, E>>> func,
+            Func<Exception, E> errorHandler)
+        {
+            var result = await resultTask;
+            return await result.BindTry(func, errorHandler);
+        }
+
+        /// <summary>
+        ///     Selects result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.
+        ///     If a given function throws an exception, an error is returned from the given error handler
+        /// </summary>
+        public static async ValueTask<UnitResult<E>> BindTry<E>(this ValueTask<UnitResult<E>> resultTask, Func<ValueTask<UnitResult<E>>> func,
+			Func<Exception, E> errorHandler)
+		{
+			var result = await resultTask;
+			return await result.BindTry(func, errorHandler);
+		}			
+	}
+}
+#endif

--- a/CSharpFunctionalExtensions/Result/Methods/Extensions/BindTry.cs
+++ b/CSharpFunctionalExtensions/Result/Methods/Extensions/BindTry.cs
@@ -1,0 +1,106 @@
+﻿using System;
+
+namespace CSharpFunctionalExtensions
+{
+    public static partial class ResultExtensions
+    {
+        
+        /// <summary>
+        ///     Selects result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.
+        ///     If a given function throws an exception, an error is returned from the given (or default) error handler
+        /// </summary>
+        public static Result BindTry(this Result result, Func<Result> func,
+            Func<Exception, string> errorHandler = null)
+        {
+            return result.IsFailure
+                ? result
+                : Result.Try(() => func(), errorHandler).Bind(r => r);
+        }
+
+        /// <summary>
+        ///     Selects result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.
+        ///     If a given function throws an exception, an error is returned from the given (or default) error handler
+        /// </summary>
+        public static Result<K> BindTry<K>(this Result result, Func<Result<K>> func,
+            Func<Exception, string> errorHandler = null)
+        {
+            return result.IsFailure
+                ? Result.Failure<K>(result.Error)
+                : Result.Try(() => func(), errorHandler).Bind(r => r);
+        }
+
+
+        /// <summary>
+        ///     Selects result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.
+        ///     If a given function throws an exception, an error is returned from the given (or default) error handler
+        /// </summary>
+        public static Result BindTry<T>(this Result<T> result, Func<T, Result> func,
+            Func<Exception, string> errorHandler = null)
+        {
+            return result.IsFailure
+                ? Result.Failure(result.Error)
+                : Result.Try(() => func(result.Value), errorHandler).Bind(r => r);
+        }
+
+        /// <summary>
+        ///     Selects result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.
+        ///     If a given function throws an exception, an error is returned from the given (or default) error handler
+        /// </summary>
+        public static Result<K> BindTry<T, K>(this Result<T> result, Func<T, Result<K>> func,
+            Func<Exception, string> errorHandler = null)
+        {
+            return result.IsFailure
+                ? Result.Failure<K>(result.Error)
+                : Result.Try(() => func(result.Value), errorHandler).Bind(r => r);
+        }
+
+        /// <summary>
+        ///    Selects result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.        
+        ///    If a given function throws an exception, an error is returned from the given (or default) error handler
+        /// </summary>
+        public static Result<K, E> BindTry<T, K, E>(this Result<T, E> result, Func<T, Result<K, E>> func,
+            Func<Exception, E> errorHandler)
+        {            
+            return result.IsFailure
+                ? Result.Failure<K,E>(result.Error)
+                : Result.Try(() => func(result.Value), errorHandler).Bind(r => r);           
+        }
+
+
+        /// <summary>
+        ///     Selects result from the return value of a given function. If the calling UnitResult is a failure, a new failure result is returned instead.
+        ///     If a given function throws an exception, an error is returned from the given (or default) error handler
+        /// </summary>
+        public static UnitResult<E> BindTry<E>(this UnitResult<E> result, Func<UnitResult<E>> func,
+            Func<Exception, E> errorHandler)
+        {
+            return result.IsFailure
+                ? result
+                : Result.Try(() => func(), errorHandler).Bind(r => r);
+        }
+
+        /// <summary>
+        ///     Selects result from the return value of a given function. If the calling UnitResult is a failure, a new failure result is returned instead.
+        ///     If a given function throws an exception, an error is returned from the given (or default) error handler
+        /// </summary>
+        public static Result<T, E> BindTry<T, E>(this UnitResult<E> result, Func<Result<T, E>> func,
+            Func<Exception, E> errorHandler)
+        {
+            return result.IsFailure
+                ? Result.Failure<T, E>(result.Error)
+                : Result.Try(() => func(), errorHandler).Bind(r => r);
+        }
+
+        /// <summary>
+        ///     Selects result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.
+        ///     If a given function throws an exception, an error is returned from the given (or default) error handler
+        /// </summary>
+        public static UnitResult<E> BindTry<T, E>(this Result<T, E> result, Func<T, UnitResult<E>> func,
+            Func<Exception, E> errorHandler)
+        {
+            return result.IsFailure
+                ? Result.Failure<T, E>(result.Error)
+                : Result.Try(() => func(result.Value), errorHandler).Bind(r => r);
+        }
+    }
+}

--- a/CSharpFunctionalExtensions/Result/Methods/Extensions/BindTry.cs
+++ b/CSharpFunctionalExtensions/Result/Methods/Extensions/BindTry.cs
@@ -4,11 +4,14 @@ namespace CSharpFunctionalExtensions
 {
     public static partial class ResultExtensions
     {
-        
         /// <summary>
         ///     Selects result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.
         ///     If a given function throws an exception, an error is returned from the given (or default) error handler
-        /// </summary>
+        /// </summary>        
+        /// <param name="result">Extended result</param>
+        /// <param name="func">Function returning result to to bind</param>
+        /// <param name="errorHandler">Error handling function</param>        
+        /// <returns>Binding result</returns>
         public static Result BindTry(this Result result, Func<Result> func,
             Func<Exception, string> errorHandler = null)
         {
@@ -20,7 +23,12 @@ namespace CSharpFunctionalExtensions
         /// <summary>
         ///     Selects result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.
         ///     If a given function throws an exception, an error is returned from the given (or default) error handler
-        /// </summary>
+        /// </summary>        
+        /// <typeparam name="K"><paramref name="func" /> Result Type parameter</typeparam>
+        /// <param name="result">Extended result</param>
+        /// <param name="func">Function returning result to to bind</param>
+        /// <param name="errorHandler">Error handling function</param>        
+        /// <returns>Binding result</returns>
         public static Result<K> BindTry<K>(this Result result, Func<Result<K>> func,
             Func<Exception, string> errorHandler = null)
         {
@@ -34,6 +42,11 @@ namespace CSharpFunctionalExtensions
         ///     Selects result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.
         ///     If a given function throws an exception, an error is returned from the given (or default) error handler
         /// </summary>
+        /// <typeparam name="T">Result Type parameter</typeparam>        
+        /// <param name="result">Extended result</param>
+        /// <param name="func">Function returning result to to bind</param>
+        /// <param name="errorHandler">Error handling function</param>        
+        /// <returns>Binding result</returns>
         public static Result BindTry<T>(this Result<T> result, Func<T, Result> func,
             Func<Exception, string> errorHandler = null)
         {
@@ -46,6 +59,12 @@ namespace CSharpFunctionalExtensions
         ///     Selects result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.
         ///     If a given function throws an exception, an error is returned from the given (or default) error handler
         /// </summary>
+        /// <typeparam name="T">Result Type parameter</typeparam>
+        /// <typeparam name="K"><paramref name="func" /> Result Type parameter</typeparam>        
+        /// <param name="result">Extended result</param>
+        /// <param name="func">Function returning result to to bind</param>
+        /// <param name="errorHandler">Error handling function</param>        
+        /// <returns>Binding result</returns>
         public static Result<K> BindTry<T, K>(this Result<T> result, Func<T, Result<K>> func,
             Func<Exception, string> errorHandler = null)
         {
@@ -58,6 +77,13 @@ namespace CSharpFunctionalExtensions
         ///    Selects result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.        
         ///    If a given function throws an exception, an error is returned from the given (or default) error handler
         /// </summary>
+        /// <typeparam name="T">Result Type parameter</typeparam>
+        /// <typeparam name="K"><paramref name="func" /> Result Type parameter</typeparam>
+        /// <typeparam name="E">Error Type parameter</typeparam>
+        /// <param name="result">Extended result</param>
+        /// <param name="func">Function returning result to to bind</param>
+        /// <param name="errorHandler">Error handling function</param>        
+        /// <returns>Binding result</returns>
         public static Result<K, E> BindTry<T, K, E>(this Result<T, E> result, Func<T, Result<K, E>> func,
             Func<Exception, E> errorHandler)
         {            
@@ -66,11 +92,15 @@ namespace CSharpFunctionalExtensions
                 : Result.Try(() => func(result.Value), errorHandler).Bind(r => r);           
         }
 
-
         /// <summary>
         ///     Selects result from the return value of a given function. If the calling UnitResult is a failure, a new failure result is returned instead.
         ///     If a given function throws an exception, an error is returned from the given (or default) error handler
-        /// </summary>
+        /// </summary>        
+        /// <typeparam name="E">Error Type parameter</typeparam>
+        /// <param name="result">Extended result</param>
+        /// <param name="func">Function returning result to to bind</param>
+        /// <param name="errorHandler">Error handling function</param>        
+        /// <returns>Binding result</returns>
         public static UnitResult<E> BindTry<E>(this UnitResult<E> result, Func<UnitResult<E>> func,
             Func<Exception, E> errorHandler)
         {
@@ -83,6 +113,12 @@ namespace CSharpFunctionalExtensions
         ///     Selects result from the return value of a given function. If the calling UnitResult is a failure, a new failure result is returned instead.
         ///     If a given function throws an exception, an error is returned from the given (or default) error handler
         /// </summary>
+        /// <typeparam name="T">Result Type parameter</typeparam>
+        /// <typeparam name="E">Error Type parameter</typeparam>
+        /// <param name="result">Extended result</param>
+        /// <param name="func">Function returning result to to bind</param>
+        /// <param name="errorHandler">Error handling function</param>        
+        /// <returns>Binding result</returns>
         public static Result<T, E> BindTry<T, E>(this UnitResult<E> result, Func<Result<T, E>> func,
             Func<Exception, E> errorHandler)
         {
@@ -95,6 +131,12 @@ namespace CSharpFunctionalExtensions
         ///     Selects result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.
         ///     If a given function throws an exception, an error is returned from the given (or default) error handler
         /// </summary>
+        /// <typeparam name="T">Result Type parameter</typeparam>
+        /// <typeparam name="E">Error Type parameter</typeparam>
+        /// <param name="result">Extended result</param>
+        /// <param name="func">Function returning result to to bind</param>
+        /// <param name="errorHandler">Error handling function</param>        
+        /// <returns>Binding result</returns>
         public static UnitResult<E> BindTry<T, E>(this Result<T, E> result, Func<T, UnitResult<E>> func,
             Func<Exception, E> errorHandler)
         {

--- a/CSharpFunctionalExtensions/Result/Methods/Extensions/BindTry.cs
+++ b/CSharpFunctionalExtensions/Result/Methods/Extensions/BindTry.cs
@@ -6,10 +6,10 @@ namespace CSharpFunctionalExtensions
     {
         /// <summary>
         ///     Selects result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.
-        ///     If a given function throws an exception, an error is returned from the given (or default) error handler
+        ///     If a given function throws an exception, an error is returned from the given error handler
         /// </summary>        
         /// <param name="result">Extended result</param>
-        /// <param name="func">Function returning result to to bind</param>
+        /// <param name="func">Function returning result to bind</param>
         /// <param name="errorHandler">Error handling function</param>        
         /// <returns>Binding result</returns>
         public static Result BindTry(this Result result, Func<Result> func,
@@ -22,11 +22,11 @@ namespace CSharpFunctionalExtensions
 
         /// <summary>
         ///     Selects result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.
-        ///     If a given function throws an exception, an error is returned from the given (or default) error handler
+        ///     If a given function throws an exception, an error is returned from the given error handler
         /// </summary>        
         /// <typeparam name="K"><paramref name="func" /> Result Type parameter</typeparam>
         /// <param name="result">Extended result</param>
-        /// <param name="func">Function returning result to to bind</param>
+        /// <param name="func">Function returning result to bind</param>
         /// <param name="errorHandler">Error handling function</param>        
         /// <returns>Binding result</returns>
         public static Result<K> BindTry<K>(this Result result, Func<Result<K>> func,
@@ -40,11 +40,11 @@ namespace CSharpFunctionalExtensions
 
         /// <summary>
         ///     Selects result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.
-        ///     If a given function throws an exception, an error is returned from the given (or default) error handler
+        ///     If a given function throws an exception, an error is returned from the given error handler
         /// </summary>
         /// <typeparam name="T">Result Type parameter</typeparam>        
         /// <param name="result">Extended result</param>
-        /// <param name="func">Function returning result to to bind</param>
+        /// <param name="func">Function returning result to bind</param>
         /// <param name="errorHandler">Error handling function</param>        
         /// <returns>Binding result</returns>
         public static Result BindTry<T>(this Result<T> result, Func<T, Result> func,
@@ -57,12 +57,12 @@ namespace CSharpFunctionalExtensions
 
         /// <summary>
         ///     Selects result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.
-        ///     If a given function throws an exception, an error is returned from the given (or default) error handler
+        ///     If a given function throws an exception, an error is returned from the given error handler
         /// </summary>
         /// <typeparam name="T">Result Type parameter</typeparam>
         /// <typeparam name="K"><paramref name="func" /> Result Type parameter</typeparam>        
         /// <param name="result">Extended result</param>
-        /// <param name="func">Function returning result to to bind</param>
+        /// <param name="func">Function returning result to bind</param>
         /// <param name="errorHandler">Error handling function</param>        
         /// <returns>Binding result</returns>
         public static Result<K> BindTry<T, K>(this Result<T> result, Func<T, Result<K>> func,
@@ -75,13 +75,13 @@ namespace CSharpFunctionalExtensions
 
         /// <summary>
         ///    Selects result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.        
-        ///    If a given function throws an exception, an error is returned from the given (or default) error handler
+        ///    If a given function throws an exception, an error is returned from the given error handler
         /// </summary>
         /// <typeparam name="T">Result Type parameter</typeparam>
         /// <typeparam name="K"><paramref name="func" /> Result Type parameter</typeparam>
         /// <typeparam name="E">Error Type parameter</typeparam>
         /// <param name="result">Extended result</param>
-        /// <param name="func">Function returning result to to bind</param>
+        /// <param name="func">Function returning result to bind</param>
         /// <param name="errorHandler">Error handling function</param>        
         /// <returns>Binding result</returns>
         public static Result<K, E> BindTry<T, K, E>(this Result<T, E> result, Func<T, Result<K, E>> func,
@@ -94,11 +94,11 @@ namespace CSharpFunctionalExtensions
 
         /// <summary>
         ///     Selects result from the return value of a given function. If the calling UnitResult is a failure, a new failure result is returned instead.
-        ///     If a given function throws an exception, an error is returned from the given (or default) error handler
+        ///     If a given function throws an exception, an error is returned from the given error handler
         /// </summary>        
         /// <typeparam name="E">Error Type parameter</typeparam>
         /// <param name="result">Extended result</param>
-        /// <param name="func">Function returning result to to bind</param>
+        /// <param name="func">Function returning result to bind</param>
         /// <param name="errorHandler">Error handling function</param>        
         /// <returns>Binding result</returns>
         public static UnitResult<E> BindTry<E>(this UnitResult<E> result, Func<UnitResult<E>> func,
@@ -111,12 +111,12 @@ namespace CSharpFunctionalExtensions
 
         /// <summary>
         ///     Selects result from the return value of a given function. If the calling UnitResult is a failure, a new failure result is returned instead.
-        ///     If a given function throws an exception, an error is returned from the given (or default) error handler
+        ///     If a given function throws an exception, an error is returned from the given error handler
         /// </summary>
         /// <typeparam name="T">Result Type parameter</typeparam>
         /// <typeparam name="E">Error Type parameter</typeparam>
         /// <param name="result">Extended result</param>
-        /// <param name="func">Function returning result to to bind</param>
+        /// <param name="func">Function returning result to bind</param>
         /// <param name="errorHandler">Error handling function</param>        
         /// <returns>Binding result</returns>
         public static Result<T, E> BindTry<T, E>(this UnitResult<E> result, Func<Result<T, E>> func,
@@ -129,12 +129,12 @@ namespace CSharpFunctionalExtensions
 
         /// <summary>
         ///     Selects result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.
-        ///     If a given function throws an exception, an error is returned from the given (or default) error handler
+        ///     If a given function throws an exception, an error is returned from the given error handler
         /// </summary>
         /// <typeparam name="T">Result Type parameter</typeparam>
         /// <typeparam name="E">Error Type parameter</typeparam>
         /// <param name="result">Extended result</param>
-        /// <param name="func">Function returning result to to bind</param>
+        /// <param name="func">Function returning result to bind</param>
         /// <param name="errorHandler">Error handling function</param>        
         /// <returns>Binding result</returns>
         public static UnitResult<E> BindTry<T, E>(this Result<T, E> result, Func<T, UnitResult<E>> func,


### PR DESCRIPTION
Added ```BindTry``` extensions to resolve problems with ```OnSuccessTry``` extensions for functions returning ```Result``` (all kinds).