### PR TITLE
Adding optional IEqualityComparer for Maybe

### DIFF
--- a/CSharpFunctionalExtensions.Tests/MaybeTests/EqualityTests.cs
+++ b/CSharpFunctionalExtensions.Tests/MaybeTests/EqualityTests.cs
@@ -1,4 +1,7 @@
-﻿using FluentAssertions;
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using FluentAssertions;
 using Xunit;
 
 
@@ -27,6 +30,56 @@ namespace CSharpFunctionalExtensions.Tests.MaybeTests
         }
 
         [Fact]
+        public void Two_maybes_of_the_same_content_are_comparable_by_equals_override()
+        {
+            Maybe<DummyClass> maybe1 = new DummyClass(1);
+            Maybe<DummyClass> maybe2 = new DummyClass(1);
+
+            bool equals1 = maybe1.Equals(maybe2);
+            bool equals2 = ((object)maybe1).Equals(maybe2);
+            bool equals3 = maybe1 == maybe2;
+            bool equals4 = maybe1 != maybe2;
+            bool equals5 = maybe1.GetHashCode() == maybe2.GetHashCode();
+
+            equals1.Should().BeTrue();
+            equals2.Should().BeTrue();
+            equals3.Should().BeTrue();
+            equals4.Should().BeFalse();
+            equals5.Should().BeTrue();
+        }
+
+        [Fact]
+        public void Two_maybes_of_the_same_content_are_comparable_by_comparer()
+        {
+            Maybe<DummyClassWithoutEqualsOverrides> maybe1 = Maybe<DummyClassWithoutEqualsOverrides>.From(new DummyClassWithoutEqualsOverrides(1), new DummyComparer());
+            Maybe<DummyClassWithoutEqualsOverrides> maybe2 = Maybe<DummyClassWithoutEqualsOverrides>.From(new DummyClassWithoutEqualsOverrides(1), new DummyComparer());
+
+            bool equals1 = maybe1.Equals(maybe2);
+            bool equals2 = ((object)maybe1).Equals(maybe2);
+            bool equals3 = maybe1 == maybe2;
+            bool equals4 = maybe1 != maybe2;
+            bool equals5 = maybe1.GetHashCode() == maybe2.GetHashCode();
+
+            equals1.Should().BeTrue();
+            equals2.Should().BeTrue();
+            equals3.Should().BeTrue();
+            equals4.Should().BeFalse();
+            equals5.Should().BeTrue();
+        }
+
+        [Fact]
+        public void Two_maybes_of_the_same_content_are_comparable_by_gethashcode_override()
+        {
+            var instance = new DummyClass(1337);
+            Maybe<DummyClass> maybe1 = instance;
+            Maybe<DummyClass> maybe2 = instance;
+
+            bool areGetHashCodeIdentical = maybe1.GetHashCode() == maybe2.GetHashCode();
+
+            areGetHashCodeIdentical.Should().BeTrue();
+        }
+
+        [Fact]
         public void Two_maybes_are_not_equal_if_differ()
         {
             Maybe<MyClass> maybe1 = new MyClass();
@@ -43,6 +96,17 @@ namespace CSharpFunctionalExtensions.Tests.MaybeTests
             equals3.Should().BeFalse();
             equals4.Should().BeTrue();
             equals5.Should().BeFalse();
+        }
+
+        [Fact]
+        public void Two_different_maybes_are_comparable_by_gethashcode_override()
+        {
+            Maybe<DummyClass> maybe1 = new DummyClass(1);
+            Maybe<DummyClass> maybe2 = new DummyClass(2);
+
+            bool equals = maybe1.GetHashCode() == maybe2.GetHashCode();
+
+            equals.Should().BeFalse();
         }
 
         [Fact]
