### PR TITLE
MapTry feature

### DIFF
--- a/CSharpFunctionalExtensions.Tests/CSharpFunctionalExtensions.Tests.csproj
+++ b/CSharpFunctionalExtensions.Tests/CSharpFunctionalExtensions.Tests.csproj
@@ -481,5 +481,26 @@
 	<Compile Update="ResultTests\Extensions\BindTryTests.ValueTask.Right.cs">
 		<DependentUpon>BindTryTests.ValueTask.cs</DependentUpon>
 	</Compile>
+	<Compile Update="ResultTests\Extensions\MapTryTests.Task.cs">
+		<DependentUpon>MapTryTests.cs</DependentUpon>
+	</Compile>
+	<Compile Update="ResultTests\Extensions\MapTryTests.ValueTask.cs">
+		<DependentUpon>MapTryTests.cs</DependentUpon>
+	</Compile>
+	<Compile Update="ResultTests\Extensions\MapTryTests.Base.cs">
+		<DependentUpon>MapTryTests.cs</DependentUpon>
+	</Compile>
+	<Compile Update="ResultTests\Extensions\MapTryTests.Task.Left.cs">
+		<DependentUpon>MapTryTests.Task.cs</DependentUpon>
+	</Compile>
+	<Compile Update="ResultTests\Extensions\MapTryTests.Task.Right.cs">
+		<DependentUpon>MapTryTests.Task.cs</DependentUpon>
+	</Compile>
+	<Compile Update="ResultTests\Extensions\MapTryTests.ValueTask.Left.cs">
+		<DependentUpon>MapTryTests.ValueTask.cs</DependentUpon>
+	</Compile>
+	<Compile Update="ResultTests\Extensions\MapTryTests.ValueTask.Right.cs">
+		<DependentUpon>MapTryTests.ValueTask.cs</DependentUpon>
+	</Compile>
   </ItemGroup>  
 </Project>

--- a/CSharpFunctionalExtensions.Tests/NonParallelTestCollectionAttribute.cs
+++ b/CSharpFunctionalExtensions.Tests/NonParallelTestCollectionAttribute.cs
@@ -1,0 +1,10 @@
+﻿using Xunit;
+
+namespace CSharpFunctionalExtensions.Tests
+{
+    [CollectionDefinition(Name, DisableParallelization = true)]
+    public sealed class NonParallelTestCollectionDefinition
+    {
+        internal const string Name = "Non-Parallel Collection";
+    }
+}

--- a/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/MapTryTests.Base.cs
+++ b/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/MapTryTests.Base.cs
@@ -1,0 +1,82 @@
+﻿using CSharpFunctionalExtensions.Tests.MaybeTests.Extensions;
+using FluentAssertions;
+using System;
+using System.Threading.Tasks;
+
+namespace CSharpFunctionalExtensions.Tests.ResultTests.Extensions
+{
+    public class MapTryTestsBase : MapTestsBase
+    {        
+        protected K Throwing_K() => throw new Exception(ErrorMessage, GetFuncException());
+        protected K Throwing_T_K(T _) => throw new Exception(ErrorMessage, GetFuncException());
+
+        protected Task<K> Task_Throwing_K() => throw new Exception(ErrorMessage, GetFuncException());
+        protected Task<K> Task_Throwing_T_K(T _) => throw new Exception(ErrorMessage, GetFuncException());
+
+        protected ValueTask<K> ValueTask_Throwing_K() => throw new Exception(ErrorMessage, GetFuncException());
+        protected ValueTask<K> ValueTask_Throwing_T_K(T _) => throw new Exception(ErrorMessage, GetFuncException());
+
+
+        protected static string ErrorHandler(Exception _) => ErrorMessage2;
+        protected static E ErrorHandler_E(Exception _) => E.Value2;
+
+        protected void AssertSuccess(Result<K,E> result)
+        {
+            result.IsSuccess.Should().BeTrue();
+            result.Value.Should().Be(K.Value);
+            FuncExecuted.Should().BeTrue();
+        }
+
+        protected void AssertSuccess(Result<K> result)
+        {
+            result.IsSuccess.Should().BeTrue();
+            result.Value.Should().Be(K.Value);                   
+            FuncExecuted.Should().BeTrue();
+        }
+
+        protected void AssertFailure(Result<K,E> result)
+        {
+            AssertFailure(result, E.Value, false);
+        }
+        protected void AssertFailureFromHandler(Result<K, E> result)
+        {
+            AssertFailure(result, E.Value2, true);
+        }
+        protected void AssertFailure(Result result)
+        {
+            AssertFailure(result, ErrorMessage, false);
+        }
+        protected void AssertFailureFromHandler(Result result)
+        {
+            AssertFailure(result, ErrorMessage2, true);
+        }
+        protected void AssertFailureFromDefaultHandler(Result result)
+        {
+            AssertFailure(result, ErrorMessage, true);
+        }
+
+        protected void AssertFailure(Result result, string message, bool fromFunc)
+        {
+            result.IsFailure.Should().BeTrue();
+            result.Error.Should().Be(message);
+            FuncExecuted.Should().Be(fromFunc);
+        }
+        protected void AssertFailure(Result<T,E> result, E error, bool fromFunc)
+        {
+            result.IsFailure.Should().BeTrue();
+            result.Error.Should().Be(error);
+            FuncExecuted.Should().Be(fromFunc);
+        }
+        protected void AssertFailure(UnitResult<E> result, E errorValue, bool fromFunc)
+        {
+            result.IsFailure.Should().BeTrue();
+            result.Error.Should().Be(errorValue);
+            FuncExecuted.Should().Be(fromFunc);
+        }
+        private Exception GetFuncException()
+        {
+            Func_K();
+            return new Exception("Thrown from function");
+        }
+    }
+}

--- a/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/MapTryTests.Task.Left.cs
+++ b/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/MapTryTests.Task.Left.cs
@@ -1,0 +1,156 @@
+﻿using System.Threading.Tasks;
+using Xunit;
+
+namespace CSharpFunctionalExtensions.Tests.ResultTests.Extensions
+{
+    public class MapTryTests_Task_Left : MapTryTestsBase
+    {
+        #region MapTry for Task<Result> with function returning K
+        [Fact]
+        public async Task MapTry_execute_func_K_on_task_success_returns_success()
+        {
+            Task<Result> sut = Result.Success().AsTask();
+
+            Result<K> result = await sut.MapTry(Func_K);
+
+            AssertSuccess(result);
+        }
+
+        [Fact]
+        public async Task MapTry_execute_func_K_on_task_failure_returns_failure()
+        {
+            Task<Result> sut = Result.Failure(ErrorMessage).AsTask();
+
+            Result<K> result = await sut.MapTry(Func_K);
+
+            AssertFailure(result);
+        }
+
+        [Fact]
+        public async Task MapTry_execute_throwing_func_K_on_taks_success_returns_failure_with_exception_message()
+        {
+            Task<Result> sut = Result.Success().AsTask();
+
+            Result<K> result = await sut.MapTry(Throwing_K);
+
+            AssertFailureFromDefaultHandler(result);
+        }
+
+        [Fact]
+        public async Task MapTry_execute_throwing_func_K_on_success_with_custom_error_handler_returns_failure_with_custom_message()
+        {
+            Task<Result> sut = Result.Success().AsTask();
+
+            Result<K> result = await sut.MapTry(Throwing_K, ErrorHandler);
+
+            AssertFailureFromHandler(result);
+        }
+        #endregion
+
+        #region MapTry for Task<Result<T>> with function returning K
+        [Fact]
+        public async Task MapTry_execute_func_K_on_task_success_T_returns_success()
+        {
+            Task<Result<T>> sut = Result.Success(T.Value).AsTask();
+
+            Result<K> result = await sut.MapTry(Func_T_K);
+
+            AssertSuccess(result);
+        }
+
+        [Fact]
+        public async Task MapTry_execute_func_K_on_task_failure_T_returns_failure()
+        {
+            Task<Result<T>> sut = Result.Failure<T>(ErrorMessage).AsTask();
+
+            Result<K> result = await sut.MapTry(Func_T_K);
+
+            AssertFailure(result);
+        }
+
+        [Fact]
+        public async Task MapTry_execute_throwing_func_K_on_taks_success_T_returns_failure_with_exception_message()
+        {
+            Task<Result<T>> sut = Result.Success(T.Value).AsTask();
+
+            Result<K> result = await sut.MapTry(Throwing_T_K);
+
+            AssertFailureFromDefaultHandler(result);
+        }
+
+        [Fact]
+        public async Task MapTry_execute_throwing_func_K_on_success_T_with_custom_error_handler_returns_failure_with_custom_message()
+        {
+            Task<Result<T>> sut = Result.Success(T.Value).AsTask();
+
+            Result<K> result = await sut.MapTry(Throwing_T_K, ErrorHandler);
+
+            AssertFailureFromHandler(result);
+        }
+        #endregion
+
+        #region MapTry for Task<Result<T,E>> with function returning K
+        [Fact]
+        public async Task MapTry_execute_func_T_K_on_task_success_T_E_returns_success()
+        {
+            Task<Result<T, E>> sut = Result.Success<T, E>(T.Value).AsTask();
+
+            Result<K, E> result = await sut.MapTry(Func_T_K, ErrorHandler_E);
+
+            AssertSuccess(result);
+        }
+
+        [Fact]
+        public async Task MapTry_execute_func_T_K_on_task_failure_T_E_returns_failure()
+        {
+            Task<Result<T, E>> sut = Result.Failure<T, E>(E.Value).AsTask();
+
+            Result<K, E> result = await sut.MapTry(Func_T_K, ErrorHandler_E);
+
+            AssertFailure(result);
+        }
+
+        [Fact]
+        public async Task MapTry_execute_throwing_func_T_K_on_success_T_E_returns_failure_with_value_from_error_handler()
+        {
+            Task<Result<T, E>> sut = Result.Success<T, E>(T.Value).AsTask();
+
+            Result<K, E> result = await sut.MapTry(Throwing_T_K, ErrorHandler_E);
+
+            AssertFailureFromHandler(result);
+        }
+        #endregion
+
+        #region MapTry for Task<UnitResult<E>> with function returning K
+        [Fact]
+        public async Task MapTry_execute_func_K_on_task_success_E_returns_success()
+        {
+            Task<UnitResult<E>> sut = UnitResult.Success<E>().AsTask();
+
+            Result<K, E> result = await sut.MapTry(Func_K, ErrorHandler_E);
+
+            AssertSuccess(result);
+        }
+
+        [Fact]
+        public async Task MapTry_execute_func_K_on_task_failure_E_returns_failure()
+        {
+            Task<UnitResult<E>> sut = UnitResult.Failure(E.Value).AsTask();
+
+            Result<K, E> result = await sut.MapTry(Func_K, ErrorHandler_E);
+
+            AssertFailure(result);
+        }
+
+        [Fact]
+        public async Task MapTry_execute_throwing_func_K_on_success_E_returns_failure_with_value_from_error_handler()
+        {
+            Task<UnitResult<E>> sut = UnitResult.Success<E>().AsTask();
+
+            Result<K, E> result = await sut.MapTry(Throwing_K, ErrorHandler_E);
+
+            AssertFailureFromHandler(result);
+        }
+        #endregion        
+    }
+}

