### PR TITLE
Result<T, E>::GetValueOrDefault()

### DIFF
--- a/CSharpFunctionalExtensions/Result/ResultTE.cs
+++ b/CSharpFunctionalExtensions/Result/ResultTE.cs
@@ -36,6 +36,14 @@ namespace CSharpFunctionalExtensions
             ResultCommonLogic.GetObjectData(this, info);
         }
 
+        public T GetValueOrDefault(T defaultValue = default)
+        {
+            if (IsFailure)
+                return defaultValue;
+
+            return Value;
+        }
+
         public static implicit operator Result<T, E>(T value)
         {
             if (value is IResult<T, E> result)


### PR DESCRIPTION
GetValueOrDefault() is available for Result<T>, but not for Result<T, E>.