### PR TITLE
Update README to reflect maintained testing framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -547,21 +547,26 @@ Console.WriteLine(bananaInventory.MapError(ErrorEnhancer).ToString()); // "Faile
 
 ## Testing
 
-For extension methods on top of this library's `Result` and `Maybe` that you can use in tests,
-you can use [FluentAssertions](https://fluentassertions.com/)
-with [this NuGet package](https://www.nuget.org/packages/FluentAssertions.CSharpFunctionalExtensions/) ([GitHub link](https://github.com/pedromtcosta/FluentAssertions.CSharpFunctionalExtensions)).
+### CSharpFunctionalExtensions.FluentAssertions
 
-Example:
+A small set of extensions to make test assertions more fluent when using CSharpFunctionalExtensions! Check out the [repo for this library](https://github.com/NitroDevs/CSharpFunctionalExtensions.FluentAssertions) more information!
+
+Includes custom assertions for
+- Maybe
+- Result
+- Result<T>
+- Result<T, E>
+- UnitResult
+
+#### Example
 
 ```csharp
-// Arrange
-var myClass = new MyClass();
+var result = Result.Success(420);
 
-// Act
-Result result = myClass.TheMethod();
-
-// Assert
-result.Should().BeSuccess();
+result.Should().Succeed(); // passes
+result.Should().SucceedWith(420); // passes
+result.Should().SucceedWith(69); // throws
+result.Should().Fail(); // throws
 ```
 
 ## Read or Watch more about these ideas


### PR DESCRIPTION
Updates the README to include a reference to `CSharpFunctionalExtensions.FluentAssertions`, a set of extensions to make test assertions more fluent when using CSharpFunctionalExtensions. This removes a reference to the no longer maintained `FluentAssertions.CSharpFunctionalExtensions`, which works well but has not been updated in quite some time and lacks many of the latest additions like `Result<T, E>`, `Unit Result`, etc. Note that the project name is an h3, so that other testing frameworks could be included as well under the `## Testing` h2 header in the future.