--- a/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/MapTryTests.Task.Right.cs
+++ b/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/MapTryTests.Task.Right.cs
@@ -1,0 +1,156 @@
+﻿using System.Threading.Tasks;
+using Xunit;
+
+namespace CSharpFunctionalExtensions.Tests.ResultTests.Extensions
+{
+    public class MapTryTests_Task_Right : MapTryTestsBase
+    {        
+        #region MapTry for Result with function returning Task<K>
+        [Fact]
+        public async Task MapTry_execute_task_func_K_on_success_returns_success()
+        {
+            Result sut = Result.Success();
+
+            Result<K> result = await sut.MapTry(Task_Func_K);
+
+            AssertSuccess(result);
+        }
+
+        [Fact]
+        public async Task MapTry_execute_task_func_K_on_failure_returns_failure()
+        {
+            Result sut = Result.Failure(ErrorMessage);
+
+            Result<K> result = await sut.MapTry(Task_Func_K);
+
+            AssertFailure(result);
+        }
+
+        [Fact]
+        public async Task MapTry_execute_throwing_task_func_K_on_success_returns_failure_with_exception_message()
+        {
+            Result sut = Result.Success();
+
+            Result<K> result = await sut.MapTry(Task_Throwing_K);
+
+            AssertFailureFromDefaultHandler(result);
+        }
+
+        [Fact]
+        public async Task MapTry_execute_throwing_task_func_K_on_success_with_custom_error_handler_returns_failure_with_custom_message()
+        {
+            Result sut = Result.Success();
+
+            Result<K> result = await sut.MapTry(Task_Throwing_K, ErrorHandler);
+
+            AssertFailureFromHandler(result);
+        }
+        #endregion
+
+        #region MapTry for Result<T> with function returning Task<K>
+        [Fact]
+        public async Task MapTry_execute_task_func_K_on_success_T_returns_success()
+        {
+            Result<T> sut = Result.Success(T.Value);
+
+            Result<K> result = await sut.MapTry(Task_Func_T_K);
+
+            AssertSuccess(result);
+        }
+
+        [Fact]
+        public async Task MapTry_execute_task_func_K_on_failure_T_returns_failure()
+        {
+            Result<T> sut = Result.Failure<T>(ErrorMessage);
+
+            Result<K> result = await sut.MapTry(Task_Func_T_K);
+
+            AssertFailure(result);
+        }
+
+        [Fact]
+        public async Task MapTry_execute_throwing_task_func_K_on_success_T_returns_failure_with_exception_message()
+        {
+            Result<T> sut = Result.Success(T.Value);
+
+            Result<K> result = await sut.MapTry(Task_Throwing_T_K);
+
+            AssertFailureFromDefaultHandler(result);
+        }
+
+        [Fact]
+        public async Task MapTry_execute_throwing_task_func_K_on_success_T_with_custom_error_handler_returns_failure_with_custom_message()
+        {
+            Result<T> sut = Result.Success(T.Value);
+
+            Result<K> result = await sut.MapTry(Task_Throwing_T_K, ErrorHandler);
+
+            AssertFailureFromHandler(result);
+        }
+        #endregion
+
+        #region MapTry for Result<T,E> with function returning Task<K>
+        [Fact]
+        public async Task MapTry_execute_task_func_T_K_on_success_T_E_returns_success()
+        {
+            Result<T, E> sut = Result.Success<T, E>(T.Value);
+
+            Result<K, E> result = await sut.MapTry(Task_Func_T_K, ErrorHandler_E);
+
+            AssertSuccess(result);
+        }
+
+        [Fact]
+        public async Task MapTry_execute_task_func_T_K_on_failure_T_E_returns_failure()
+        {
+            Result<T, E> sut = Result.Failure<T, E>(E.Value);
+
+            Result<K, E> result = await sut.MapTry(Task_Func_T_K, ErrorHandler_E);
+
+            AssertFailure(result);
+        }
+
+        [Fact]
+        public async Task MapTry_execute_throwing_task_func_K_on_success_T_E_returns_failure_with_value_from_error_handler()
+        {
+            Result<T, E> sut = Result.Success<T, E>(T.Value);
+
+            Result<K, E> result = await sut.MapTry(Task_Throwing_T_K, ErrorHandler_E);
+
+            AssertFailureFromHandler(result);
+        }        
+        #endregion
+
+        #region MapTry for UnitResult<E> with function returning Task<K>
+        [Fact]
+        public async Task MapTry_execute_task_func_K_on_success_E_returns_success()
+        {
+            UnitResult<E> sut = UnitResult.Success<E>();
+
+            Result<K, E> result = await sut.MapTry(Task_Func_K, ErrorHandler_E);
+
+            AssertSuccess(result);
+        }
+
+        [Fact]
+        public async Task MapTry_execute_task_func_returning_success_T_E_on_failure_E_returns_failure()
+        {
+            UnitResult<E> sut = UnitResult.Failure(E.Value);
+
+            Result<K, E> result = await sut.MapTry(Task_Func_K, ErrorHandler_E);
+
+            AssertFailure(result);
+        }
+
+        [Fact]
+        public async Task MapTry_execute_throwing_task_func_T_E_on_success_E_returns_failure_with_value_from_error_handler()
+        {
+            UnitResult<E> sut = UnitResult.Success<E>();
+
+            Result<K, E> result = await sut.MapTry(Task_Throwing_K, ErrorHandler_E);
+
+            AssertFailureFromHandler(result);
+        }
+        #endregion          
+    }
+}

--- a/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/MapTryTests.Task.cs
+++ b/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/MapTryTests.Task.cs
@@ -1,0 +1,157 @@
+﻿using System.Threading.Tasks;
+using Xunit;
+
+namespace CSharpFunctionalExtensions.Tests.ResultTests.Extensions
+{
+    public class MapTryTests_Task : MapTryTestsBase
+    {
+        #region MapTry for Task<Result> with function returning Task<K>
+        [Fact]
+        public async Task MapTry_execute_task_func_K_on_task_success_returns_success()
+        {
+            Task<Result> sut = Result.Success().AsTask();
+
+            Result<K> result = await sut.MapTry(Task_Func_K);
+
+            AssertSuccess(result);
+        }
+
+        [Fact]
+        public async Task MapTry_execute_task_func_K_on_task_failure_returns_failure()
+        {
+            Task<Result> sut = Result.Failure(ErrorMessage).AsTask();
+
+            Result<K> result = await sut.MapTry(Task_Func_K);
+
+            AssertFailure(result);
+        }
+
+        [Fact]
+        public async Task MapTry_execute_throwing_task_func_K_on_taks_success_returns_failure_with_exception_message()
+        {
+            Task<Result> sut = Result.Success().AsTask();
+
+            Result<K> result = await sut.MapTry(Task_Throwing_K);
+
+            AssertFailureFromDefaultHandler(result);
+        }
+
+        [Fact]
+        public async Task MapTry_execute_throwing_task_func_K_on_task_success_with_custom_error_handler_returns_failure_with_custom_message()
+        {
+            Task<Result> sut = Result.Success().AsTask();
+
+            Result<K> result = await sut.MapTry(Task_Throwing_K, ErrorHandler);
+
+            AssertFailureFromHandler(result);
+        }
+        #endregion
+
+        #region MapTry for Task<Result<T>> with function returning Task<K>
+        [Fact]
+        public async Task MapTry_execute_task_func_K_on_task_success_T_returns_success()
+        {
+            Task<Result<T>> sut = Result.Success(T.Value).AsTask();
+
+            Result<K> result = await sut.MapTry(Task_Func_T_K);
+
+            AssertSuccess(result);
+        }
+
+        [Fact]
+        public async Task MapTry_execute_task_func_K_on_task_failure_T_returns_failure()
+        {
+            Task<Result<T>> sut = Result.Failure<T>(ErrorMessage).AsTask();
+
+            Result<K> result = await sut.MapTry(Task_Func_T_K);
+
+            AssertFailure(result);
+        }
+
+        [Fact]
+        public async Task MapTry_execute_throwing_task_func_K_on_taks_success_T_returns_failure_with_exception_message()
+        {
+            Task<Result<T>> sut = Result.Success(T.Value).AsTask();
+
+            Result<K> result = await sut.MapTry(Task_Throwing_T_K);
+
+            AssertFailureFromDefaultHandler(result);
+        }
+
+        [Fact]
+        public async Task MapTry_execute_throwing_task_func_K_on_success_T_with_custom_error_handler_returns_failure_with_custom_message()
+        {
+            Task<Result<T>> sut = Result.Success(T.Value).AsTask();
+
+            Result<K> result = await sut.MapTry(Task_Throwing_T_K,ErrorHandler);
+
+            AssertFailureFromHandler(result);
+        }
+        #endregion
+
+        #region MapTry for Task<UnitResult<E>> with function returning Task<K>
+        [Fact]
+        public async Task MapTry_execute_task_func_K_on_task_success_E_returns_success()
+        {
+            Task<UnitResult<E>> sut = UnitResult.Success<E>().AsTask();
+
+            Result<K, E> result = await sut.MapTry(Task_Func_K, ErrorHandler_E);
+
+            AssertSuccess(result);
+        }
+
+        [Fact]
+        public async Task MapTry_execute_task_func_K_on_task_failure_E_returns_failure()
+        {
+            Task<UnitResult<E>> sut = UnitResult.Failure(E.Value).AsTask();
+
+            Result<K, E> result = await sut.MapTry(Task_Func_K, ErrorHandler_E);
+
+            AssertFailure(result);
+        }
+
+        [Fact]
+        public async Task MapTry_execute_throwing_task_func_T_E_on_success_E_returns_failure_with_value_from_error_handler()
+        {
+            Task<UnitResult<E>> sut = UnitResult.Success<E>().AsTask();
+
+            Result<K, E> result = await sut.MapTry(Task_Throwing_K, ErrorHandler_E);
+
+            AssertFailureFromHandler(result);
+        }
+        #endregion
+
+        #region MapTry for Task<Result<T,E>> with function returning Task<K>
+        [Fact]
+        public async Task MapTry_execute_task_func_T_K_on_task_success_T_E_returns_success()
+        {
+            Task<Result<T, E>> sut = Result.Success<T, E>(T.Value).AsTask();
+
+            Result<K, E> result = await sut.MapTry(Task_Func_T_K, ErrorHandler_E);
+
+            AssertSuccess(result);
+        }
+
+        [Fact]
+        public async Task MapTry_execute_task_func_K_on_task_failure_T_E_returns_failure()
+        {
+            Task<Result<T, E>> sut = Result.Failure<T, E>(E.Value).AsTask();
+
+            Result<K, E> result = await sut.MapTry(Task_Func_T_K, ErrorHandler_E);
+
+            AssertFailure(result);
+        }
+
+        [Fact]
+        public async Task MapTry_execute_throwing_task_func_K_on_success_T_E_returns_failure_with_value_from_error_handler()
+        {
+            Task<Result<T, E>> sut = Result.Success<T, E>(T.Value).AsTask();
+
+            Result<K, E> result = await sut.MapTry(Task_Throwing_T_K, ErrorHandler_E);
+
+            AssertFailureFromHandler(result);
+        }
+        #endregion
+
+    }
+}

