### PR TITLE
Adding optional comparer to Maybe Equals and GetHashcode

### DIFF
--- a/CSharpFunctionalExtensions/Maybe/Maybe.cs
+++ b/CSharpFunctionalExtensions/Maybe/Maybe.cs
@@ -142,7 +142,7 @@ namespace CSharpFunctionalExtensions
             return false;
         }
 
-        public bool Equals(Maybe<T> other)
+        public bool Equals(Maybe<T> other, IEqualityComparer<T> comparer = null)
         {
             if (HasNoValue && other.HasNoValue)
                 return true;
@@ -150,15 +150,15 @@ namespace CSharpFunctionalExtensions
             if (HasNoValue || other.HasNoValue)
                 return false;
 
-            return EqualityComparer<T>.Default.Equals(_value, other._value);
+            return comparer.Equals(_value, other._value) ?? EqualityComparer<T>.Default.Equals(_value, other._value);
         }
 
-        public override int GetHashCode()
+        public override int GetHashCode(IEqualityComparer<T> comparer = null)
         {
             if (HasNoValue)
                 return 0;
 
-            return _value.GetHashCode();
+            return comparer.GetHashCode(_value) ?? _value.GetHashCode();
         }
 
         public override string ToString()

--- a/CSharpFunctionalExtensions/Maybe/Maybe.cs
+++ b/CSharpFunctionalExtensions/Maybe/Maybe.cs
@@ -150,7 +150,7 @@ namespace CSharpFunctionalExtensions
             if (HasNoValue || other.HasNoValue)
                 return false;
 
-            return comparer.Equals(_value, other._value) ?? EqualityComparer<T>.Default.Equals(_value, other._value);
+            return comparer?.Equals(_value, other._value) ?? EqualityComparer<T>.Default.Equals(_value, other._value);
         }
 
         public override int GetHashCode(IEqualityComparer<T> comparer = null)
@@ -158,7 +158,7 @@ namespace CSharpFunctionalExtensions
             if (HasNoValue)
                 return 0;
 
-            return comparer.GetHashCode(_value) ?? _value.GetHashCode();
+            return comparer?.GetHashCode(_value) ?? _value.GetHashCode();
         }
 
         public override string ToString()


### PR DESCRIPTION
I found my self having to write my own Maybe IEqualityComparer for a specific DTO of T. 

But I didn't want to bloat that DTO with equality comparison functionality, so i introduced a IEqualityComparer for that T type. But i couldn't give it to the Maybe.Equals and GetHashCode