@@ -146,6 +210,50 @@ namespace CSharpFunctionalExtensions.Tests.MaybeTests
 
         private class MyClass
         {
+        }
+
+        private class DummyClass
+        {
+            public int DummyInt { get; set; }
+
+            public DummyClass(int dummyInt)
+            {
+                DummyInt = dummyInt;
+            } 
+
+            public override bool Equals(object obj)
+            {
+                return obj is DummyClass @class &&
+                       DummyInt == @class.DummyInt;
+            }
+
+            public override int GetHashCode()
+            {
+                return DummyInt.GetHashCode();
+            }
+        }
+
+        private class DummyClassWithoutEqualsOverrides 
+        {
+            public int DummyInt { get; set; }
+
+            public DummyClassWithoutEqualsOverrides(int dummyInt)
+            {
+                DummyInt = dummyInt;
+            }
+        }
+
+        private class DummyComparer : IEqualityComparer<DummyClassWithoutEqualsOverrides>
+        {
+            public bool Equals(DummyClassWithoutEqualsOverrides x, DummyClassWithoutEqualsOverrides y)
+            {
+                return x.DummyInt == y.DummyInt;
+            }
+
+            public int GetHashCode([DisallowNull] DummyClassWithoutEqualsOverrides obj)
+            {
+                return obj.DummyInt.GetHashCode();
+            }
         }
     }
 }

--- a/CSharpFunctionalExtensions.Tests/MaybeTests/EqualityTests.cs
+++ b/CSharpFunctionalExtensions.Tests/MaybeTests/EqualityTests.cs
@@ -51,8 +51,8 @@ namespace CSharpFunctionalExtensions.Tests.MaybeTests
         [Fact]
         public void Two_maybes_of_the_same_content_are_comparable_by_comparer()
         {
-            Maybe<DummyClassWithoutEqualsOverrides> maybe1 = Maybe<DummyClassWithoutEqualsOverrides>.From(new DummyClassWithoutEqualsOverrides(1), new DummyComparer());
-            Maybe<DummyClassWithoutEqualsOverrides> maybe2 = Maybe<DummyClassWithoutEqualsOverrides>.From(new DummyClassWithoutEqualsOverrides(1), new DummyComparer());
+            Maybe<DummyClassWithoutEqualsOverrides> maybe1 = Maybe<DummyClassWithoutEqualsOverrides>.From(new DummyClassWithoutEqualsOverrides(1));
+            Maybe<DummyClassWithoutEqualsOverrides> maybe2 = Maybe<DummyClassWithoutEqualsOverrides>.From(new DummyClassWithoutEqualsOverrides(1));
 
             bool equals1 = maybe1.Equals(maybe2);
             bool equals2 = ((object)maybe1).Equals(maybe2);
@@ -60,11 +60,17 @@ namespace CSharpFunctionalExtensions.Tests.MaybeTests
             bool equals4 = maybe1 != maybe2;
             bool equals5 = maybe1.GetHashCode() == maybe2.GetHashCode();
 
-            equals1.Should().BeTrue();
-            equals2.Should().BeTrue();
-            equals3.Should().BeTrue();
-            equals4.Should().BeFalse();
-            equals5.Should().BeTrue();
+            var comparer = new MaybeEqualityComparer<DummyClassWithoutEqualsOverrides>(new DummyComparer());
+            bool equals6 = comparer.Equals(maybe1, maybe2);
+            bool equals7 = comparer.GetHashCode(maybe1) == comparer.GetHashCode(maybe2);
+
+            equals1.Should().BeFalse();
+            equals2.Should().BeFalse();
+            equals3.Should().BeFalse();
+            equals4.Should().BeTrue();
+            equals5.Should().BeFalse();
+            equals6.Should().BeTrue();
+            equals7.Should().BeTrue();
         }
 
         [Fact]

--- a/CSharpFunctionalExtensions/Maybe/Maybe.cs
+++ b/CSharpFunctionalExtensions/Maybe/Maybe.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections;
 using System.Collections.Generic;
 #if NET45_OR_GREATER || NETSTANDARD || NETCORE || NET5_0_OR_GREATER
 using System.Runtime.CompilerServices;

--- a/CSharpFunctionalExtensions/Maybe/Maybe.cs
+++ b/CSharpFunctionalExtensions/Maybe/Maybe.cs
@@ -100,6 +100,11 @@ namespace CSharpFunctionalExtensions
             return new Maybe<T>(obj, equalityComparer);
         }
 