--- a/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/MapTryTests.ValueTask.Left.cs
+++ b/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/MapTryTests.ValueTask.Left.cs
@@ -1,0 +1,157 @@
+﻿using System.Threading.Tasks;
+using Xunit;
+using CSharpFunctionalExtensions.ValueTasks;
+
+namespace CSharpFunctionalExtensions.Tests.ResultTests.Extensions
+{
+    public class MapTryTests_ValueTask_Left : MapTryTestsBase
+    {
+        #region MapTry for ValueTask<Result> with function returning K
+        [Fact]
+        public async ValueTask MapTry_execute_func_K_on_valuetask_success_returns_success()
+        {
+            ValueTask<Result> sut = Result.Success().AsValueTask();
+
+            Result<K> result = await sut.MapTry(valueTask:Func_K);
+
+            AssertSuccess(result);
+        }
+
+        [Fact]
+        public async ValueTask MapTry_execute_func_K_on_valuetask_failure_returns_failure()
+        {
+            ValueTask<Result> sut = Result.Failure(ErrorMessage).AsValueTask();
+
+            Result<K> result = await sut.MapTry(valueTask:Func_K);
+
+            AssertFailure(result);
+        }
+
+        [Fact]
+        public async ValueTask MapTry_execute_throwing_func_K_on_taks_success_returns_failure_with_exception_message()
+        {
+            ValueTask<Result> sut = Result.Success().AsValueTask();
+
+            Result<K> result = await sut.MapTry(valueTask:Throwing_K);
+
+            AssertFailureFromDefaultHandler(result);
+        }
+
+        [Fact]
+        public async ValueTask MapTry_execute_throwing_func_K_on_success_with_custom_error_handler_returns_failure_with_custom_message()
+        {
+            ValueTask<Result> sut = Result.Success().AsValueTask();
+
+            Result<K> result = await sut.MapTry(valueTask:Throwing_K, ErrorHandler);
+
+            AssertFailureFromHandler(result);
+        }
+        #endregion
+
+        #region MapTry for ValueTask<Result<T>> with function returning K
+        [Fact]
+        public async ValueTask MapTry_execute_func_K_on_valuetask_success_T_returns_success()
+        {
+            ValueTask<Result<T>> sut = Result.Success(T.Value).AsValueTask();
+
+            Result<K> result = await sut.MapTry(valueTask:Func_T_K);
+
+            AssertSuccess(result);
+        }
+
+        [Fact]
+        public async ValueTask MapTry_execute_func_K_on_valuetask_failure_T_returns_failure()
+        {
+            ValueTask<Result<T>> sut = Result.Failure<T>(ErrorMessage).AsValueTask();
+
+            Result<K> result = await sut.MapTry(valueTask:Func_T_K);
+
+            AssertFailure(result);
+        }
+
+        [Fact]
+        public async ValueTask MapTry_execute_throwing_func_K_on_taks_success_T_returns_failure_with_exception_message()
+        {
+            ValueTask<Result<T>> sut = Result.Success(T.Value).AsValueTask();
+
+            Result<K> result = await sut.MapTry(valueTask:Throwing_T_K);
+
+            AssertFailureFromDefaultHandler(result);
+        }
+
+        [Fact]
+        public async ValueTask MapTry_execute_throwing_func_K_on_success_T_with_custom_error_handler_returns_failure_with_custom_message()
+        {
+            ValueTask<Result<T>> sut = Result.Success(T.Value).AsValueTask();
+
+            Result<K> result = await sut.MapTry(valueTask:Throwing_T_K, ErrorHandler);
+
+            AssertFailureFromHandler(result);
+        }
+        #endregion
+
+        #region MapTry for ValueTask<Result<T,E>> with function returning K
+        [Fact]
+        public async ValueTask MapTry_execute_func_T_K_on_valuetask_success_T_E_returns_success()
+        {
+            ValueTask<Result<T, E>> sut = Result.Success<T, E>(T.Value).AsValueTask();
+
+            Result<K, E> result = await sut.MapTry(valueTask:Func_T_K, ErrorHandler_E);
+
+            AssertSuccess(result);
+        }
+
+        [Fact]
+        public async ValueTask MapTry_execute_func_T_K_on_valuetask_failure_T_E_returns_failure()
+        {
+            ValueTask<Result<T, E>> sut = Result.Failure<T, E>(E.Value).AsValueTask();
+
+            Result<K, E> result = await sut.MapTry(valueTask:Func_T_K, ErrorHandler_E);
+
+            AssertFailure(result);
+        }
+
+        [Fact]
+        public async ValueTask MapTry_execute_throwing_func_T_K_on_success_T_E_returns_failure_with_value_from_error_handler()
+        {
+            ValueTask<Result<T, E>> sut = Result.Success<T, E>(T.Value).AsValueTask();
+
+            Result<K, E> result = await sut.MapTry(valueTask:Throwing_T_K, ErrorHandler_E);
+
+            AssertFailureFromHandler(result);
+        }
+        #endregion
+
+        #region MapTry for ValueTask<UnitResult<E>> with function returning K
+        [Fact]
+        public async ValueTask MapTry_execute_func_K_on_valuetask_success_E_returns_success()
+        {
+            ValueTask<UnitResult<E>> sut = UnitResult.Success<E>().AsValueTask();
+
+            Result<K, E> result = await sut.MapTry(valueTask:Func_K, ErrorHandler_E);
+
+            AssertSuccess(result);
+        }
+
+        [Fact]
+        public async ValueTask MapTry_execute_func_K_on_valuetask_failure_E_returns_failure()
+        {
+            ValueTask<UnitResult<E>> sut = UnitResult.Failure(E.Value).AsValueTask();
+
+            Result<K, E> result = await sut.MapTry(valueTask:Func_K, ErrorHandler_E);
+
+            AssertFailure(result);
+        }
+
+        [Fact]
+        public async ValueTask MapTry_execute_throwing_func_K_on_success_E_returns_failure_with_value_from_error_handler()
+        {
+            ValueTask<UnitResult<E>> sut = UnitResult.Success<E>().AsValueTask();
+
+            Result<K, E> result = await sut.MapTry(valueTask:Throwing_K, ErrorHandler_E);
+
+            AssertFailureFromHandler(result);
+        }
+        #endregion        
+    }
+}

--- a/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/MapTryTests.ValueTask.Right.cs
+++ b/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/MapTryTests.ValueTask.Right.cs
@@ -1,0 +1,157 @@
+﻿using System.Threading.Tasks;
+using Xunit;
+using CSharpFunctionalExtensions.ValueTasks;
+
+namespace CSharpFunctionalExtensions.Tests.ResultTests.Extensions
+{
+    public class MapTryTests_ValueTask_Right : MapTryTestsBase
+    {
+        #region MapTry for Result with function returning ValueTask<K>
+        [Fact]
+        public async ValueTask MapTry_execute_valuetask_func_K_on_success_returns_success()
+        {
+            Result sut = Result.Success();
+
+            Result<K> result = await sut.MapTry(valueTask: ValueTask_Func_K);
+
+            AssertSuccess(result);
+        }
+
+        [Fact]
+        public async ValueTask MapTry_execute_valuetask_func_K_on_failure_returns_failure()
+        {
+            Result sut = Result.Failure(ErrorMessage);
+
+            Result<K> result = await sut.MapTry(valueTask: ValueTask_Func_K);
+
+            AssertFailure(result);
+        }
+
+        [Fact]
+        public async ValueTask MapTry_execute_throwing_valuetask_func_K_on_success_returns_failure_with_exception_message()
+        {
+            Result sut = Result.Success();
+
+            Result<K> result = await sut.MapTry(valueTask: ValueTask_Throwing_K);
+
+            AssertFailureFromDefaultHandler(result);
+        }
+
+        [Fact]
+        public async ValueTask MapTry_execute_throwing_valuetask_func_K_on_success_with_custom_error_handler_returns_failure_with_custom_message()
+        {
+            Result sut = Result.Success();
+
+            Result<K> result = await sut.MapTry(valueTask: ValueTask_Throwing_K, ErrorHandler);
+
+            AssertFailureFromHandler(result);
+        }
+        #endregion
+
+        #region MapTry for Result<T> with function returning ValueTask<K>
+        [Fact]
+        public async ValueTask MapTry_execute_valuetask_func_K_on_success_T_returns_success()
+        {
+            Result<T> sut = Result.Success(T.Value);
+
+            Result<K> result = await sut.MapTry(valueTask: ValueTask_Func_T_K);
+
+            AssertSuccess(result);
+        }
+
+        [Fact]
+        public async ValueTask MapTry_execute_valuetask_func_K_on_failure_T_returns_failure()
+        {
+            Result<T> sut = Result.Failure<T>(ErrorMessage);
+
+            Result<K> result = await sut.MapTry(valueTask: ValueTask_Func_T_K);
+
+            AssertFailure(result);
+        }
+
+        [Fact]
+        public async ValueTask MapTry_execute_throwing_valuetask_func_K_on_success_T_returns_failure_with_exception_message()
+        {
+            Result<T> sut = Result.Success(T.Value);
+
+            Result<K> result = await sut.MapTry(valueTask: ValueTask_Throwing_T_K);
+
+            AssertFailureFromDefaultHandler(result);
+        }
+
+        [Fact]
+        public async ValueTask MapTry_execute_throwing_valuetask_func_K_on_success_T_with_custom_error_handler_returns_failure_with_custom_message()
+        {
+            Result<T> sut = Result.Success(T.Value);
+
+            Result<K> result = await sut.MapTry(valueTask: ValueTask_Throwing_T_K, ErrorHandler);
+
+            AssertFailureFromHandler(result);
+        }
+        #endregion
+
+        #region MapTry for Result<T,E> with function returning ValueTask<K>
+        [Fact]
+        public async ValueTask MapTry_execute_valuetask_func_T_K_on_success_T_E_returns_success()
+        {
+            Result<T, E> sut = Result.Success<T, E>(T.Value);
+
+            Result<K, E> result = await sut.MapTry(valueTask: ValueTask_Func_T_K, ErrorHandler_E);
+
+            AssertSuccess(result);
+        }
+
+        [Fact]
+        public async ValueTask MapTry_execute_valuetask_func_T_K_on_failure_T_E_returns_failure()
+        {
+            Result<T, E> sut = Result.Failure<T, E>(E.Value);
+
+            Result<K, E> result = await sut.MapTry(valueTask: ValueTask_Func_T_K, ErrorHandler_E);
+
+            AssertFailure(result);
+        }
+
+        [Fact]
+        public async ValueTask MapTry_execute_throwing_valuetask_func_K_on_success_T_E_returns_failure_with_value_from_error_handler()
+        {
+            Result<T, E> sut = Result.Success<T, E>(T.Value);
+
+            Result<K, E> result = await sut.MapTry(valueTask: ValueTask_Throwing_T_K, ErrorHandler_E);
+
+            AssertFailureFromHandler(result);
+        }
+        #endregion
+
+        #region MapTry for UnitResult<E> with function returning ValueTask<K>
+        [Fact]
+        public async ValueTask MapTry_execute_valuetask_func_K_on_success_E_returns_success()
+        {
+            UnitResult<E> sut = UnitResult.Success<E>();
+
+            Result<K, E> result = await sut.MapTry(valueTask: ValueTask_Func_K, ErrorHandler_E);
+
+            AssertSuccess(result);
+        }
+
+        [Fact]
+        public async ValueTask MapTry_execute_valuetask_func_returning_success_T_E_on_failure_E_returns_failure()
+        {
+            UnitResult<E> sut = UnitResult.Failure(E.Value);
+
+            Result<K, E> result = await sut.MapTry(valueTask: ValueTask_Func_K, ErrorHandler_E);
+
+            AssertFailure(result);
+        }
+
+        [Fact]
+        public async ValueTask MapTry_execute_throwing_valuetask_func_T_E_on_success_E_returns_failure_with_value_from_error_handler()
+        {
+            UnitResult<E> sut = UnitResult.Success<E>();
+
+            Result<K, E> result = await sut.MapTry(valueTask: ValueTask_Throwing_K, ErrorHandler_E);
+
+            AssertFailureFromHandler(result);
+        }
+        #endregion          
+    }
+}

