### PR TITLE
Allow returning a value from Match for UnitResult

### DIFF
--- a/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/MatchTests.Task.Left.cs
+++ b/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/MatchTests.Task.Left.cs
@@ -157,5 +157,25 @@ namespace CSharpFunctionalExtensions.Tests.ResultTests.Extensions
 
             AssertFailure();
         }
+        
+        [Fact]
+        public async Task Match_Task_Left_UnitResult_E_Success_Returns_K()
+        {
+            var result = UnitResult.Success<E>();
+
+            result.Match(OnSuccess_K, OnFailure_E_K);
+
+            AssertSuccess();
+        }
+
+        [Fact]
+        public async Task Match_Task_Left_UnitResult_E_Failure_Returns_K()
+        {
+            var result = UnitResult.Failure(E.Value);
+
+            result.Match(OnSuccess_K, OnFailure_E_K);
+
+            AssertFailure();
+        }
     }
 }

--- a/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/MatchTests.Task.Right.cs
+++ b/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/MatchTests.Task.Right.cs
@@ -157,5 +157,25 @@ namespace CSharpFunctionalExtensions.Tests.ResultTests.Extensions
 
             AssertFailure();
         }
+        
+        [Fact]
+        public async Task Match_Task_Right_UnitResult_E_Success_Returns_K()
+        {
+            var result = UnitResult.Success<E>();
+
+            await result.Match(OnSuccess_K_Task, OnFailure_E_K_Task);
+
+            AssertSuccess();
+        }
+
+        [Fact]
+        public async Task Match_Task_Right_UnitResult_E_Failure_Returns_K()
+        {
+            var result = UnitResult.Failure(E.Value);
+
+            await result.Match(OnSuccess_K_Task, OnFailure_E_K_Task);
+
+            AssertFailure();
+        }
     }
 }

--- a/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/MatchTests.Task.cs
+++ b/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/MatchTests.Task.cs
@@ -157,5 +157,25 @@ namespace CSharpFunctionalExtensions.Tests.ResultTests.Extensions
 
             AssertFailure();
         }
+        
+        [Fact]
+        public async Task Match_Task_UnitResult_E_Success_Returns_K()
+        {
+            var result = UnitResult.Success<E>().AsTask();
+
+            await result.Match(OnSuccess_K_Task, OnFailure_E_K_Task);
+
+            AssertSuccess();
+        }
+
+        [Fact]
+        public async Task Match_Task_UnitResult_E_Failure_Returns_K()
+        {
+            var result = UnitResult.Failure(E.Value).AsTask();
+
+            await result.Match(OnSuccess_K_Task, OnFailure_E_K_Task);
+
+            AssertFailure();
+        }
     }
 }

--- a/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/MatchTests.ValueTask.Left.cs
+++ b/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/MatchTests.ValueTask.Left.cs
@@ -158,5 +158,25 @@ namespace CSharpFunctionalExtensions.Tests.ResultTests.Extensions
 
             AssertFailure();
         }
+        
+        [Fact]
+        public async Task Match_ValueTask_Left_UnitResult_E_Success_Returns_K()
+        {
+            var result = UnitResult.Success<E>();
+
+            result.Match(OnSuccess_K, OnFailure_E_K);
+
+            AssertSuccess();
+        }
+
+        [Fact]
+        public async Task Match_ValueTask_Left_UnitResult_E_Failure_Returns_K()
+        {
+            var result = UnitResult.Failure(E.Value);
+
+            result.Match(OnSuccess_K, OnFailure_E_K);
+
+            AssertFailure();
+        }
     }
 }

--- a/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/MatchTests.ValueTask.Right.cs
+++ b/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/MatchTests.ValueTask.Right.cs
@@ -158,5 +158,25 @@ namespace CSharpFunctionalExtensions.Tests.ResultTests.Extensions
 
             AssertFailure();
         }
+        
+        [Fact]
+        public async Task Match_ValueTask_Right_UnitResult_E_Success_Returns_K()
+        {
+            var result = UnitResult.Success<E>();
+
+            await result.Match(OnSuccess_K_ValueTask, OnFailure_E_K_ValueTask);
+
+            AssertSuccess();
+        }
+
+        [Fact]
+        public async Task Match_ValueTask_Right_UnitResult_E_Failure_Returns_K()
+        {
+            var result = UnitResult.Failure(E.Value);
+
+            await result.Match(OnSuccess_K_ValueTask, OnFailure_E_K_ValueTask);
+
+            AssertFailure();
+        }
     }
 }

--- a/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/MatchTests.ValueTask.cs
+++ b/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/MatchTests.ValueTask.cs
@@ -158,5 +158,25 @@ namespace CSharpFunctionalExtensions.Tests.ResultTests.Extensions
 
             AssertFailure();
         }
