### PR TITLE
Add ToResult extension to Nullable.

### DIFF
--- a/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/NullableExtensionTests.cs
+++ b/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/NullableExtensionTests.cs
@@ -1,0 +1,198 @@
+﻿#if NETCOREAPP3_0_OR_GREATER
+namespace CSharpFunctionalExtensions.Tests.ResultTests.Extensions
+{
+    using System;
+    using System.Threading.Tasks;
+    using FluentAssertions;
+    using Xunit;
+
+    public class NullableExtensionTests
+    {
+        [Fact]
+        public void Convert_nullable_struct_to_result_pass()
+        {
+            // Arrange
+            DateTime? date = DateTime.Now;
+
+            // Act
+            var result = date.ToResult("Date not set.");
+
+            // Assert
+            result.IsSuccess.Should().BeTrue();
+            result.Value.Should().Be(date.Value);
+        }
+
+        [Fact]
+        public void Convert_nullable_struct_to_result_fail()
+        {
+            // Arrange
+            DateTime? date = default;
+
+            // Act
+            var result = date.ToResult("Date not set.");
+
+            // Assert
+            result.IsFailure.Should().BeTrue();
+            result.Error.Should().Be("Date not set.");
+
+        }
+
+        [Fact]
+        public void Convert_nullable_class_to_result_pass()
+        {
+            // Arrange
+            MyClass? myClass = new();
+
+            // Act
+            var result = myClass.ToResult("MyClass is not set.");
+
+            // Assert
+            result.IsSuccess.Should().BeTrue();
+            result.Value.Should().Be(myClass);
+        }
+
+        [Fact]
+        public void Convert_nullable_class_to_result_fail()
+        {
+            // Arrange
+            MyClass? myClass = default;
+
+            // Act
+            var result = myClass.ToResult("MyClass is not set.");
+
+            // Assert
+            result.IsFailure.Should().BeTrue();
+            result.Error.Should().Be("MyClass is not set.");
+        }
+
+        // async class
+        [Fact]
+        public async Task Convert_task_nullable_class_to_result_pass()
+        {
+            // Arrange
+            MyClass? my = new();
+            var myClassTask = Task.FromResult((MyClass?)my);
+
+            // Act
+            var result = await myClassTask.ToResultAsync("MyClass is not set.");
+
+            // Assert
+            result.IsSuccess.Should().BeTrue();
+            result.Value.Should().Be(my);
+        }
+
+        [Fact]
+        public async Task Convert_task_nullable_class_to_result_fail()
+        {
+            // Arrange
+            MyClass? my = default;
+            var myClassTask = Task.FromResult(my);
+
+            // Act
+            var result = await myClassTask.ToResultAsync("MyClass is not set.");
+
+            // Assert
+            result.IsFailure.Should().BeTrue();
+            result.Error.Should().Be("MyClass is not set.");
+        }
+
+        [Fact]
+        public async Task Convert_valuetask_nullable_class_to_result_pass()
+        {
+            // Arrange
+            MyClass? my = new();
+
+            var myClassTask = ValueTask.FromResult((MyClass?)my);
+
+            // Act
+            var result = await myClassTask.ToResultAsync("MyClass is not set.");
+
+            // Assert
+            result.IsSuccess.Should().BeTrue();
+            result.Value.Should().Be(my);
+        }
+
+        [Fact]
+        public async Task Convert_valuetask_nullable_class_to_result_fail()
+        {
+            // Arrange
+            MyClass? my = null;
+            var myClassTask = ValueTask.FromResult(my);
+
+            // Act
+            var result = await myClassTask.ToResultAsync("MyClass is not set.");
+
+            // Assert
+            result.IsFailure.Should().BeTrue();
+            result.Error.Should().Be("MyClass is not set.");
+        }
+
+        // async struct
+        [Fact]
+        public async Task Convert_task_nullable_struct_to_result_pass()
+        {
+            // Arrange
+            DateTime? my = DateTime.Now;
+            var myClassTask = Task.FromResult(my);
+
+            // Act
+            var result = await myClassTask.ToResultAsync("Date is not set.");
+
+            // Assert
+            result.IsSuccess.Should().BeTrue();
+            result.Value.Should().Be(my.Value);
+        }
+
+        [Fact]
+        public async Task Convert_task_nullable_struct_to_result_fail()
+        {
+            // Arrange
+            DateTime? my = default;
+            var myClassTask = Task.FromResult(my);
+
+            // Act
+            var result = await myClassTask.ToResultAsync("Date is not set.");
+
+            // Assert
+            result.IsFailure.Should().BeTrue();
+            result.Error.Should().Be("Date is not set.");
+        }
+
+        [Fact]
+        public async Task Convert_valuetask_nullable_struct_to_result_pass()
+        {
+            // Arrange
+            DateTime? my = DateTime.Now;
+
+            var myClassTask = ValueTask.FromResult(my);
+
+            // Act
+            var result = await myClassTask.ToResultAsync("Date is not set.");
+
+            // Assert
+            result.IsSuccess.Should().BeTrue();
+            result.Value.Should().Be(my.Value);
+        }
+
+        [Fact]
+        public async Task Convert_valuetask_nullable_struct_to_result_fail()
+        {
+            // Arrange
+            MyClass? my = null;
+            var myClassTask = ValueTask.FromResult(my);
+
+            // Act
+            var result = await myClassTask.ToResultAsync("Date is not set.");
+
+            // Assert
+            result.IsFailure.Should().BeTrue();
+            result.Error.Should().Be("Date is not set.");
+        }
+    }
+
+    internal class MyClass
+    {
+    }
+}
+
+#endif

