### PR TITLE
Make Entity implement IComparable

### DIFF
--- a/CSharpFunctionalExtensions.Tests/EntityTests/IComparableTests.cs
+++ b/CSharpFunctionalExtensions.Tests/EntityTests/IComparableTests.cs
@@ -1,0 +1,72 @@
+﻿using System;
+using System.Linq;
+using FluentAssertions;
+using Xunit;
+
+namespace CSharpFunctionalExtensions.Tests.EntityTests
+{
+    public class IComparableTests
+    {
+        [Fact]
+        public void Can_sort_entities()
+        {
+            var entity1 = new MyEntity(1);
+            var entity2 = new MyEntity(2);
+            var entity3 = new MyEntity(3);
+            var entity4 = new MyEntity(4);
+
+            MyEntity[] myEntities = new[] { entity3, entity1, entity4, entity2 }
+                .OrderBy(x => x)
+                .ToArray();
+
+            myEntities[0].Should().BeSameAs(entity1);
+            myEntities[1].Should().BeSameAs(entity2);
+            myEntities[2].Should().BeSameAs(entity3);
+            myEntities[3].Should().BeSameAs(entity4);
+        }
+
+        [Fact]
+        public void Entities_with_different_id_types_are_comparatively_null()
+        {
+            var longEntity = new MyEntity(1);
+            var guidEntity = new MyOtherEntity(new Guid("282e6fe9-a272-45da-aa16-757449ab2818"));
+
+            int result1 = longEntity.CompareTo(guidEntity);
+            int result2 = guidEntity.CompareTo(longEntity);
+
+            result1.Should().Be(1);
+            result2.Should().Be(1);
+        }
+
+        [Fact]
+        public void Can_sort_entity_that_is_null()
+        {
+            var entity1 = new MyEntity(1);
+            var entity2 = new MyEntity(2);
+
+            MyEntity[] entities = new[] { entity1, entity2, null }
+                .OrderBy(x => x)
+                .ToArray();
+
+            entities[0].Should().BeNull();
+            entities[1].Should().BeSameAs(entity1);
+            entities[2].Should().BeSameAs(entity2);
+        }
+        
+        private class MyEntity : Entity
+        {
+            public MyEntity(long id)
+                : base(id)
+            {
+            }
+        }
+        
+        private class MyOtherEntity : Entity<Guid>
+        {
+            public MyOtherEntity(Guid id)
+                : base(id)
+            {
+            }
+        }
+    }
+}

--- a/CSharpFunctionalExtensions/Entity/Entity.cs
+++ b/CSharpFunctionalExtensions/Entity/Entity.cs
@@ -1,6 +1,8 @@
-﻿namespace CSharpFunctionalExtensions
+﻿using System;
+
+namespace CSharpFunctionalExtensions
 {
-    public abstract class Entity<TId>
+    public abstract class Entity<TId> : IComparable, IComparable<Entity<TId>> where TId : IComparable<TId>
     {
         public virtual TId Id { get; protected set; }
 
@@ -54,6 +56,22 @@
         public override int GetHashCode()
         {
             return (ValueObject.GetUnproxiedType(this).ToString() + Id).GetHashCode();
+        }
+
+        public virtual int CompareTo(Entity<TId> other)
+        {
+            if (other is null)
+                return 1;
+
+            if (ReferenceEquals(this, other))
+                return 0;
+
+            return Id.CompareTo(other.Id);
+        }
+
+        public virtual int CompareTo(object other)
+        {
+            return CompareTo(other as Entity<TId>);
         }
     }
 

--- a/CSharpFunctionalExtensions/ValueObject/ValueObject.cs
+++ b/CSharpFunctionalExtensions/ValueObject/ValueObject.cs
@@ -59,8 +59,8 @@ namespace CSharpFunctionalExtensions
             return
                 GetEqualityComponents().Zip(
                     other.GetEqualityComponents(),
-                    (left, rigth) =>
-                        left?.CompareTo(rigth) ?? (rigth is null ? 0 : -1))
+                    (left, right) =>
+                        left?.CompareTo(right) ?? (right is null ? 0 : -1))
                 .FirstOrDefault(cmp => cmp != 0);
         }
 


### PR DESCRIPTION
Having Entity implement IComparable allows entities to be implicitly used as equality components in ValueObjects.

This PR relates to Issue #509.