+        
+        [Fact]
+        public async Task Match_ValueTask_UnitResult_E_Success_Returns_K()
+        {
+            var result = UnitResult.Success<E>().AsValueTask();
+
+            await result.Match(OnSuccess_K_ValueTask, OnFailure_E_K_ValueTask);
+
+            AssertSuccess();
+        }
+
+        [Fact]
+        public async Task Match_ValueTask_UnitResult_E_Failure_Returns_K()
+        {
+            var result = UnitResult.Failure(E.Value).AsValueTask();
+
+            await result.Match(OnSuccess_K_ValueTask, OnFailure_E_K_ValueTask);
+
+            AssertFailure();
+        }
     }
 }

--- a/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/MatchTests.cs
+++ b/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/MatchTests.cs
@@ -156,5 +156,29 @@ namespace CSharpFunctionalExtensions.Tests.ResultTests.Extensions
 
             AssertFailure();
         }
+        
+        [Fact]
+        public void Match_UnitResult_E_Success_Returns_K()
+        {
+            var result = UnitResult.Success<E>();
+
+            var matched = result.Match(OnSuccess_K, OnFailure_E_K);
+
+            AssertSuccess();
+            
+            matched.Should().Be(K.Value);
+        }
+        
+        [Fact]
+        public void Match_UnitResult_E_Failure_Returns_K()
+        {
+            var result = UnitResult.Failure(E.Value);
+
+            var matched = result.Match(OnSuccess_K, OnFailure_E_K);
+
+            AssertFailure();
+            
+            matched.Should().Be(K.Value2);
+        }
     }
 }

--- a/CSharpFunctionalExtensions/Result/Methods/Extensions/Match.Task.Left.cs
+++ b/CSharpFunctionalExtensions/Result/Methods/Extensions/Match.Task.Left.cs
@@ -28,6 +28,17 @@ namespace CSharpFunctionalExtensions
         {
             return (await resultTask.DefaultAwait()).Match(onSuccess, onFailure);
         }
+        
+        /// <summary>
+        ///     Returns the result of the given <paramref name="onSuccess"/> function if the calling Result is a success. Otherwise, it returns the result of the given <paramref name="onFailure"/> function.
+        /// </summary>
+        public static async Task<K> Match<K, E>(
+            this Task<UnitResult<E>> resultTask,
+            Func<K> onSuccess, 
+            Func<E, K> onFailure)
+        {
+            return (await resultTask.DefaultAwait()).Match(onSuccess, onFailure);
+        }
 
         /// <summary>
         ///     Invokes the given <paramref name="onSuccess"/> action if the calling Result is a success. Otherwise, it invokes the given <paramref name="onFailure"/> action.

--- a/CSharpFunctionalExtensions/Result/Methods/Extensions/Match.Task.Right.cs
+++ b/CSharpFunctionalExtensions/Result/Methods/Extensions/Match.Task.Right.cs
@@ -34,6 +34,16 @@ namespace CSharpFunctionalExtensions
                 ? onSuccess()
                 : onFailure(result.Error);
         }
+        
+        /// <summary>
+        ///     Returns the result of the given <paramref name="onSuccess"/> function if the calling Result is a success. Otherwise, it returns the result of the given <paramref name="onFailure"/> function.
+        /// </summary>
+        public static Task<K> Match<K, E>(this UnitResult<E> result, Func<Task<K>> onSuccess, Func<E, Task<K>> onFailure)
+        {
+            return result.IsSuccess
+                ? onSuccess()
+                : onFailure(result.Error);
+        }
 
         /// <summary>
         ///     Invokes the given <paramref name="onSuccess"/> action if the calling Result is a success. Otherwise, it invokes the given <paramref name="onFailure"/> action.

--- a/CSharpFunctionalExtensions/Result/Methods/Extensions/Match.Task.cs
+++ b/CSharpFunctionalExtensions/Result/Methods/Extensions/Match.Task.cs
@@ -31,6 +31,15 @@ namespace CSharpFunctionalExtensions
             return await (await resultTask.DefaultAwait())
                 .Match(onSuccess, onFailure).DefaultAwait();
         }
+        
+        /// <summary>
+        ///     Returns the result of the given <paramref name="onSuccess"/> function if the calling Result is a success. Otherwise, it returns the result of the given <paramref name="onFailure"/> function.
+        /// </summary>
+        public static async Task<K> Match<K, E>(this Task<UnitResult<E>> resultTask, Func<Task<K>> onSuccess, Func<E, Task<K>> onFailure)
+        {
+            return await (await resultTask.DefaultAwait())
+                .Match(onSuccess, onFailure).DefaultAwait();
+        }
 
         /// <summary>
         ///     Invokes the given <paramref name="onSuccess"/> action if the calling Result is a success. Otherwise, it invokes the given <paramref name="onFailure"/> action.

