### PR TITLE
add a method overload for GetValueOrThrow, that enables a custom exce…

### DIFF
--- a/CSharpFunctionalExtensions.Tests/MaybeTests/Extensions/GetValueOrThrowTests.cs
+++ b/CSharpFunctionalExtensions.Tests/MaybeTests/Extensions/GetValueOrThrowTests.cs
@@ -29,10 +29,10 @@ namespace CSharpFunctionalExtensions.Tests.MaybeTests.Extensions
             Func<int> func = () =>
             {
                 var maybe = Maybe<int>.None;
-                return maybe.GetValueOrThrow(new DumnmyDomainException(errorMessage));
+                return maybe.GetValueOrThrow(new DummyDomainException(errorMessage));
             };
 
-            func.Should().Throw<DumnmyDomainException>().WithMessage(errorMessage);
+            func.Should().Throw<DummyDomainException>().WithMessage(errorMessage);
         }
 
         [Fact]
@@ -47,9 +47,9 @@ namespace CSharpFunctionalExtensions.Tests.MaybeTests.Extensions
             result.Should().Be(value);
         }
 
-        private class DumnmyDomainException : Exception
+        private class DummyDomainException : Exception
         {
-            public DumnmyDomainException(string message) 
+            public DummyDomainException(string message) 
                 : base(message)
             {
             }

--- a/CSharpFunctionalExtensions.Tests/MaybeTests/Extensions/GetValueOrThrowTests.cs
+++ b/CSharpFunctionalExtensions.Tests/MaybeTests/Extensions/GetValueOrThrowTests.cs
@@ -22,6 +22,20 @@ namespace CSharpFunctionalExtensions.Tests.MaybeTests.Extensions
         }
 
         [Fact]
+        public void GetValueOrThrow_throws_with_custom_exception_if_source_is_empty()
+        {
+            const string errorMessage = "Maybe is none";
+
+            Func<int> func = () =>
+            {
+                var maybe = Maybe<int>.None;
+                return maybe.GetValueOrThrow(new DumnmyDomainException(errorMessage));
+            };
+
+            func.Should().Throw<DumnmyDomainException>().WithMessage(errorMessage);
+        }
+
+        [Fact]
         public void GetValueOrThrow_returns_value_if_source_has_value()
         {
             const int value = 1;
@@ -31,6 +45,14 @@ namespace CSharpFunctionalExtensions.Tests.MaybeTests.Extensions
             var result = maybe.GetValueOrThrow(errorMessage);
 
             result.Should().Be(value);
+        }
+
+        private class DumnmyDomainException : Exception
+        {
+            public DumnmyDomainException(string message) 
+                : base(message)
+            {
+            }
         }
     }
 }

--- a/CSharpFunctionalExtensions/Maybe/Maybe.cs
+++ b/CSharpFunctionalExtensions/Maybe/Maybe.cs
@@ -30,6 +30,18 @@ namespace CSharpFunctionalExtensions
             return _value;
         }
 
+        /// <summary>
+        /// Returns the inner value if there's one, otherwise throws a custom exception with <paramref name="exception"/>
+        /// </summary>
+        /// <exception cref="Exception">Maybe has no value.</exception>
+        public T GetValueOrThrow(Exception exception)
+        {
+            if (HasNoValue)
+                throw exception;
+
+            return _value;
+        }
+
         public T GetValueOrDefault(T defaultValue = default)
         {
             if (HasNoValue)

--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ Console.WriteLine(noFruit.ToString()); // "No value"
 
 Use case: Procedurally accessing the inner value of the Maybe
 
-**Note**: Call this will throw a `InvalidOperationException` if there is no value
+**Note**: Calling this will throw a `InvalidOperationException` if there is no value
 
 ```csharp
 Maybe<string> apple = "apple";
@@ -168,6 +168,7 @@ Maybe<string> noFruit = Maybe<string>.None;
 
 Console.WriteLine(apple.GetValueOrThrow()); // "apple";
 Console.WriteLine(noFruit.GetValueOrThrow()); // throws InvalidOperationException !!
+Console.WriteLine(noFruit.GetValueOrThrow(new CustomException())); // throws CustomException !!
 ```
 
 #### HasValue and HasNoValue


### PR DESCRIPTION
I added a method overload for GetValueOrThrow, that enables a custom exception instead of the default InvalidOperationException.


**Justifications:**
I found myself needing that feature, in my production code. The leaner the better for me.

since it was not available I had to do

```
if (result.HasNoValue)
{
     throw new DomainException
}

this.VeryNotComplicatedLogic(result.Value)
```
vs
```
this.VeryNotComplicatedLogic(result.GetValueOrThrow(new DomainException))
```