--- a/CSharpFunctionalExtensions/CSharpFunctionalExtensions.csproj
+++ b/CSharpFunctionalExtensions/CSharpFunctionalExtensions.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net40;net45;netstandard2.0;net6.0</TargetFrameworks>
     <PackageId>CSharpFunctionalExtensions</PackageId>
     <Authors>Vladimir Khorikov</Authors>
     <Description>CSharpFunctionalExtensions - functional extensions for C#</Description>
@@ -20,6 +20,9 @@
     <NoWarn>1591;1701;1702</NoWarn>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(TargetFramework)'=='net45'">
+	<AssemblyTitle>CSharpFunctionalExtensions .NET 4.5</AssemblyTitle>
+  </PropertyGroup>
   <PropertyGroup Condition="'$(TargetFramework)'=='netstandard2.0'">
     <AssemblyTitle>CSharpFunctionalExtensions .NET Standard 2.0</AssemblyTitle>
   </PropertyGroup>

--- a/CSharpFunctionalExtensions/CSharpFunctionalExtensions.csproj
+++ b/CSharpFunctionalExtensions/CSharpFunctionalExtensions.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net40;net45;netstandard2.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net40;net45;net461;netstandard2.0;net5.0;net6.0</TargetFrameworks>
     <PackageId>CSharpFunctionalExtensions</PackageId>
     <Authors>Vladimir Khorikov</Authors>
     <Description>CSharpFunctionalExtensions - functional extensions for C#</Description>
@@ -21,10 +21,16 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(TargetFramework)'=='net45'">
-	<AssemblyTitle>CSharpFunctionalExtensions .NET 4.5</AssemblyTitle>
+    <AssemblyTitle>CSharpFunctionalExtensions .NET 4.5</AssemblyTitle>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(TargetFramework)'=='net461'">
+    <AssemblyTitle>CSharpFunctionalExtensions .NET 4.6.1</AssemblyTitle>
   </PropertyGroup>
   <PropertyGroup Condition="'$(TargetFramework)'=='netstandard2.0'">
     <AssemblyTitle>CSharpFunctionalExtensions .NET Standard 2.0</AssemblyTitle>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(TargetFramework)'=='net5.0'">
