### PR TITLE
Add two additional TapIf.Task functions

### DIFF
--- a/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/TapIfTests.Base.cs
+++ b/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/TapIfTests.Base.cs
@@ -71,7 +71,7 @@ namespace CSharpFunctionalExtensions.Tests.ResultTests.Extensions
             actionExecuted = true;
             return Result.Success().AsTask();
         }
-
+        
         protected Task<Result<K>> Task_Func_Result_K(bool _)
         {
             actionExecuted = true;
@@ -135,6 +135,12 @@ namespace CSharpFunctionalExtensions.Tests.ResultTests.Extensions
                 predicateExecuted = true;
                 return value;
             };
+        }
+        
+        protected Task<bool> Task_Predicate(bool a)
+        {
+            predicateExecuted = true;
+            return Task.FromResult(a);
         }
     }
 }

--- a/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/TapIfTests.Task.cs
+++ b/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/TapIfTests.Task.cs
@@ -1,4 +1,5 @@
-﻿using FluentAssertions;
+﻿using System.Threading.Tasks;
+using FluentAssertions;
 using Xunit;
 
 namespace CSharpFunctionalExtensions.Tests.ResultTests.Extensions
@@ -138,6 +139,38 @@ namespace CSharpFunctionalExtensions.Tests.ResultTests.Extensions
             Result<bool, E> result = Result.SuccessIf(isSuccess, condition, E.Value);
 
             var returned = result.AsTask().TapIf(Predicate, Task_Action_T).Result;
+
+            predicateExecuted.Should().Be(isSuccess);
+            actionExecuted.Should().Be(isSuccess && condition);
+            result.Should().Be(returned);
+        }
+        
+        [Theory]
+        [InlineData(true, true)]
+        [InlineData(true, false)]
+        [InlineData(false, true)]
+        [InlineData(false, false)]
+        public async Task TapIf_Task_T_E_executes_action_Task_T_per_predicate_and_returns_self(bool isSuccess, bool condition)
+        {
+            Result<bool, E> result = Result.SuccessIf(isSuccess, condition, E.Value);
+
+            var returned = await result.AsTask().TapIf(() => Task_Predicate(condition), Task_Action_T);
+
+            predicateExecuted.Should().Be(isSuccess);
+            actionExecuted.Should().Be(isSuccess && condition);
+            result.Should().Be(returned);
+        }
+
+        [Theory]
+        [InlineData(true, true)]
+        [InlineData(true, false)]
+        [InlineData(false, true)]
+        [InlineData(false, false)]
+        public async Task TapIf_Task_T_E_executes_action_Task_T_per_predicate_T_and_returns_self(bool isSuccess, bool condition)
+        {
+            Result<bool, E> result = Result.SuccessIf(isSuccess, condition, E.Value);
+
+            var returned = await result.AsTask().TapIf(Task_Predicate, Task_Action_T);
 
             predicateExecuted.Should().Be(isSuccess);
             actionExecuted.Should().Be(isSuccess && condition);

--- a/CSharpFunctionalExtensions/Result/Methods/Extensions/TapIf.Task.cs
+++ b/CSharpFunctionalExtensions/Result/Methods/Extensions/TapIf.Task.cs
@@ -135,5 +135,32 @@ namespace CSharpFunctionalExtensions
             else
                 return result;
         }
+        
+        /// <summary>
+        ///     Executes the given action if the calling result is a success and condition is true. Returns the calling result.
+        /// </summary>
+        public static async Task<Result<T, E>> TapIf<T, E>(this Task<Result<T, E>> resultTask, Func<Task<bool>> predicate, Func<T, Task> func)
+        {
+            Result<T, E> result = await resultTask.DefaultAwait();
+            
+            if (result.IsSuccess && await predicate().DefaultAwait())
+                return await result.Tap(func).DefaultAwait();
+            else
+                return result;
+        }
+
+        /// <summary>
+        ///     Executes the given action if the calling result is a success and condition is true. Returns the calling result.
+        /// </summary>
+        public static async Task<Result<T, E>> TapIf<T, E>(this Task<Result<T, E>> resultTask, Func<T, Task<bool>> predicate, Func<T, Task> func)
+        {
+            Result<T, E> result = await resultTask.DefaultAwait();
+            
+            if (result.IsSuccess && await predicate(result.Value).DefaultAwait())
+                return await result.Tap(func).DefaultAwait();
+            else
+                return result;
+        }
+
     }
 }


### PR DESCRIPTION
This PR adds two additional `TapIf.Task` functional extensions to the Result type.

Sorry, if the formatting doesn't entirely match the remainder of the repo, it's my first PR here :)
I tried to keep it as consistent as possible with most other functions I could find under the same extension directory.