### PR TITLE
Add IError<string> to the Result struct

### DIFF
--- a/CSharpFunctionalExtensions/Result/Result.cs
+++ b/CSharpFunctionalExtensions/Result/Result.cs
@@ -5,7 +5,7 @@ using System.Runtime.Serialization;
 namespace CSharpFunctionalExtensions
 {
     [Serializable]
-    public readonly partial struct Result : IResult, ISerializable
+    public readonly partial struct Result : IResult, ISerializable, IError<string>
     {
         public bool IsFailure { get; }
         public bool IsSuccess => !IsFailure;


### PR DESCRIPTION
Adding `IError<string>` interface to the `Result` struct.

Fixes #546