+    <AssemblyTitle>CSharpFunctionalExtensions .NET 5.0</AssemblyTitle>
   </PropertyGroup>
   <PropertyGroup Condition="'$(TargetFramework)'=='net6.0'">
     <AssemblyTitle>CSharpFunctionalExtensions .NET 6.0</AssemblyTitle>

--- a/CSharpFunctionalExtensions/CSharpFunctionalExtensions.csproj
+++ b/CSharpFunctionalExtensions/CSharpFunctionalExtensions.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net40;net45;net461;net472;netstandard2.0;net5.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
     <PackageId>CSharpFunctionalExtensions</PackageId>
     <Authors>Vladimir Khorikov</Authors>
     <Description>CSharpFunctionalExtensions - functional extensions for C#</Description>
@@ -20,17 +20,8 @@
     <NoWarn>1591;1701;1702</NoWarn>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(TargetFramework)'=='net45'">
-    <AssemblyTitle>CSharpFunctionalExtensions .NET 4.5</AssemblyTitle>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(TargetFramework)'=='net461'">
-    <AssemblyTitle>CSharpFunctionalExtensions .NET 4.6.1</AssemblyTitle>
-  </PropertyGroup>
   <PropertyGroup Condition="'$(TargetFramework)'=='netstandard2.0'">
     <AssemblyTitle>CSharpFunctionalExtensions .NET Standard 2.0</AssemblyTitle>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(TargetFramework)'=='net5.0'">
-    <AssemblyTitle>CSharpFunctionalExtensions .NET 5.0</AssemblyTitle>
   </PropertyGroup>
   <PropertyGroup Condition="'$(TargetFramework)'=='net6.0'">
     <AssemblyTitle>CSharpFunctionalExtensions .NET 6.0</AssemblyTitle>

--- a/CSharpFunctionalExtensions/Result/NullableExtensions.cs
+++ b/CSharpFunctionalExtensions/Result/NullableExtensions.cs
@@ -1,0 +1,56 @@
+﻿#if NETCOREAPP3_0_OR_GREATER
+using System.Threading.Tasks;
+
+namespace CSharpFunctionalExtensions
+{
+
+    public static partial class NullableExtensions
+    {
+        public static Result<T, E> ToResult<T, E>(in this T? nullable, E error)
+            where T : struct
+        {
+            if (!nullable.HasValue)
+                return Result.Failure<T, E>(error);
+
+            return Result.Success<T, E>(nullable.Value);
+        }
+        public static Result<T, E> ToResult<T, E>(this T? obj, E error)
+            where T : class
+        {
+            if (obj == null)
+                return Result.Failure<T, E>(error);
+
+            return Result.Success<T, E>(obj);
+        }
+
+        public static async Task<Result<T, E>> ToResultAsync<T, E>(this Task<T?> nullableTask, E errors)
+            where T : struct
+        {
+            var nullable = await nullableTask.ConfigureAwait(false);
+            return nullable.ToResult(errors);
+        }
+
+        public static async Task<Result<T, E>> ToResultAsync<T, E>(this Task<T?> nullableTask, E errors)
+        where T : class
+        {
+            var nullable = await nullableTask.ConfigureAwait(false);
+            return nullable.ToResult(errors);
+        }
+        
+        public static async ValueTask<Result<T, E>> ToResultAsync<T, E>(this ValueTask<T?> nullableTask, E errors)
+            where T : struct
+        {
+            var nullable = await nullableTask.ConfigureAwait(false);
+            return nullable.ToResult(errors);
+        }
+
+        public static async ValueTask<Result<T, E>> ToResultAsync<T, E>(this ValueTask<T?> nullableTask, E errors)
+            where T : class
+        {
+            var nullable = await nullableTask.ConfigureAwait(false);
+            return nullable.ToResult(errors);
+        }
+    }
+}
+
+#endif


### PR DESCRIPTION
With the support of nullable added to C#, it is more natural to use nullable over Maybe extension.
The PR will add support to convert null/nullable to Result.

Removed old .net framework from build target. .Net users can use .net standard library. 