--- a/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/MapTryTests.ValueTask.cs
+++ b/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/MapTryTests.ValueTask.cs
@@ -1,0 +1,158 @@
+﻿using System.Threading.Tasks;
+using Xunit;
+using CSharpFunctionalExtensions.ValueTasks;
+
+namespace CSharpFunctionalExtensions.Tests.ResultTests.Extensions
+{
+    public class MapTryTests_ValueTask : MapTryTestsBase
+    {
+        #region MapTry for ValueTask<Result> with function returning ValueTask<K>
+        [Fact]
+        public async ValueTask MapTry_execute_valuetask_func_K_on_valuetask_success_returns_success()
+        {
+            ValueTask<Result> sut = Result.Success().AsValueTask();
+
+            Result<K> result = await sut.MapTry(ValueTask_Func_K);
+
+            AssertSuccess(result);
+        }
+
+        [Fact]
+        public async ValueTask MapTry_execute_valuetask_func_K_on_valuetask_failure_returns_failure()
+        {
+            ValueTask<Result> sut = Result.Failure(ErrorMessage).AsValueTask();
+
+            Result<K> result = await sut.MapTry(ValueTask_Func_K);
+
+            AssertFailure(result);
+        }
+
+        [Fact]
+        public async ValueTask MapTry_execute_throwing_valuetask_func_K_on_taks_success_returns_failure_with_exception_message()
+        {
+            ValueTask<Result> sut = Result.Success().AsValueTask();
+
+            Result<K> result = await sut.MapTry(ValueTask_Throwing_K);
+
+            AssertFailureFromDefaultHandler(result);
+        }
+
+        [Fact]
+        public async ValueTask MapTry_execute_throwing_valuetask_func_K_on_valuetask_success_with_custom_error_handler_returns_failure_with_custom_message()
+        {
+            ValueTask<Result> sut = Result.Success().AsValueTask();
+
+            Result<K> result = await sut.MapTry(ValueTask_Throwing_K, ErrorHandler);
+
+            AssertFailureFromHandler(result);
+        }
+        #endregion
+
+        #region MapTry for ValueTask<Result<T>> with function returning ValueTask<K>
+        [Fact]
+        public async ValueTask MapTry_execute_valuetask_func_K_on_valuetask_success_T_returns_success()
+        {
+            ValueTask<Result<T>> sut = Result.Success(T.Value).AsValueTask();
+
+            Result<K> result = await sut.MapTry(ValueTask_Func_T_K);
+
+            AssertSuccess(result);
+        }
+
+        [Fact]
+        public async ValueTask MapTry_execute_valuetask_func_K_on_valuetask_failure_T_returns_failure()
+        {
+            ValueTask<Result<T>> sut = Result.Failure<T>(ErrorMessage).AsValueTask();
+
+            Result<K> result = await sut.MapTry(ValueTask_Func_T_K);
+
+            AssertFailure(result);
+        }
+
+        [Fact]
+        public async ValueTask MapTry_execute_throwing_valuetask_func_K_on_taks_success_T_returns_failure_with_exception_message()
+        {
+            ValueTask<Result<T>> sut = Result.Success(T.Value).AsValueTask();
+
+            Result<K> result = await sut.MapTry(ValueTask_Throwing_T_K);
+
+            AssertFailureFromDefaultHandler(result);
+        }
+
+        [Fact]
+        public async ValueTask MapTry_execute_throwing_valuetask_func_K_on_success_T_with_custom_error_handler_returns_failure_with_custom_message()
+        {
+            ValueTask<Result<T>> sut = Result.Success(T.Value).AsValueTask();
+
+            Result<K> result = await sut.MapTry(ValueTask_Throwing_T_K,ErrorHandler);
+
+            AssertFailureFromHandler(result);
+        }
+        #endregion
+
+        #region MapTry for ValueTask<UnitResult<E>> with function returning ValueTask<K>
+        [Fact]
+        public async ValueTask MapTry_execute_valuetask_func_K_on_valuetask_success_E_returns_success()
+        {
+            ValueTask<UnitResult<E>> sut = UnitResult.Success<E>().AsValueTask();
+
+            Result<K, E> result = await sut.MapTry(ValueTask_Func_K, ErrorHandler_E);
+
+            AssertSuccess(result);
+        }
+
+        [Fact]
+        public async ValueTask MapTry_execute_valuetask_func_K_on_valuetask_failure_E_returns_failure()
+        {
+            ValueTask<UnitResult<E>> sut = UnitResult.Failure(E.Value).AsValueTask();
+
+            Result<K, E> result = await sut.MapTry(ValueTask_Func_K, ErrorHandler_E);
+
+            AssertFailure(result);
+        }
+
+        [Fact]
+        public async ValueTask MapTry_execute_throwing_valuetask_func_T_E_on_success_E_returns_failure_with_value_from_error_handler()
+        {
+            ValueTask<UnitResult<E>> sut = UnitResult.Success<E>().AsValueTask();
+
+            Result<K, E> result = await sut.MapTry(ValueTask_Throwing_K, ErrorHandler_E);
+
+            AssertFailureFromHandler(result);
+        }
+        #endregion
+
+        #region MapTry for ValueTask<Result<T,E>> with function returning ValueTask<K>
+        [Fact]
+        public async ValueTask MapTry_execute_valuetask_func_T_K_on_valuetask_success_T_E_returns_success()
+        {
+            ValueTask<Result<T, E>> sut = Result.Success<T, E>(T.Value).AsValueTask();
+
+            Result<K, E> result = await sut.MapTry(ValueTask_Func_T_K, ErrorHandler_E);
+
+            AssertSuccess(result);
+        }
+
+        [Fact]
+        public async ValueTask MapTry_execute_valuetask_func_K_on_valuetask_failure_T_E_returns_failure()
+        {
+            ValueTask<Result<T, E>> sut = Result.Failure<T, E>(E.Value).AsValueTask();
+
+            Result<K, E> result = await sut.MapTry(ValueTask_Func_T_K, ErrorHandler_E);
+
+            AssertFailure(result);
+        }
+
+        [Fact]
+        public async ValueTask MapTry_execute_throwing_valuetask_func_K_on_success_T_E_returns_failure_with_value_from_error_handler()
+        {
+            ValueTask<Result<T, E>> sut = Result.Success<T, E>(T.Value).AsValueTask();
+
+            Result<K, E> result = await sut.MapTry(ValueTask_Throwing_T_K, ErrorHandler_E);
+
+            AssertFailureFromHandler(result);
+        }
+        #endregion
+
+    }
+}

--- a/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/MapTryTests.cs
+++ b/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/MapTryTests.cs
@@ -1,0 +1,152 @@
+﻿using FluentAssertions;
+using Xunit;
+
+namespace CSharpFunctionalExtensions.Tests.ResultTests.Extensions
+{
+    public sealed class MapTryTests : MapTryTestsBase
+    {        
+
+        #region MapTry for Result with function returning K
+        [Fact]
+        public void MapTry_execute_func_K_on_success_returns_success()
+        {
+            Result sut = Result.Success();
+
+            Result<K> result = sut.MapTry(Func_K);
+            
+            AssertSuccess(result);
+        }
+        [Fact]
+        public void MapTry_execute_func_K_on_failure_returns_failure()
+        {
+            Result sut = Result.Failure(ErrorMessage);
+
+            Result<K> result = sut.MapTry(Func_K);
+
+            AssertFailure(result);
+        }        
+
+        [Fact]
+        public void MapTry_execute_throwing_func_K_on_success_returns_failure_with_exception_message()
+        {
+            Result sut = Result.Success();
+
+            Result<K> result = sut.MapTry(Throwing_K);
+
+            AssertFailureFromDefaultHandler(result);
+        }
+        [Fact]
+        public void MapTry_execute_throwing_func_K_on_success_with_custom_error_handler_returns_failure_with_custom_message()
+        {
+            Result sut = Result.Success();
+
+            Result<K> result = sut.MapTry(Throwing_K, ErrorHandler);
+
+            AssertFailureFromHandler(result);
+        }
+        #endregion
+
+        #region MapTry for Result<T> with function returning K
+        [Fact]
+        public void MapTry_execute_func_T_K_on_success_T_returns_success_K()
+        {
+            Result<T> sut = Result.Success(T.Value);
+
+            Result<K> result = sut.MapTry(Func_T_K);
+
+            AssertSuccess(result);
+        }
+        [Fact]
+        public void MapTry_execute_func_T_K_on_failure_T_returns_failure_K()
+        {
+            Result<T> sut = Result.Failure<T>(ErrorMessage);
+
+            Result<K> result = sut.MapTry(Func_T_K);
+
+            AssertFailure(result);
+            result.Should().BeOfType<Result<K>>();
+        }        
+
+        [Fact]
+        public void MapTry_execute_throwing_func_T_K_on_success_T_returns_failure_K_with_exception_message()
+        {
+            Result<T> sut = Result.Success(T.Value);
+
+            Result<K> result = sut.MapTry(Throwing_T_K);
+
+            AssertFailureFromDefaultHandler(result);
+        }
+        [Fact]
+        public void MapTry_execute_throwing_func_T_K_on_success_T_with_custom_error_handler_returns_failure_K_with_custom_message()
+        {
+            Result<T> sut = Result.Success(T.Value);
+
+            Result<K> result = sut.MapTry(Throwing_T_K, ErrorHandler);
+
+            AssertFailureFromHandler(result);
+        }
+        #endregion
+
+        #region MapTry for Result<T,E> with function returning K
+        [Fact]
+        public void MapTry_execute_func_T_K_on_success_T_E_returns_success_K_E()
+        {
+            Result<T, E> sut = Result.Success<T, E>(T.Value);
+
+            Result<K, E> result = sut.MapTry(Func_T_K, ErrorHandler_E);
+
+            AssertSuccess(result);            
+        }
+        [Fact]
+        public void MapTry_execute_func_T_K_on_failure_T_E_returns_failure_K_E()
+        {
+            Result<T, E> sut = Result.Failure<T, E>(E.Value);
+
+            Result<K, E> result = sut.MapTry(Func_T_K, ErrorHandler_E);
+
+            AssertFailure(result);            
+        }
+        
+        [Fact]
+        public void MapTry_execute_throwing_func_T_K_on_success_T_E_returns_failure_K_E_with_value_from_error_handler()
+        {
+            Result<T, E> sut = Result.Success<T, E>(T.Value);
+
+            Result<K, E> result = sut.MapTry(Throwing_T_K, ErrorHandler_E);
+
+            AssertFailureFromHandler(result);
+        }
+        #endregion
+
+        #region MapTry for UnitResult<E> with function returning K
+        [Fact]
+        public void MapTry_execute_func_K_on_success_E_returns_success_T_E()
+        {
+            UnitResult<E> sut = UnitResult.Success<E>();
+
+            Result<K, E> result = sut.MapTry(Func_K, ErrorHandler_E);
+
+            AssertSuccess(result);
+        }
+        [Fact]
+        public void MapTry_execute_func_K_on_failure_E_returns_failure_K_E()
+        {
+            UnitResult<E> sut = UnitResult.Failure(E.Value);
+
+            Result<K, E> result = sut.MapTry(Func_K, ErrorHandler_E);
+
+            AssertFailure(result);
+        }        
+
+        [Fact]
+        public void MapTry_execute_throwing_func_K_on_success_E_returns_failure_K_E_with_value_from_error_handler()
+        {
+            UnitResult<E> sut = UnitResult.Success<E>();
+
+            Result<K, E> result = sut.MapTry(Throwing_K, ErrorHandler_E);
+
+            AssertFailureFromHandler(result);
+        }
+        #endregion
+    }
+}

