### PR TITLE
Switch to license expression for package license

### DIFF
--- a/CSharpFunctionalExtensions/CSharpFunctionalExtensions.csproj
+++ b/CSharpFunctionalExtensions/CSharpFunctionalExtensions.csproj
@@ -6,7 +6,7 @@
     <Description>CSharpFunctionalExtensions - functional extensions for C#</Description>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <PackageTags>C# Functional</PackageTags>
-    <PackageLicense>https://github.com/vkhorikov/CSharpFunctionalExtensions/blob/master/LICENSE</PackageLicense>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageProjectUrl>https://enterprisecraftsmanship.com/ps-func</PackageProjectUrl>
     <RepositoryUrl>https://github.com/vkhorikov/CSharpFunctionalExtensions/</RepositoryUrl>
     <NeutralLanguage>en-US</NeutralLanguage>


### PR DESCRIPTION
In order to ease retrieval of license by tooling aiming to check them, as well as ensuring that a change to the master branch license would not be retroactively applied to older packages, I would propose to use [PackageLicenseExpression](https://learn.microsoft.com/en-us/nuget/reference/msbuild-targets#packing-a-license-expression-or-a-license-file) to pack the nuget package, rather than rely on a reference to the LICENSE file in the master branch of the repository.

