### PR TITLE
Add Select/SelectMany Result methods to perform do-notation like operation via LINQ

### DIFF
--- a/CSharpFunctionalExtensions.Tests/ResultTests/Methods/SelectTests.cs
+++ b/CSharpFunctionalExtensions.Tests/ResultTests/Methods/SelectTests.cs
@@ -1,0 +1,98 @@
+﻿using System.Threading.Tasks;
+using FluentAssertions;
+using FluentAssertions.Execution;
+using Xunit;
+
+namespace CSharpFunctionalExtensions.Tests.ResultTests.Methods;
+
+public class SelectTests : TestBase
+{
+    private static class Fixture
+    {
+        public const string ExpectingValue = "Hello, LINQ";
+    }
+
+    [Fact]
+    public void Select_Result_then_Select_Another_Result_return_success()
+    {
+        var result = (
+            from s in FetchSome()
+            from a in FetchAnother()
+            select MapFetches(s, a)
+        );
+
+        using (_ = new AssertionScope())
+        {
+            var (isSuccess, _, resultValue) = result;
+
+            isSuccess.Should().BeTrue();
+            resultValue.Should().Be(Fixture.ExpectingValue);
+        }
+    }
+
+    [Fact]
+    public void Select_Result_of_Error_then_Select_Another_Result_return_first_failure()
+    {
+        var result = (
+            from s in FetchSomeError()
+            from a in FetchAnother()
+            select MapFetches(s, a)
+        );
+
+        using (_ = new AssertionScope())
+        {
+            var (_, isFailure, _, error) = result;
+
+            isFailure.Should().BeTrue();
+            error.Should().Be(ErrorMessage);
+        }
+    }
+
+    [Fact]
+    public async Task Select_ResultTask_then_Select_Another_Result_return_success()
+    {
+        var result = await (
+            from s in FetchSome().AsCompletedTask()
+            from a in FetchAnother()
+            select MapFetches(s, a)
+        );
+
+        using (_ = new AssertionScope())
+        {
+            var (isSuccess, _, resultValue) = result;
+
+            isSuccess.Should().BeTrue();
+            resultValue.Should().Be(Fixture.ExpectingValue);
+        }
+    }
+
+    [Fact]
+    public async Task Select_ResultTask_of_Error_then_Select_Another_Result_return_first_failure()
+    {
+        var result = await (
+            from s in FetchSomeError().AsCompletedTask()
+            from a in FetchAnother()
+            select MapFetches(s, a)
+        );
+
+        using (_ = new AssertionScope())
+        {
+            var (_, isFailure, _, error) = result;
+
+            isFailure.Should().BeTrue();
+            error.Should().Be(ErrorMessage);
+        }
+    }
+
+    private static Result<T> FetchSome() =>
+        T.Value;
+
+    private static Result<T> FetchSomeError() =>
+        Result.Failure<T>(ErrorMessage);
+
+    private static Result<K> FetchAnother() =>
+        K.Value;
+
+    private static string MapFetches(T s, K a) =>
+        Fixture.ExpectingValue;
+}

--- a/CSharpFunctionalExtensions/Result/Methods/Select.cs
+++ b/CSharpFunctionalExtensions/Result/Methods/Select.cs
@@ -1,0 +1,58 @@
+﻿using System;
+using System.Threading.Tasks;
+
+namespace CSharpFunctionalExtensions
+{
+    public readonly partial struct Result<T>
+    {
+        /// <summary>
+        /// Bind operation for performing do-notation like LINQ operation.
+        /// </summary>
+        public Result<K> Select<K>(Func<T, K> func) =>
+            IsFailure ? Result.Failure<K>(Error) : func(Value);
+
+        /// <summary>
+        /// Bind operation for performing do-notation like LINQ operation.
+        /// </summary>
+        public async Task<Result<K>> Select<K>(Func<T, Task<K>> func) {
+            if (IsFailure)
+            {
+                return Result.Failure<K>(Error);
+            }
+
+            return await func(Value).DefaultAwait();
+        }
+
+        public Result<C> SelectMany<K, C>(
+            Func<T, Result<K>> bind, Func<T, K, C> project
+        ) {
+            if (IsFailure)
+            {
+                return Result.Failure<C>(Error);
+            }
+
+            var resultToBind = bind(Value);
+
+            return resultToBind.IsFailure
+                ? Result.Failure<C>(resultToBind.Error)
+                : project(Value, resultToBind.Value);
+        }
+
+        public async Task<Result<C>> SelectMany<B, C>(
+            Func<T, Result<B>> bind, Func<T, B, Task<C>> project
+        ) {
+            if (IsFailure) {
+                return Result.Failure<C>(Error);
+            }
+
+            var resultToBind = bind(Value);
+
+            if (resultToBind.IsFailure)
+            {
+                return Result.Failure<C>(resultToBind.Error);
+            }
+
+            return await project(Value, resultToBind.Value).DefaultAwait();
+        }
+    }
+}


### PR DESCRIPTION
This one address same problem from a proposal in #535.

```csharp
var result = await (
    from one in Result.Success(1)
    from two in Result.Success(2)
    from three in Task.FromResult(Result.Success(3))
    select one + two + three
);

Assert(result.Value, 6);
```