+        public static Maybe<T> From(T obj)
+        {
+            return new Maybe<T>(obj);
+        }
+
         public static bool operator ==(Maybe<T> maybe, T value)
         {
             if (value is Maybe<T>)

--- a/CSharpFunctionalExtensions/Maybe/Maybe.cs
+++ b/CSharpFunctionalExtensions/Maybe/Maybe.cs
@@ -19,8 +19,6 @@ namespace CSharpFunctionalExtensions
 
         private readonly T _value;
 
-        private readonly IEqualityComparer<T> _equalityComparer;
-
         /// <summary>
         /// Returns the inner value if there's one, otherwise throws an InvalidOperationException with <paramref name="errorMessage"/>
         /// </summary>
@@ -68,19 +66,17 @@ namespace CSharpFunctionalExtensions
         public bool HasValue => _isValueSet;
         public bool HasNoValue => !HasValue;
 
-        private Maybe(T value, IEqualityComparer<T> equalityComparer = null)
+        private Maybe(T value)
         {
             if (value == null)
             {
                 _isValueSet = false;
                 _value = default;
-                _equalityComparer = EqualityComparer<T>.Default;
                 return;
             }
 
             _isValueSet = true;
             _value = value;
-            _equalityComparer = equalityComparer ?? EqualityComparer<T>.Default;
         }
 
         public static implicit operator Maybe<T>(T value)
@@ -94,11 +90,6 @@ namespace CSharpFunctionalExtensions
         }
 
         public static implicit operator Maybe<T>(Maybe value) => None;
-
-        public static Maybe<T> From(T obj, IEqualityComparer<T> equalityComparer = null)
-        {
-            return new Maybe<T>(obj, equalityComparer);
-        }
 
         public static Maybe<T> From(T obj)
         {
@@ -160,7 +151,7 @@ namespace CSharpFunctionalExtensions
             if (HasNoValue || other.HasNoValue)
                 return false;
 
-            return _equalityComparer.Equals(_value, other._value);
+            return EqualityComparer<T>.Default.Equals(_value, other._value);
         }
 
         public override int GetHashCode()
@@ -168,7 +159,7 @@ namespace CSharpFunctionalExtensions
             if (HasNoValue)
                 return 0;
 
-            return _equalityComparer.GetHashCode(_value);
+            return _value.GetHashCode();
         }
 
         public override string ToString()

--- a/CSharpFunctionalExtensions/Maybe/MaybeEqualityComparer.cs
+++ b/CSharpFunctionalExtensions/Maybe/MaybeEqualityComparer.cs
@@ -1,0 +1,29 @@
+﻿using System.Collections.Generic;
+
+namespace CSharpFunctionalExtensions
+{
+    public class MaybeEqualityComparer<T> : IEqualityComparer<Maybe<T>>
+    {
+        private readonly IEqualityComparer<T> _equalityComparer;
+
+        public MaybeEqualityComparer(IEqualityComparer<T> equalityComparer = null)
+        {
+            _equalityComparer = equalityComparer ?? EqualityComparer<T>.Default;
+        }
+
+        public bool Equals(Maybe<T> x, Maybe<T> y)
+        {
+            if (x.HasNoValue && y.HasNoValue)
+            {
+                return true;
+            }
+
+            return x.HasValue && y.HasValue && _equalityComparer.Equals(x.Value, y.Value);
+        }
+
+        public int GetHashCode(Maybe<T> obj)
+        {
+            return obj.HasNoValue ? 0 : _equalityComparer.GetHashCode(obj.Value);
+        }
+    }
+}


### PR DESCRIPTION
Context:
Given that most Generic<T> class like HashSet<T>, Dictionnary<T>, ThreadSafeDictionary<T>, can be instanciate with something else than the default EqualityComparer.Default. I wanted to add this functionality to the Maybe class.

It adds flexibility, and help to be Open/Close.

Added test:

- Given a T class with object.Equals override then it is used correctly
- Given a T class with object.GetHashCode override then it is used correctly
- Given a Maybe<T> class with a T comparer, then it is used