--- a/CSharpFunctionalExtensions/Result/Methods/Extensions/Match.ValueTask.Left.cs
+++ b/CSharpFunctionalExtensions/Result/Methods/Extensions/Match.ValueTask.Left.cs
@@ -31,6 +31,14 @@ namespace CSharpFunctionalExtensions.ValueTasks
         }
 
         /// <summary>
+        ///     Returns the result of the given <paramref name="onSuccess"/> valueTask action if the calling Result is a success. Otherwise, it returns the result of the given <paramref name="onFailure"/> valueTask action.
+        /// </summary>
+        public static async ValueTask<K> Match<K, E>(this ValueTask<UnitResult<E>> resultTask, Func<K> onSuccess, Func<E, K> onFailure)
+        {
+            return (await resultTask).Match(onSuccess, onFailure);
+        }
+
+        /// <summary>
         ///     Invokes the given <paramref name="onSuccess"/> action if the calling Result is a success. Otherwise, it invokes the given <paramref name="onFailure"/> action.
         /// </summary>
         public static async Task Match<T, E>(this ValueTask<Result<T, E>> resultTask, Action<T> onSuccess, Action<E> onFailure)

--- a/CSharpFunctionalExtensions/Result/Methods/Extensions/Match.ValueTask.Right.cs
+++ b/CSharpFunctionalExtensions/Result/Methods/Extensions/Match.ValueTask.Right.cs
@@ -37,6 +37,16 @@ namespace CSharpFunctionalExtensions.ValueTasks
         }
 
         /// <summary>
+        ///      Returns the result of the given <paramref name="onSuccessValueTask"/> valueTask action if the calling Result is a success. Otherwise, it returns the result of the given <paramref name="onFailureValueTask"/> valueTask action.
+        /// </summary>
+        public static ValueTask<K> Match<K, E>(this UnitResult<E> result, Func<ValueTask<K>> onSuccessValueTask, Func<E, ValueTask<K>> onFailureValueTask)
+        {
+            return result.IsSuccess
+                ? onSuccessValueTask()
+                : onFailureValueTask(result.Error);
+        }
+
+        /// <summary>
         ///     Invokes the given <paramref name="onSuccessValueTask"/> action if the calling Result is a success. Otherwise, it invokes the given <paramref name="onFailureValueTask"/> action.
         /// </summary>
         public static ValueTask Match<T, E>(this Result<T, E> result, Func<T, ValueTask> onSuccessValueTask, Func<E, ValueTask> onFailureValueTask)

--- a/CSharpFunctionalExtensions/Result/Methods/Extensions/Match.ValueTask.cs
+++ b/CSharpFunctionalExtensions/Result/Methods/Extensions/Match.ValueTask.cs
@@ -32,6 +32,15 @@ namespace CSharpFunctionalExtensions.ValueTasks
             return await (await resultTask)
                 .Match(onSuccessValueTask, onFailureValueTask);
         }
+        
+        /// <summary>
+        ///     Returns the result of the given <paramref name="onSuccessValueTask"/> valueTask action if the calling Result is a success. Otherwise, it returns the result of the given <paramref name="onFailureValueTask"/> valueTask action.
+        /// </summary>
+        public static async ValueTask<K> Match<K, E>(this ValueTask<UnitResult<E>> resultTask, Func<ValueTask<K>> onSuccessValueTask, Func<E, ValueTask<K>> onFailureValueTask)
+        {
+            return await (await resultTask)
+                .Match(onSuccessValueTask, onFailureValueTask);
+        }
 
         /// <summary>
         ///     Invokes the given <paramref name="onSuccessValueTask"/> action if the calling Result is a success. Otherwise, it invokes the given <paramref name="onFailureValueTask"/> action.

--- a/CSharpFunctionalExtensions/Result/Methods/Extensions/Match.cs
+++ b/CSharpFunctionalExtensions/Result/Methods/Extensions/Match.cs
@@ -36,6 +36,16 @@ namespace CSharpFunctionalExtensions
                 ? onSuccess()
                 : onFailure(result.Error);
         }
+        
+        /// <summary>
+        ///     Returns the result of the given <paramref name="onSuccess"/> function if the calling Result is a success. Otherwise, it returns the result of the given <paramref name="onFailure"/> function.
+        /// </summary>
+        public static K Match<K, E>(this UnitResult<E> result, Func<K> onSuccess, Func<E, K> onFailure)
+        {
+            return result.IsSuccess 
+                ? onSuccess() 
+                : onFailure(result.Error);
+        }
 
         /// <summary>
         ///     Invokes the given <paramref name="onSuccess"/> action if the calling Result is a success. Otherwise, it invokes the given <paramref name="onFailure"/> action.


### PR DESCRIPTION
This is a use case this PR fixes:
![image](https://user-images.githubusercontent.com/9553053/235920293-d4800a5a-e064-44cd-b4eb-4b701e586a1b.png)
