### PR TITLE
Fix symmetry violation of ValueObject comparison

### DIFF
--- a/CSharpFunctionalExtensions.Tests/EntityTests/BasicTests.cs
+++ b/CSharpFunctionalExtensions.Tests/EntityTests/BasicTests.cs
@@ -151,7 +151,7 @@ namespace CSharpFunctionalExtensions.Tests.EntityTests
                 Value2 = value2;
             }
 
-            protected override IEnumerable<object> GetEqualityComponents()
+            protected override IEnumerable<IComparable> GetEqualityComponents()
             {
                 yield return Value1;
                 yield return Value2;

--- a/CSharpFunctionalExtensions.Tests/MaybeTests/ImplicitConversionTests.cs
+++ b/CSharpFunctionalExtensions.Tests/MaybeTests/ImplicitConversionTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using FluentAssertions;
 using Xunit;
 
@@ -35,7 +36,7 @@ namespace CSharpFunctionalExtensions.Tests.MaybeTests
             {
             }
 
-            protected override IEnumerable<object> GetEqualityComponents()
+            protected override IEnumerable<IComparable> GetEqualityComponents()
             {
                 yield return Value.ToLower();
             }

--- a/CSharpFunctionalExtensions.Tests/ValueObjectTests/BasicTests.cs
+++ b/CSharpFunctionalExtensions.Tests/ValueObjectTests/BasicTests.cs
@@ -109,7 +109,7 @@ namespace CSharpFunctionalExtensions.Tests.ValueObjectTests
                 _components = components;
             }
 
-            protected override IEnumerable<object> GetEqualityComponents()
+            protected override IEnumerable<IComparable> GetEqualityComponents()
             {
                 return _components;
             }
@@ -124,7 +124,7 @@ namespace CSharpFunctionalExtensions.Tests.ValueObjectTests
                 Value = value;
             }
 
-            protected override IEnumerable<object> GetEqualityComponents()
+            protected override IEnumerable<IComparable> GetEqualityComponents()
             {
                 yield return Value;
             }
@@ -139,7 +139,7 @@ namespace CSharpFunctionalExtensions.Tests.ValueObjectTests
                 Value = value;
             }
 
-            protected override IEnumerable<object> GetEqualityComponents()
+            protected override IEnumerable<IComparable> GetEqualityComponents()
             {
                 yield return Value;
             }
@@ -156,7 +156,7 @@ namespace CSharpFunctionalExtensions.Tests.ValueObjectTests
                 Amount = amount;
             }
 
-            protected override IEnumerable<object> GetEqualityComponents()
+            protected override IEnumerable<IComparable> GetEqualityComponents()
             {
                 yield return Currency.ToUpper();
                 yield return Math.Round(Amount, 2);
@@ -174,7 +174,7 @@ namespace CSharpFunctionalExtensions.Tests.ValueObjectTests
                 City = city;
             }
 
-            protected override IEnumerable<object> GetEqualityComponents()
+            protected override IEnumerable<IComparable> GetEqualityComponents()
             {
                 yield return Street;
                 yield return City;

--- a/CSharpFunctionalExtensions.Tests/ValueObjectTests/IComparableTests.cs
+++ b/CSharpFunctionalExtensions.Tests/ValueObjectTests/IComparableTests.cs
@@ -78,6 +78,7 @@ namespace CSharpFunctionalExtensions.Tests.ValueObjectTests
 
             result1.Should().NotBe(0);
             result2.Should().NotBe(0);
+            Math.Sign(result1).Should().NotBe(Math.Sign(result2));
         }
 
         [Fact]
@@ -91,6 +92,7 @@ namespace CSharpFunctionalExtensions.Tests.ValueObjectTests
 
             result1.Should().NotBe(0);
             result2.Should().NotBe(0);
+            Math.Sign(result1).Should().NotBe(Math.Sign(result2));
         }
 
         [Fact]
@@ -104,6 +106,7 @@ namespace CSharpFunctionalExtensions.Tests.ValueObjectTests
 
             result1.Should().NotBe(0);
             result2.Should().NotBe(0);
+            Math.Sign(result1).Should().NotBe(Math.Sign(result2));
         }
 
         [Fact]

--- a/CSharpFunctionalExtensions.Tests/ValueObjectTests/IComparableTests.cs
+++ b/CSharpFunctionalExtensions.Tests/ValueObjectTests/IComparableTests.cs
@@ -132,7 +132,7 @@ namespace CSharpFunctionalExtensions.Tests.ValueObjectTests
                 _components = components;
             }
 
-            protected override IEnumerable<object> GetEqualityComponents()
+            protected override IEnumerable<IComparable> GetEqualityComponents()
             {
                 yield return _components.Length;
                 foreach (string component in _components)
@@ -151,9 +151,9 @@ namespace CSharpFunctionalExtensions.Tests.ValueObjectTests
                 SomeProperty = someProperty;
             }
 
-            protected override IEnumerable<object> GetEqualityComponents()
+            protected override IEnumerable<IComparable> GetEqualityComponents()
             {
-                yield return SomeProperty;
+                yield return SomeProperty.GetHashCode();
             }
         }
 
@@ -170,7 +170,7 @@ namespace CSharpFunctionalExtensions.Tests.ValueObjectTests
                 Suffix = suffix;
             }
 