--- a/CSharpFunctionalExtensions.Tests/ResultTests/Methods/CombineTests.cs
+++ b/CSharpFunctionalExtensions.Tests/ResultTests/Methods/CombineTests.cs
@@ -7,6 +7,7 @@ using Xunit;
 
 namespace CSharpFunctionalExtensions.Tests.ResultTests
 {
+    [Collection(NonParallelTestCollectionDefinition.Name)]
     public class CombineTests : TestBase
     {
         [Fact]

--- a/CSharpFunctionalExtensions.Tests/ResultTests/Methods/TryTests.Task.cs
+++ b/CSharpFunctionalExtensions.Tests/ResultTests/Methods/TryTests.Task.cs
@@ -4,6 +4,7 @@ using Xunit;
 
 namespace CSharpFunctionalExtensions.Tests.ResultTests.Methods.Try
 {
+    [Collection(NonParallelTestCollectionDefinition.Name)]
     public class TryTestBaseTestsTask : TryTestBaseTask
     {
         [Fact]
@@ -33,7 +34,7 @@ namespace CSharpFunctionalExtensions.Tests.ResultTests.Methods.Try
             result.Error.Should().Be(ErrorHandlerMessage);
         }
 
-        [Fact]
+        [Fact]        
         public async Task ResultTry_Async_execute_action_failed_with_configured_default_error_handler_failed_result_expected()
         {
             var defaultTryErrorHandler = Result.Configuration.DefaultTryErrorHandler;

--- a/CSharpFunctionalExtensions/CSharpFunctionalExtensions.csproj
+++ b/CSharpFunctionalExtensions/CSharpFunctionalExtensions.csproj
@@ -540,5 +540,23 @@
 	<Compile Update="Result\Methods\Extensions\BindTry.ValueTask.Right.cs">
 		<DependentUpon>BindTry.ValueTask.cs</DependentUpon>
 	</Compile>
+	<Compile Update="Result\Methods\Extensions\MapTry.Task.cs">
+		<DependentUpon>MapTry.cs</DependentUpon>
+	</Compile>
+	<Compile Update="Result\Methods\Extensions\MapTry.ValueTask.cs">
+		<DependentUpon>MapTry.cs</DependentUpon>
+	</Compile>
+	<Compile Update="Result\Methods\Extensions\MapTry.Task.Left.cs">
+		<DependentUpon>MapTry.Task.cs</DependentUpon>
+	</Compile>
+	<Compile Update="Result\Methods\Extensions\MapTry.Task.Right.cs">
+		<DependentUpon>MapTry.Task.cs</DependentUpon>
+	</Compile>
+	<Compile Update="Result\Methods\Extensions\MapTry.ValueTask.Left.cs">
+		<DependentUpon>MapTry.ValueTask.cs</DependentUpon>
+	</Compile>
+	<Compile Update="Result\Methods\Extensions\MapTry.ValueTask.Right.cs">
+		<DependentUpon>MapTry.ValueTask.cs</DependentUpon>
+	</Compile>
   </ItemGroup> 
 </Project>

--- a/CSharpFunctionalExtensions/Result/Methods/Extensions/BindTry.ValueTask.Left.cs
+++ b/CSharpFunctionalExtensions/Result/Methods/Extensions/BindTry.ValueTask.Left.cs
@@ -11,30 +11,30 @@ namespace CSharpFunctionalExtensions.ValueTasks
         ///     If a given function throws an exception, an error is returned from the given error handler
         /// </summary>        
         /// <param name="resultValueTask">Extended result</param>
-        /// <param name="func">Function returning result to bind</param>
+        /// <param name="valueTask">Function returning result to bind</param>
         /// <param name="errorHandler">Error handling function</param>
         /// <returns>Binding result</returns>
-        public static async ValueTask<Result> BindTry(this ValueTask<Result> resultValueTask, Func<Result> func,
+        public static async ValueTask<Result> BindTry(this ValueTask<Result> resultValueTask, Func<Result> valueTask,
             Func<Exception, string> errorHandler = null)
         {
             var result = await resultValueTask;
-            return result.BindTry(func, errorHandler);
+            return result.BindTry(valueTask, errorHandler);
         }
 
         /// <summary>
         ///     Selects result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.
         ///     If a given function throws an exception, an error is returned from the given error handler
         /// </summary>        
-        /// <typeparam name="K"><paramref name="func" /> Result Type parameter</typeparam>        
+        /// <typeparam name="K"><paramref name="valueTask" /> Result Type parameter</typeparam>        
         /// <param name="resultValueTask">Extended result</param>
-        /// <param name="func">Function returning result to bind</param>
+        /// <param name="valueTask">Function returning result to bind</param>
         /// <param name="errorHandler">Error handling function</param>
         /// <returns>Binding result</returns>
-        public static async ValueTask<Result<K>> BindTry<K>(this ValueTask<Result> resultValueTask, Func<Result<K>> func,
+        public static async ValueTask<Result<K>> BindTry<K>(this ValueTask<Result> resultValueTask, Func<Result<K>> valueTask,
             Func<Exception, string> errorHandler = null)
         {
             var result = await resultValueTask;
-            return result.BindTry(func, errorHandler);
+            return result.BindTry(valueTask, errorHandler);
         }
 
         /// <summary>
@@ -43,14 +43,14 @@ namespace CSharpFunctionalExtensions.ValueTasks
         /// </summary>
         /// <typeparam name="T">Result Type parameter</typeparam>        
         /// <param name="resultValueTask">Extended result</param>
-        /// <param name="func">Function returning result to bind</param>
+        /// <param name="valueTask">Function returning result to bind</param>
         /// <param name="errorHandler">Error handling function</param>
         /// <returns>Binding result</returns>
-        public static async ValueTask<Result> BindTry<T>(this ValueTask<Result<T>> resultValueTask, Func<T, Result> func,
+        public static async ValueTask<Result> BindTry<T>(this ValueTask<Result<T>> resultValueTask, Func<T, Result> valueTask,
             Func<Exception, string> errorHandler = null)
         {
             var result = await resultValueTask;
-            return result.BindTry(func, errorHandler);
+            return result.BindTry(valueTask, errorHandler);
         }
 
         /// <summary>
@@ -58,16 +58,16 @@ namespace CSharpFunctionalExtensions.ValueTasks
         ///     If a given function throws an exception, an error is returned from the given error handler
         /// </summary>
         /// <typeparam name="T">Result Type parameter</typeparam>
-        /// <typeparam name="K"><paramref name="func" /> Result Type parameter</typeparam>        
+        /// <typeparam name="K"><paramref name="valueTask" /> Result Type parameter</typeparam>        
         /// <param name="resultValueTask">Extended result</param>
-        /// <param name="func">Function returning result to bind</param>
+        /// <param name="valueTask">Function returning result to bind</param>
         /// <param name="errorHandler">Error handling function</param>
         /// <returns>Binding result</returns>
-        public static async ValueTask<Result<K>> BindTry<T, K>(this ValueTask<Result<T>> resultValueTask, Func<T, Result<K>> func,
+        public static async ValueTask<Result<K>> BindTry<T, K>(this ValueTask<Result<T>> resultValueTask, Func<T, Result<K>> valueTask,
             Func<Exception, string> errorHandler = null)
         {
             var result = await resultValueTask;
-            return result.BindTry(func, errorHandler);
+            return result.BindTry(valueTask, errorHandler);
         }
 
         /// <summary>
@@ -77,14 +77,14 @@ namespace CSharpFunctionalExtensions.ValueTasks
         /// <typeparam name="T">Result Type parameter</typeparam>        
         /// <typeparam name="E">Error Type parameter</typeparam>
         /// <param name="resultValueTask">Extended result</param>
-        /// <param name="func">Function returning result to bind</param>
+        /// <param name="valueTask">Function returning result to bind</param>
         /// <param name="errorHandler">Error handling function</param>
         /// <returns>Binding result</returns>
-        public static async ValueTask<UnitResult<E>> BindTry<T, E>(this ValueTask<Result<T, E>> resultValueTask, Func<T, UnitResult<E>> func,
+        public static async ValueTask<UnitResult<E>> BindTry<T, E>(this ValueTask<Result<T, E>> resultValueTask, Func<T, UnitResult<E>> valueTask,
             Func<Exception, E> errorHandler)
         {
             var result = await resultValueTask;
-            return result.BindTry(func, errorHandler);
+            return result.BindTry(valueTask, errorHandler);
         }
 
         /// <summary>
@@ -92,17 +92,17 @@ namespace CSharpFunctionalExtensions.ValueTasks
         ///     If a given function throws an exception, an error is returned from the given error handler
         /// </summary>
         /// <typeparam name="T">Result Type parameter</typeparam>
-        /// <typeparam name="K"><paramref name="func" /> Result Type parameter</typeparam>
+        /// <typeparam name="K"><paramref name="valueTask" /> Result Type parameter</typeparam>
         /// <typeparam name="E">Error Type parameter</typeparam>
         /// <param name="resultValueTask">Extended result</param>
-        /// <param name="func">Function returning result to bind</param>
+        /// <param name="valueTask">Function returning result to bind</param>
         /// <param name="errorHandler">Error handling function</param>
         /// <returns>Binding result</returns>
-        public static async ValueTask<Result<K, E>> BindTry<T, K, E>(this ValueTask<Result<T, E>> resultValueTask, Func<T, Result<K, E>> func,
+        public static async ValueTask<Result<K, E>> BindTry<T, K, E>(this ValueTask<Result<T, E>> resultValueTask, Func<T, Result<K, E>> valueTask,
             Func<Exception, E> errorHandler)
         {
             var result = await resultValueTask;
-            return result.BindTry(func, errorHandler);
+            return result.BindTry(valueTask, errorHandler);
         }
 
         /// <summary>
@@ -111,14 +111,14 @@ namespace CSharpFunctionalExtensions.ValueTasks
         /// </summary>        
         /// <typeparam name="E">Error Type parameter</typeparam>
         /// <param name="resultValueTask">Extended result</param>
-        /// <param name="func">Function returning result to bind</param>
+        /// <param name="valueTask">Function returning result to bind</param>
         /// <param name="errorHandler">Error handling function</param>
         /// <returns>Binding result</returns>
-        public static async ValueTask<UnitResult<E>> BindTry<E>(this ValueTask<UnitResult<E>> resultValueTask, Func<UnitResult<E>> func,
+        public static async ValueTask<UnitResult<E>> BindTry<E>(this ValueTask<UnitResult<E>> resultValueTask, Func<UnitResult<E>> valueTask,
             Func<Exception, E> errorHandler)
         {
             var result = await resultValueTask;
-            return result.BindTry(func, errorHandler);
+            return result.BindTry(valueTask, errorHandler);
         }
 
         /// <summary>
@@ -128,14 +128,14 @@ namespace CSharpFunctionalExtensions.ValueTasks
         /// <typeparam name="T">Result Type parameter</typeparam>        
         /// <typeparam name="E">Error Type parameter</typeparam>
         /// <param name="resultValueTask">Extended result</param>
-        /// <param name="func">Function returning result to bind</param>
+        /// <param name="valueTask">Function returning result to bind</param>
         /// <param name="errorHandler">Error handling function</param>
         /// <returns>Binding result</returns>
-        public static async ValueTask<Result<T, E>> BindTry<T, E>(this ValueTask<UnitResult<E>> resultValueTask, Func<Result<T, E>> func,
+        public static async ValueTask<Result<T, E>> BindTry<T, E>(this ValueTask<UnitResult<E>> resultValueTask, Func<Result<T, E>> valueTask,
             Func<Exception, E> errorHandler)
         {
             var result = await resultValueTask;
-            return result.BindTry(func, errorHandler);
+            return result.BindTry(valueTask, errorHandler);
         }        
     }
 }

--- a/CSharpFunctionalExtensions/Result/Methods/Extensions/BindTry.ValueTask.Right.cs
+++ b/CSharpFunctionalExtensions/Result/Methods/Extensions/BindTry.ValueTask.Right.cs
@@ -11,18 +11,18 @@ namespace CSharpFunctionalExtensions.ValueTasks
         ///     If a given function throws an exception, an error is returned from the given error handler
         /// </summary>
         /// <typeparam name="T">Result Type parameter</typeparam>
-        /// <typeparam name="K"><paramref name="func" /> Result Type parameter</typeparam>
+        /// <typeparam name="K"><paramref name="valueTask" /> Result Type parameter</typeparam>
         /// <typeparam name="E">Error Type parameter</typeparam>
         /// <param name="result">Extended result</param>
-        /// <param name="func">Function returning result to bind</param>
+        /// <param name="valueTask">Function returning result to bind</param>
         /// <param name="errorHandler">Error handling function</param>
         /// <returns>Binding result</returns>
-        public static async ValueTask<Result<K, E>> BindTry<T, K, E>(this Result<T, E> result, Func<T, ValueTask<Result<K, E>>> func,
+        public static async ValueTask<Result<K, E>> BindTry<T, K, E>(this Result<T, E> result, Func<T, ValueTask<Result<K, E>>> valueTask,
             Func<Exception, E> errorHandler)
         {
             return result.IsFailure
                 ? Result.Failure<K, E>(result.Error)
-                : await Result.Try(() => func(result.Value),errorHandler).Bind(r => r);
+                : await Result.Try(async () => await valueTask(result.Value),errorHandler).Bind(r => r);
         }
 
         /// <summary>
@@ -30,34 +30,34 @@ namespace CSharpFunctionalExtensions.ValueTasks
         ///     If a given function throws an exception, an error is returned from the given error handler
         /// </summary>
         /// <typeparam name="T">Result Type parameter</typeparam>
-        /// <typeparam name="K"><paramref name="func" /> Result Type parameter</typeparam>        
+        /// <typeparam name="K"><paramref name="valueTask" /> Result Type parameter</typeparam>        
         /// <param name="result">Extended result</param>
-        /// <param name="func">Function returning result to bind</param>
+        /// <param name="valueTask">Function returning result to bind</param>
         /// <param name="errorHandler">Error handling function</param>
         /// <returns>Binding result</returns>
-        public static async ValueTask<Result<K>> BindTry<T, K>(this Result<T> result, Func<T, ValueTask<Result<K>>> func,
+        public static async ValueTask<Result<K>> BindTry<T, K>(this Result<T> result, Func<T, ValueTask<Result<K>>> valueTask,
             Func<Exception, string> errorHandler = null)
         {
             return result.IsFailure
                 ? Result.Failure<K>(result.Error)
-                : await Result.Try(() => func(result.Value), errorHandler).Bind(r => r);
+                : await Result.Try(async () => await valueTask(result.Value), errorHandler).Bind(r => r);
         }
 
         /// <summary>
         ///     Selects result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.
         ///     If a given function throws an exception, an error is returned from the given error handler
         /// </summary>        
-        /// <typeparam name="K"><paramref name="func" /> Result Type parameter</typeparam>        
+        /// <typeparam name="K"><paramref name="valueTask" /> Result Type parameter</typeparam>        
         /// <param name="result">Extended result</param>
-        /// <param name="func">Function returning result to bind</param>
+        /// <param name="valueTask">Function returning result to bind</param>
         /// <param name="errorHandler">Error handling function</param>
         /// <returns>Binding result</returns>
-        public static async ValueTask<Result<K>> BindTry<K>(this Result result, Func<ValueTask<Result<K>>> func,
+        public static async ValueTask<Result<K>> BindTry<K>(this Result result, Func<ValueTask<Result<K>>> valueTask,
             Func<Exception, string> errorHandler = null)
         {
             return result.IsFailure
                 ? Result.Failure<K>(result.Error)
-                : await Result.Try(() => func(), errorHandler).Bind(r => r);
+                : await Result.Try(async () => await valueTask(), errorHandler).Bind(r => r);
         }
 
         /// <summary>
@@ -66,15 +66,15 @@ namespace CSharpFunctionalExtensions.ValueTasks
         /// </summary>
         /// <typeparam name="T">Result Type parameter</typeparam>        
         /// <param name="result">Extended result</param>
-        /// <param name="func">Function returning result to bind</param>
+        /// <param name="valueTask">Function returning result to bind</param>
         /// <param name="errorHandler">Error handling function</param>
         /// <returns>Binding result</returns>
-        public static async ValueTask<Result> BindTry<T>(this Result<T> result, Func<T, ValueTask<Result>> func,
+        public static async ValueTask<Result> BindTry<T>(this Result<T> result, Func<T, ValueTask<Result>> valueTask,
             Func<Exception, string> errorHandler = null)
         {
             return result.IsFailure
                 ? Result.Failure(result.Error)
-                : await Result.Try(() => func(result.Value), errorHandler).Bind(r => r);
+                : await Result.Try(async () => await valueTask(result.Value), errorHandler).Bind(r => r);
         }
 
         /// <summary>
@@ -82,15 +82,15 @@ namespace CSharpFunctionalExtensions.ValueTasks
         ///     If a given function throws an exception, an error is returned from the given error handler
         /// </summary>        
         /// <param name="result">Extended result</param>
-        /// <param name="func">Function returning result to bind</param>
+        /// <param name="valueTask">Function returning result to bind</param>
         /// <param name="errorHandler">Error handling function</param>
         /// <returns>Binding result</returns>
-        public static async ValueTask<Result> BindTry(this Result result, Func<ValueTask<Result>> func,
+        public static async ValueTask<Result> BindTry(this Result result, Func<ValueTask<Result>> valueTask,
             Func<Exception, string> errorHandler = null)
         {
             return result.IsFailure
                 ? Result.Failure(result.Error)
-                : await Result.Try(() => func(), errorHandler).Bind(r => r);
+                : await Result.Try(async () => await valueTask(), errorHandler).Bind(r => r);
         }
 
         /// <summary>
@@ -99,15 +99,15 @@ namespace CSharpFunctionalExtensions.ValueTasks
         /// </summary>        
         /// <typeparam name="E">Error Type parameter</typeparam>
         /// <param name="result">Extended result</param>
-        /// <param name="func">Function returning result to bind</param>
+        /// <param name="valueTask">Function returning result to bind</param>
         /// <param name="errorHandler">Error handling function</param>
         /// <returns>Binding result</returns>
-        public static async ValueTask<UnitResult<E>> BindTry<E>(this UnitResult<E> result, Func<ValueTask<UnitResult<E>>> func,
+        public static async ValueTask<UnitResult<E>> BindTry<E>(this UnitResult<E> result, Func<ValueTask<UnitResult<E>>> valueTask,
             Func<Exception, E> errorHandler)
         {            
             return result.IsFailure
                 ? UnitResult.Failure(result.Error)
-                : await Result.Try(() => func(), errorHandler).Bind(r => r);
+                : await Result.Try(async () => await valueTask(), errorHandler).Bind(r => r);
         }
 
         /// <summary>
@@ -117,15 +117,15 @@ namespace CSharpFunctionalExtensions.ValueTasks
         /// <typeparam name="T">Result Type parameter</typeparam>        
         /// <typeparam name="E">Error Type parameter</typeparam>
         /// <param name="result">Extended result</param>
-        /// <param name="func">Function returning result to bind</param>
+        /// <param name="valueTask">Function returning result to bind</param>
         /// <param name="errorHandler">Error handling function</param>
         /// <returns>Binding result</returns>
-        public static async ValueTask<Result<T, E>> BindTry<T, E>(this UnitResult<E> result, Func<ValueTask<Result<T, E>>> func,
+        public static async ValueTask<Result<T, E>> BindTry<T, E>(this UnitResult<E> result, Func<ValueTask<Result<T, E>>> valueTask,
             Func<Exception, E> errorHandler)
         {
             return result.IsFailure
                 ? Result.Failure<T,E>(result.Error)
-                : await Result.Try(() => func(), errorHandler).Bind(r => r);
+                : await Result.Try(async () => await valueTask(), errorHandler).Bind(r => r);
         }
 
         /// <summary>
@@ -135,15 +135,15 @@ namespace CSharpFunctionalExtensions.ValueTasks
         /// <typeparam name="T">Result Type parameter</typeparam>        
         /// <typeparam name="E">Error Type parameter</typeparam>
         /// <param name="result">Extended result</param>
-        /// <param name="func">Function returning result to bind</param>
+        /// <param name="valueTask">Function returning result to bind</param>
         /// <param name="errorHandler">Error handling function</param>
         /// <returns>Binding result</returns>
-        public static async ValueTask<UnitResult<E>> BindTry<T, E>(this Result<T, E> result, Func<T, ValueTask<UnitResult<E>>> func,
+        public static async ValueTask<UnitResult<E>> BindTry<T, E>(this Result<T, E> result, Func<T, ValueTask<UnitResult<E>>> valueTask,
             Func<Exception, E> errorHandler)
         {
             return result.IsFailure
                 ? UnitResult.Failure(result.Error)
-                : await Result.Try(() => func(result.Value), errorHandler).Bind(r => r);           
+                : await Result.Try(async () => await valueTask(result.Value), errorHandler).Bind(r => r);           
         }
     }
 }

--- a/CSharpFunctionalExtensions/Result/Methods/Extensions/BindTry.ValueTask.cs
+++ b/CSharpFunctionalExtensions/Result/Methods/Extensions/BindTry.ValueTask.cs
@@ -11,30 +11,30 @@ namespace CSharpFunctionalExtensions.ValueTasks
         ///     If a given function throws an exception, an error is returned from the given error handler
         /// </summary>        
         /// <param name="resultTask">Extended result</param>
-        /// <param name="func">Function returning result to bind</param>
+        /// <param name="valueTask">Function returning result to bind</param>
         /// <param name="errorHandler">Error handling function</param>
         /// <returns>Binding result</returns>
-        public static async ValueTask<Result> BindTry(this ValueTask<Result> resultTask, Func<ValueTask<Result>> func,
+        public static async ValueTask<Result> BindTry(this ValueTask<Result> resultTask, Func<ValueTask<Result>> valueTask,
 			Func<Exception, string> errorHandler = null)
 		{            
 			var result = await resultTask;
-			return await result.BindTry(func, errorHandler);
+			return await result.BindTry(valueTask, errorHandler);
 		}
 
         /// <summary>
         ///     Selects result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.
         ///     If a given function throws an exception, an error is returned from the given error handler
         /// </summary>        
-        /// <typeparam name="K"><paramref name="func" /> Result Type parameter</typeparam>        
+        /// <typeparam name="K"><paramref name="valueTask" /> Result Type parameter</typeparam>        
         /// <param name="resultTask">Extended result</param>
-        /// <param name="func">Function returning result to bind</param>
+        /// <param name="valueTask">Function returning result to bind</param>
         /// <param name="errorHandler">Error handling function</param>
         /// <returns>Binding result</returns>
-        public static async ValueTask<Result<K>> BindTry<K>(this ValueTask<Result> resultTask, Func<ValueTask<Result<K>>> func,
+        public static async ValueTask<Result<K>> BindTry<K>(this ValueTask<Result> resultTask, Func<ValueTask<Result<K>>> valueTask,
             Func<Exception, string> errorHandler = null)
         {
             var result = await resultTask;
-            return await result.BindTry(func, errorHandler);
+            return await result.BindTry(valueTask, errorHandler);
         }
 
         /// <summary>
@@ -43,14 +43,14 @@ namespace CSharpFunctionalExtensions.ValueTasks
         /// </summary>
         /// <typeparam name="T">Result Type parameter</typeparam>        
         /// <param name="resultTask">Extended result</param>
-        /// <param name="func">Function returning result to bind</param>
+        /// <param name="valueTask">Function returning result to bind</param>
         /// <param name="errorHandler">Error handling function</param>
         /// <returns>Binding result</returns>
-        public static async ValueTask<Result> BindTry<T>(this ValueTask<Result<T>> resultTask, Func<T, ValueTask<Result>> func,
+        public static async ValueTask<Result> BindTry<T>(this ValueTask<Result<T>> resultTask, Func<T, ValueTask<Result>> valueTask,
 			Func<Exception, string> errorHandler = null)
 		{
 			var result = await resultTask;
-			return await result.BindTry(func, errorHandler);
+			return await result.BindTry(valueTask, errorHandler);
 		}
 
         /// <summary>
@@ -58,16 +58,16 @@ namespace CSharpFunctionalExtensions.ValueTasks
         ///     If a given function throws an exception, an error is returned from the given error handler
         /// </summary>    
         /// <typeparam name="T">Result Type parameter</typeparam>
-        /// <typeparam name="K"><paramref name="func" /> Result Type parameter</typeparam>        
+        /// <typeparam name="K"><paramref name="valueTask" /> Result Type parameter</typeparam>        
         /// <param name="resultTask">Extended result</param>
-        /// <param name="func">Function returning result to bind</param>
+        /// <param name="valueTask">Function returning result to bind</param>
         /// <param name="errorHandler">Error handling function</param>
         /// <returns>Binding result</returns>
-        public static async ValueTask<Result<K>> BindTry<T, K>(this ValueTask<Result<T>> resultTask, Func<T, ValueTask<Result<K>>> func,
+        public static async ValueTask<Result<K>> BindTry<T, K>(this ValueTask<Result<T>> resultTask, Func<T, ValueTask<Result<K>>> valueTask,
             Func<Exception, string> errorHandler = null)
         {
             var result = await resultTask;
-            return await result.BindTry(func, errorHandler);
+            return await result.BindTry(valueTask, errorHandler);
         }
 
         /// <summary>
@@ -77,14 +77,14 @@ namespace CSharpFunctionalExtensions.ValueTasks
         /// <typeparam name="T">Result Type parameter</typeparam>
         /// <typeparam name="E">Error Type parameter</typeparam>
         /// <param name="resultTask">Extended result</param>
-        /// <param name="func">Function returning result to bind</param>
+        /// <param name="valueTask">Function returning result to bind</param>
         /// <param name="errorHandler">Error handling function</param>
         /// <returns>Binding result</returns>
-        public static async ValueTask<UnitResult<E>> BindTry<T, E>(this ValueTask<Result<T, E>> resultTask, Func<T, ValueTask<UnitResult<E>>> func,
+        public static async ValueTask<UnitResult<E>> BindTry<T, E>(this ValueTask<Result<T, E>> resultTask, Func<T, ValueTask<UnitResult<E>>> valueTask,
             Func<Exception, E> errorHandler)
         {
             var result = await resultTask;
-            return await result.BindTry(func, errorHandler);
+            return await result.BindTry(valueTask, errorHandler);
         }
 
         /// <summary>
@@ -92,17 +92,17 @@ namespace CSharpFunctionalExtensions.ValueTasks
         ///     If a given function throws an exception, an error is returned from the given error handler
         /// </summary>
         /// <typeparam name="T">Result Type parameter</typeparam>
-        /// <typeparam name="K"><paramref name="func" /> Result Type parameter</typeparam>
+        /// <typeparam name="K"><paramref name="valueTask" /> Result Type parameter</typeparam>
         /// <typeparam name="E">Error Type parameter</typeparam>
         /// <param name="resultTask">Extended result</param>
-        /// <param name="func">Function returning result to bind</param>
+        /// <param name="valueTask">Function returning result to bind</param>
         /// <param name="errorHandler">Error handling function</param>
         /// <returns>Binding result</returns>
-        public static async ValueTask<Result<K, E>> BindTry<T, K, E>(this ValueTask<Result<T, E>> resultTask, Func<T, ValueTask<Result<K, E>>> func,
+        public static async ValueTask<Result<K, E>> BindTry<T, K, E>(this ValueTask<Result<T, E>> resultTask, Func<T, ValueTask<Result<K, E>>> valueTask,
 			Func<Exception, E> errorHandler)
 		{
 			var result = await resultTask;
-			return await result.BindTry(func, errorHandler);
+			return await result.BindTry(valueTask, errorHandler);
 		}
 
         /// <summary>
@@ -112,14 +112,14 @@ namespace CSharpFunctionalExtensions.ValueTasks
         /// <typeparam name="T">Result Type parameter</typeparam>
         /// <typeparam name="E">Error Type parameter</typeparam>
         /// <param name="resultTask">Extended result</param>
-        /// <param name="func">Function returning result to bind</param>
+        /// <param name="valueTask">Function returning result to bind</param>
         /// <param name="errorHandler">Error handling function</param>
         /// <returns>Binding result</returns>
-		public static async ValueTask<Result<T, E>> BindTry<T, E>(this ValueTask<UnitResult<E>> resultTask, Func<ValueTask<Result<T, E>>> func,
+		public static async ValueTask<Result<T, E>> BindTry<T, E>(this ValueTask<UnitResult<E>> resultTask, Func<ValueTask<Result<T, E>>> valueTask,
             Func<Exception, E> errorHandler)
         {
             var result = await resultTask;
-            return await result.BindTry(func, errorHandler);
+            return await result.BindTry(valueTask, errorHandler);
         }
 
 
@@ -129,14 +129,14 @@ namespace CSharpFunctionalExtensions.ValueTasks
         /// </summary>        
         /// <typeparam name="E">Error Type parameter</typeparam>
         /// <param name="resultTask">Extended result</param>
-        /// <param name="func">Function returning result to bind</param>
+        /// <param name="valueTask">Function returning result to bind</param>
         /// <param name="errorHandler">Error handling function</param>
         /// <returns>Binding result</returns>
-        public static async ValueTask<UnitResult<E>> BindTry<E>(this ValueTask<UnitResult<E>> resultTask, Func<ValueTask<UnitResult<E>>> func,
+        public static async ValueTask<UnitResult<E>> BindTry<E>(this ValueTask<UnitResult<E>> resultTask, Func<ValueTask<UnitResult<E>>> valueTask,
 			Func<Exception, E> errorHandler)
 		{
 			var result = await resultTask;
-			return await result.BindTry(func, errorHandler);
+			return await result.BindTry(valueTask, errorHandler);
 		}			
 	}
 }

--- a/CSharpFunctionalExtensions/Result/Methods/Extensions/MapTry.Task.Left.cs
+++ b/CSharpFunctionalExtensions/Result/Methods/Extensions/MapTry.Task.Left.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using System.Threading.Tasks;
+
+namespace CSharpFunctionalExtensions
+{
+    public static partial class AsyncResultExtensionsLeftOperand
+    {
+        /// <summary>
+        ///     Creates a new result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.
+        ///     If a given function throws an exception, an error is returned from the given error handler
+        /// </summary>
+        public static async Task<Result<K, E>> MapTry<T, K, E>(this Task<Result<T, E>> resultTask, Func<T, K> func,
+            Func<Exception, E> errorHandler)
+        {
+            Result<T, E> result = await resultTask.DefaultAwait();
+            return result.MapTry(func, errorHandler);
+        }
+
+        /// <summary>
+        ///     Creates a new result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.
+        ///     If a given function throws an exception, an error is returned from the given error handler
+        /// </summary>
+        public static async Task<Result<K, E>> MapTry<K, E>(this Task<UnitResult<E>> resultTask, Func<K> func,
+            Func<Exception, E> errorHandler)
+        {
+            UnitResult<E> result = await resultTask.DefaultAwait();
+            return result.MapTry(func, errorHandler);
+        }
+
+        /// <summary>
+        ///     Creates a new result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.
+        ///     If a given function throws an exception, an error is returned from the given error handler
+        /// </summary>
+        public static async Task<Result<K>> MapTry<T, K>(this Task<Result<T>> resultTask, Func<T, K> func,
+            Func<Exception, string> errorHandler = null)
+        {
+            Result<T> result = await resultTask.DefaultAwait();
+            return result.MapTry(func, errorHandler);
+        }
+
+        /// <summary>
+        ///     Creates a new result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.
+        ///     If a given function throws an exception, an error is returned from the given error handler
+        /// </summary>
+        public static async Task<Result<K>> MapTry<K>(this Task<Result> resultTask, Func<K> func,
+            Func<Exception, string> errorHandler = null)
+        {
+            Result result = await resultTask.DefaultAwait();
+            return result.MapTry(func, errorHandler);
+        }
+    }
+}

--- a/CSharpFunctionalExtensions/Result/Methods/Extensions/MapTry.Task.Right.cs
+++ b/CSharpFunctionalExtensions/Result/Methods/Extensions/MapTry.Task.Right.cs
@@ -1,0 +1,56 @@
+﻿using System;
+using System.Threading.Tasks;
+
+namespace CSharpFunctionalExtensions
+{
+    public static partial class AsyncResultExtensionsRightOperand
+    {
+        /// <summary>
+        ///     Creates a new result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.
+        ///     If a given function throws an exception, an error is returned from the given error handler
+        /// </summary>
+        public static async Task<Result<K, E>> MapTry<T, K, E>(this Result<T, E> result, Func<T, Task<K>> func,
+            Func<Exception, E> errorHandler)
+        {
+            return result.IsFailure
+                ? Result.Failure<K, E>(result.Error)
+                : await Result.Try(() => func(result.Value), errorHandler).DefaultAwait();
+        }
+
+        /// <summary>
+        ///     Creates a new result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.
+        ///     If a given function throws an exception, an error is returned from the given error handler
+        /// </summary>
+        public static async Task<Result<K, E>> MapTry<K, E>(this UnitResult<E> result, Func<Task<K>> func,
+            Func<Exception, E> errorHandler)
+        {
+            return result.IsFailure
+                ? Result.Failure<K, E>(result.Error)
+                : await Result.Try(() => func(), errorHandler).DefaultAwait();
+        }
+
+        /// <summary>
+        ///     Creates a new result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.
+        ///     If a given function throws an exception, an error is returned from the given error handler
+        /// </summary>
+        public static async Task<Result<K>> MapTry<T, K>(this Result<T> result, Func<T, Task<K>> func,
+            Func<Exception, string> errorHandler = null)
+        {
+            return result.IsFailure
+                ? Result.Failure<K>(result.Error)
+                : await Result.Try(() => func(result.Value), errorHandler).DefaultAwait();
+        }
+
+        /// <summary>
+        ///     Creates a new result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.
+        ///     If a given function throws an exception, an error is returned from the given error handler
+        /// </summary>
+        public static async Task<Result<K>> MapTry<K>(this Result result, Func<Task<K>> func,
+            Func<Exception, string> errorHandler = null)
+        {
+            return result.IsFailure
+                ? Result.Failure<K>(result.Error)
+                : await Result.Try(() => func(), errorHandler).DefaultAwait();
+        }
+    }
+}

--- a/CSharpFunctionalExtensions/Result/Methods/Extensions/MapTry.Task.cs
+++ b/CSharpFunctionalExtensions/Result/Methods/Extensions/MapTry.Task.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using System.Threading.Tasks;
+
+namespace CSharpFunctionalExtensions
+{
+    public static partial class AsyncResultExtensionsBothOperands
+    {
+        /// <summary>
+        ///     Creates a new result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.
+        ///     If a given function throws an exception, an error is returned from the given error handler
+        /// </summary>
+        public static async Task<Result<K, E>> MapTry<T, K, E>(this Task<Result<T, E>> resultTask, Func<T, Task<K>> func,
+            Func<Exception, E> errorHandler)
+        {
+            var result = await resultTask.DefaultAwait();
+            return await result.MapTry(func, errorHandler).DefaultAwait();
+        }
+
+        /// <summary>
+        ///     Creates a new result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.
+        ///     If a given function throws an exception, an error is returned from the given error handler
+        /// </summary>
+        public static async Task<Result<K, E>> MapTry<K, E>(this Task<UnitResult<E>> resultTask, Func<Task<K>> func,
+            Func<Exception, E> errorHandler)
+        {
+            var result = await resultTask.DefaultAwait();
+            return await result.MapTry(func, errorHandler).DefaultAwait();
+        }
+
+        /// <summary>
+        ///     Creates a new result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.
+        ///     If a given function throws an exception, an error is returned from the given error handler
+        /// </summary>
+        public static async Task<Result<K>> MapTry<T, K>(this Task<Result<T>> resultTask, Func<T, Task<K>> func,
+            Func<Exception, string> errorHandler = null)
+        {
+            var result = await resultTask.DefaultAwait();
+            return await result.MapTry(func, errorHandler).DefaultAwait();
+        }
+
+        /// <summary>
+        ///     Creates a new result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.
+        ///     If a given function throws an exception, an error is returned from the given error handler
+        /// </summary>
+        public static async Task<Result<K>> MapTry<K>(this Task<Result> resultTask, Func<Task<K>> func,
+            Func<Exception, string> errorHandler = null)
+        {
+            var result = await resultTask.DefaultAwait();
+            return await result.MapTry(func, errorHandler).DefaultAwait();
+        }
+    }
+}

--- a/CSharpFunctionalExtensions/Result/Methods/Extensions/MapTry.ValueTask.Left.cs
+++ b/CSharpFunctionalExtensions/Result/Methods/Extensions/MapTry.ValueTask.Left.cs
@@ -1,0 +1,54 @@
+﻿#if NET5_0_OR_GREATER
+using System;
+using System.Threading.Tasks;
+
+namespace CSharpFunctionalExtensions.ValueTasks
+{
+    public static partial class AsyncResultExtensionsLeftOperand
+    {
+        /// <summary>
+        ///     Creates a new result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.
+        ///     If a given function throws an exception, an error is returned from the given error handler
+        /// </summary>
+        public static async ValueTask<Result<K, E>> MapTry<T, K, E>(this ValueTask<Result<T, E>> resultTask, Func<T, K> valueTask,
+            Func<Exception, E> errorHandler)
+        {
+            Result<T, E> result = await resultTask;
+            return result.MapTry(valueTask, errorHandler);
+        }
+
+        /// <summary>
+        ///     Creates a new result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.
+        ///     If a given function throws an exception, an error is returned from the given error handler
+        /// </summary>
+        public static async ValueTask<Result<K, E>> MapTry<K, E>(this ValueTask<UnitResult<E>> resultTask, Func<K> valueTask,
+            Func<Exception, E> errorHandler)
+        {
+            UnitResult<E> result = await resultTask;
+            return result.MapTry(valueTask, errorHandler);
+        }
+
+        /// <summary>
+        ///     Creates a new result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.
+        ///     If a given function throws an exception, an error is returned from the given error handler
+        /// </summary>
+        public static async ValueTask<Result<K>> MapTry<T, K>(this ValueTask<Result<T>> resultTask, Func<T, K> valueTask,
+            Func<Exception, string> errorHandler = null)
+        {
+            Result<T> result = await resultTask;
+            return result.MapTry(valueTask, errorHandler);
+        }
+
+        /// <summary>
+        ///     Creates a new result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.
+        ///     If a given function throws an exception, an error is returned from the given error handler
+        /// </summary>
+        public static async ValueTask<Result<K>> MapTry<K>(this ValueTask<Result> resultTask, Func<K> valueTask,
+            Func<Exception, string> errorHandler = null)
+        {
+            Result result = await resultTask;
+            return result.MapTry(valueTask, errorHandler);
+        }
+    }
+}
+#endif

--- a/CSharpFunctionalExtensions/Result/Methods/Extensions/MapTry.ValueTask.Right.cs
+++ b/CSharpFunctionalExtensions/Result/Methods/Extensions/MapTry.ValueTask.Right.cs
@@ -1,0 +1,58 @@
+﻿#if NET5_0_OR_GREATER
+using System;
+using System.Threading.Tasks;
+
+namespace CSharpFunctionalExtensions.ValueTasks
+{
+    public static partial class AsyncResultExtensionsRightOperand
+    {
+        /// <summary>
+        ///     Creates a new result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.
+        ///     If a given function throws an exception, an error is returned from the given error handler
+        /// </summary>
+        public static async ValueTask<Result<K, E>> MapTry<T, K, E>(this Result<T, E> result, Func<T, ValueTask<K>> valueTask,
+            Func<Exception, E> errorHandler)
+        {
+            return result.IsFailure
+                ? Result.Failure<K, E>(result.Error)
+                : await Result.Try(async () => await valueTask(result.Value), errorHandler).DefaultAwait();
+        }
+
+        /// <summary>
+        ///     Creates a new result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.
+        ///     If a given function throws an exception, an error is returned from the given error handler
+        /// </summary>
+        public static async ValueTask<Result<K, E>> MapTry<K, E>(this UnitResult<E> result, Func<ValueTask<K>> valueTask,
+            Func<Exception, E> errorHandler)
+        {
+            return result.IsFailure
+                ? Result.Failure<K, E>(result.Error)
+                : await Result.Try(async () => await valueTask(), errorHandler).DefaultAwait();
+        }
+
+        /// <summary>
+        ///     Creates a new result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.
+        ///     If a given function throws an exception, an error is returned from the given error handler
+        /// </summary>
+        public static async ValueTask<Result<K>> MapTry<T, K>(this Result<T> result, Func<T, ValueTask<K>> valueTask,
+            Func<Exception, string> errorHandler = null)
+        {
+            return result.IsFailure
+                ? Result.Failure<K>(result.Error)
+                : await Result.Try(async () => await valueTask(result.Value), errorHandler).DefaultAwait();
+        }
+
+        /// <summary>
+        ///     Creates a new result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.
+        ///     If a given function throws an exception, an error is returned from the given error handler
+        /// </summary>
+        public static async ValueTask<Result<K>> MapTry<K>(this Result result, Func<ValueTask<K>> valueTask,
+            Func<Exception, string> errorHandler = null)
+        {
+            return result.IsFailure
+                ? Result.Failure<K>(result.Error)
+                : await Result.Try(async () => await valueTask(), errorHandler).DefaultAwait();
+        }
+    }
+}
+#endif

--- a/CSharpFunctionalExtensions/Result/Methods/Extensions/MapTry.ValueTask.cs
+++ b/CSharpFunctionalExtensions/Result/Methods/Extensions/MapTry.ValueTask.cs
@@ -1,0 +1,54 @@
+﻿#if NET5_0_OR_GREATER
+using System;
+using System.Threading.Tasks;
+
+namespace CSharpFunctionalExtensions.ValueTasks
+{
+    public static partial class AsyncResultExtensionsBothOperands
+    {
+        /// <summary>
+        ///     Creates a new result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.
+        ///     If a given function throws an exception, an error is returned from the given error handler
+        /// </summary>
+        public static async ValueTask<Result<K, E>> MapTry<T, K, E>(this ValueTask<Result<T, E>> resultTask, Func<T, ValueTask<K>> valueTask,
+            Func<Exception, E> errorHandler)
+        {
+            var result = await resultTask;
+            return await result.MapTry(valueTask, errorHandler);
+        }
+
+        /// <summary>
+        ///     Creates a new result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.
+        ///     If a given function throws an exception, an error is returned from the given error handler
+        /// </summary>
+        public static async ValueTask<Result<K, E>> MapTry<K, E>(this ValueTask<UnitResult<E>> resultTask, Func<ValueTask<K>> valueTask,
+            Func<Exception, E> errorHandler)
+        {
+            var result = await resultTask;
+            return await result.MapTry(valueTask, errorHandler);
+        }
+
+        /// <summary>
+        ///     Creates a new result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.
+        ///     If a given function throws an exception, an error is returned from the given error handler
+        /// </summary>
+        public static async ValueTask<Result<K>> MapTry<T, K>(this ValueTask<Result<T>> resultTask, Func<T, ValueTask<K>> valueTask,
+            Func<Exception, string> errorHandler = null)
+        {
+            var result = await resultTask;
+            return await result.MapTry(valueTask, errorHandler);
+        }
+
+        /// <summary>
+        ///     Creates a new result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.
+        ///     If a given function throws an exception, an error is returned from the given error handler
+        /// </summary>
+        public static async ValueTask<Result<K>> MapTry<K>(this ValueTask<Result> resultTask, Func<ValueTask<K>> valueTask,
+            Func<Exception, string> errorHandler = null)
+        {
+            var result = await resultTask;
+            return await result.MapTry(valueTask, errorHandler);
+        }
+    }
+}
+#endif

--- a/CSharpFunctionalExtensions/Result/Methods/Extensions/MapTry.cs
+++ b/CSharpFunctionalExtensions/Result/Methods/Extensions/MapTry.cs
@@ -1,0 +1,55 @@
+﻿using System;
+
+namespace CSharpFunctionalExtensions
+{
+    public static partial class ResultExtensions
+    {
+        /// <summary>
+        ///     Creates a new result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.
+        ///     If a given function throws an exception, an error is returned from the given error handler
+        /// </summary>
+        public static Result<K, E> MapTry<T, K, E>(this Result<T, E> result, Func<T, K> func,
+            Func<Exception, E> errorHandler)
+        {
+            return result.IsFailure
+                ? Result.Failure<K, E>(result.Error)
+                : Result.Try(() => func(result.Value), errorHandler);  
+        }
+
+        /// <summary>
+        ///     Creates a new result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.
+        ///     If a given function throws an exception, an error is returned from the given error handler
+        /// </summary>
+        public static Result<K, E> MapTry<K, E>(this UnitResult<E> result, Func<K> func,
+            Func<Exception, E> errorHandler)
+        {
+            return result.IsFailure
+                ? Result.Failure<K, E>(result.Error)
+                : Result.Try(() => func(), errorHandler);
+        }
+
+        /// <summary>
+        ///     Creates a new result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.
+        ///     If a given function throws an exception, an error is returned from the given error handler
+        /// </summary>
+        public static Result<K> MapTry<T, K>(this Result<T> result, Func<T, K> func,
+            Func<Exception, string> errorHandler = null)
+        {
+            return result.IsFailure
+                ? Result.Failure<K>(result.Error)
+                : Result.Try(() => func(result.Value), errorHandler);
+        }
+
+        /// <summary>
+        ///     Creates a new result from the return value of a given function. If the calling Result is a failure, a new failure result is returned instead.
+        ///     If a given function throws an exception, an error is returned from the given error handler
+        /// </summary>
+        public static Result<K> MapTry<K>(this Result result, Func<K> func,
+            Func<Exception, string> errorHandler = null)
+        {
+            return result.IsFailure
+                ? Result.Failure<K>(result.Error)
+                : Result.Try(() => func(), errorHandler);
+        }
+    }
+}


### PR DESCRIPTION
Added MapTry Result extensions as a next step to obsolete OnSuccessTry extensions.
Fixed Unit tests issue for global Result configuration Tests  (occasionally some test faulted when running in parallel). Those tests are now forced to run non-parallel.
Fixed BindTry ValueTask function parameter naming to taskValue.