-            protected override IEnumerable<object> GetEqualityComponents()
+            protected override IEnumerable<IComparable> GetEqualityComponents()
             {
                 yield return First;
                 yield return Last;

--- a/CSharpFunctionalExtensions/ValueObject/EnumValueObject.cs
+++ b/CSharpFunctionalExtensions/ValueObject/EnumValueObject.cs
@@ -7,7 +7,7 @@ namespace CSharpFunctionalExtensions
 {
     public abstract class EnumValueObject<TEnumeration, TId> : ValueObject
         where TEnumeration : EnumValueObject<TEnumeration, TId>
-        where TId : struct
+        where TId : struct, IComparable
     {
         private int? _cachedHashCode;
         
@@ -111,7 +111,7 @@ namespace CSharpFunctionalExtensions
 
         public override string ToString() => Name;
 
-        protected override IEnumerable<object> GetEqualityComponents()
+        protected override IEnumerable<IComparable> GetEqualityComponents()
         {
             yield return Id;
         }
@@ -224,7 +224,7 @@ namespace CSharpFunctionalExtensions
 
         public override string ToString() => Id;
 
-        protected override IEnumerable<object> GetEqualityComponents()
+        protected override IEnumerable<IComparable> GetEqualityComponents()
         {
             yield return Id;
         }

--- a/CSharpFunctionalExtensions/ValueObject/SimpleValueObject.cs
+++ b/CSharpFunctionalExtensions/ValueObject/SimpleValueObject.cs
@@ -5,6 +5,7 @@ namespace CSharpFunctionalExtensions
 {
     [Serializable]
     public abstract class SimpleValueObject<T> : ValueObject
+        where T : IComparable
     {
         public T Value { get; }
 
@@ -13,7 +14,7 @@ namespace CSharpFunctionalExtensions
             Value = value;
         }
 
-        protected override IEnumerable<object> GetEqualityComponents()
+        protected override IEnumerable<IComparable> GetEqualityComponents()
         {
             yield return Value;
         }

--- a/CSharpFunctionalExtensions/ValueObject/ValueObject.cs
+++ b/CSharpFunctionalExtensions/ValueObject/ValueObject.cs
@@ -10,7 +10,7 @@ namespace CSharpFunctionalExtensions
     {
         private int? _cachedHashCode;
 
-        protected abstract IEnumerable<object> GetEqualityComponents();
+        protected abstract IEnumerable<IComparable> GetEqualityComponents();
 
         public override bool Equals(object obj)
         {
@@ -42,49 +42,31 @@ namespace CSharpFunctionalExtensions
             return _cachedHashCode.Value;
         }
 
-        public virtual int CompareTo(object obj)
-        {
-            Type thisType = GetUnproxiedType(this);
-            Type otherType = GetUnproxiedType(obj);
-
-            if (thisType != otherType)
-                return string.Compare(thisType.ToString(), otherType.ToString(), StringComparison.Ordinal);
-
-            var other = (ValueObject)obj;
-
-            object[] components = GetEqualityComponents().ToArray();
-            object[] otherComponents = other.GetEqualityComponents().ToArray();
-
-            for (int i = 0; i < components.Length; i++)
-            {
-                int comparison = CompareComponents(components[i], otherComponents[i]);
-                if (comparison != 0)
-                    return comparison;
-            }
-
-            return 0;
-        }
-
-        private int CompareComponents(object object1, object object2)
-        {
-            if (object1 is null && object2 is null)
-                return 0;
-
-            if (object1 is null)
-                return -1;
-
-            if (object2 is null)
-                return 1;
-
-            if (object1 is IComparable comparable1 && object2 is IComparable comparable2)
-                return comparable1.CompareTo(comparable2);
-
-            return object1.Equals(object2) ? 0 : -1;
-        }
-
+        
         public virtual int CompareTo(ValueObject other)
         {
-            return CompareTo(other as object);
+            if (other is null)
+                return 1;
+
+            if (ReferenceEquals(this, other))
+                return 0;
+
+            Type thisType = GetUnproxiedType(this);
+            Type otherType = GetUnproxiedType(other);
+            if (thisType != otherType)
+                return string.Compare($"{thisType}", $"{otherType}", StringComparison.Ordinal);
+
+            return
+                GetEqualityComponents().Zip(
+                    other.GetEqualityComponents(),
+                    (left, rigth) =>
+                        left?.CompareTo(rigth) ?? (rigth is null ? 0 : -1))
+                .FirstOrDefault(cmp => cmp != 0);
+        }
+
+        public virtual int CompareTo(object other) 
+        {
+            return CompareTo(other as ValueObject);
         }
 
         public static bool operator ==(ValueObject a, ValueObject b)


### PR DESCRIPTION
Comparing two incomparable objects in this way can lead to unpredictable results.

        private int CompareComponents(object object1, object object2)
        {
            ...
            **return object1.Equals(object2) ? 0 : -1;**
        }

Expected if (object1 > object2) then (object2 < object1)

To prevent comparison of non-comparable components of VO it is proposed to change signature of ValueObject.GetEqualityComponents abstract method:

--protected abstract IEnumerable\<object\> GetEqualityComponents();
++protected abstract IEnumerable\<IComparable\> GetEqualityComponents();
