### PR TITLE
Add `Result.Of` methods

### DIFF
--- a/CSharpFunctionalExtensions.Tests/ResultTests/Methods/OfTests.cs
+++ b/CSharpFunctionalExtensions.Tests/ResultTests/Methods/OfTests.cs
@@ -1,0 +1,105 @@
+﻿using System;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Xunit;
+
+namespace CSharpFunctionalExtensions.Tests.ResultTests.Methods;
+
+public class OfTests
+{
+    [Fact]
+    public void Of_can_create_ResultT_from_value()
+    {
+        string value = "value";
+
+        Result<string> result = Result.Of(value);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().Be(value);
+    }
+
+    [Fact]
+    public void Of_can_create_ResultT_from_func()
+    {
+        string value = "value";
+        Func<string> func = () => value;
+
+        Result<string> result = Result.Of(func);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().Be(value);
+    }
+
+    [Fact]
+    public async Task Of_can_create_ResultT_from_valueTask()
+    {
+        string value = "value";
+        Task<string> valueTask = Task.FromResult(value);
+
+        Result<string> result = await Result.Of(valueTask);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().Be(value);
+    }
+
+    [Fact]
+    public async Task Of_can_create_ResultT_from_valueTaskFunc()
+    {
+        string value = "value";
+        Task<string> valueTask = Task.FromResult(value);
+        Func<Task<string>> valueTaskFunc = () => valueTask;
+
+        Result<string> result = await Result.Of(valueTaskFunc);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().Be(value);
+    }
+
+    [Fact]
+    public void Of_can_create_ResultTE_from_value()
+    {
+        string value = "value";
+
+        Result<string, object> result = Result.Of<string, object>(value);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().Be(value);
+    }
+
+    [Fact]
+    public void Of_can_create_ResultTE_from_func()
+    {
+        string value = "value";
+        Func<string> func = () => value;
+
+        Result<string, object> result = Result.Of<string, object>(func);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().Be(value);
+    }
+
+    [Fact]
+    public async Task Of_can_create_ResultTE_from_valueTask()
+    {
+        string value = "value";
+        Task<string> valueTask = Task.FromResult(value);
+
+        Result<string, object> result = await Result.Of<string, object>(valueTask);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().Be(value);
+    }
+
+    [Fact]
+    public async Task Of_can_create_ResultTE_from_valueTaskFunc()
+    {
+        string value = "value";
+        Task<string> valueTask = Task.FromResult(value);
+        Func<Task<string>> valueTaskFunc = () => valueTask;
+
+        Result<string, object> result = await Result.Of<string, object>(valueTaskFunc);
+
+        result.IsSuccess.Should().BeTrue();
+        result.Value.Should().Be(value);
+    }
+}

--- a/CSharpFunctionalExtensions/Result/Methods/Of.cs
+++ b/CSharpFunctionalExtensions/Result/Methods/Of.cs
@@ -1,0 +1,84 @@
+﻿using System;
+using System.Threading.Tasks;
+
+namespace CSharpFunctionalExtensions
+{
+    public partial struct Result
+    {
+        /// <summary>
+        ///     Creates a successful <see cref="Result{T}" /> containing the given value.
+        /// </summary>
+        public static Result<T> Of<T>(T value) where T : notnull
+        {
+            return new Result<T>(false, default, value);
+        }
+
+        /// <summary>
+        ///     Creates a successful <see cref="Result{T}" /> containing the given value from a <see cref="Func{T}" />.
+        /// </summary>
+        public static Result<T> Of<T>(Func<T> func) where T : notnull
+        {
+            T value = func();
+
+            return new Result<T>(false, default, value);
+        }
+
+        /// <summary>
+        ///     Creates a successful <see cref="Result{T}" /> containing the given async value.
+        /// </summary>
+        public static async Task<Result<T>> Of<T>(Task<T> valueTask) where T : notnull
+        {
+            T value = await valueTask;
+
+            return new Result<T>(false, default, value);
+        }
+
+        /// <summary>
+        ///     Creates a successful <see cref="Result{T}" /> containing the given value from an async <see cref="Func{T}" />.
+        /// </summary>
+        public static async Task<Result<T>> Of<T>(Func<Task<T>> valueTaskFunc) where T : notnull
+        {
+            T value = await valueTaskFunc();
+
+            return new Result<T>(false, default, value);
+        }
+
+        /// <summary>
+        ///     Creates a successful <see cref="Result{T}" /> containing the given value.
+        /// </summary>
+        public static Result<T, E> Of<T, E>(T value) where T : notnull
+        {
+            return new Result<T, E>(false, default, value);
+        }
+
+        /// <summary>
+        ///     Creates a successful <see cref="Result{T}" /> containing the given value from a <see cref="Func{T}" />.
+        /// </summary>
+        public static Result<T, E> Of<T, E>(Func<T> func) where T : notnull
+        {
+            T value = func();
+
+            return new Result<T, E>(false, default, value);
+        }
+
+        /// <summary>
+        ///     Creates a successful <see cref="Result{T}" /> containing the given async value.
+        /// </summary>
+        public static async Task<Result<T, E>> Of<T, E>(Task<T> valueTask) where T : notnull
+        {
+            T value = await valueTask;
+
+            return new Result<T, E>(false, default, value);
+        }
+
+        /// <summary>
+        ///     Creates a successful <see cref="Result{T}" /> containing the given value from an async <see cref="Func{T}" />.
+        /// </summary>
+        public static async Task<Result<T, E>> Of<T, E>(Func<Task<T>> valueTaskFunc) where T : notnull
+        {
+            T value = await valueTaskFunc();
+
+            return new Result<T, E>(false, default, value);
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -487,6 +487,15 @@ Result<FruitInventory> failedOperation = Result.Failure<FruitInventory>("Could n
 Result successInventoryUpdate = Result.Success();
 ```
 
+To create a success result of a value you can also use the `Of` method which has overloads for `Func<T>` and `Task<T>`.
+
+```csharp
+Result<Something> something = Result.Of(_service.CreateSomething());
+Result<Something> something = await Result.Of(_service.CreateSomethingAsync());
+Result<Something> something = Result.Of(() => _service.CreateSomething());
+Result<Something> something = await Result.Of(() => _service.CreateSomethingAsync());
+```
+
 #### Conditional Construction: SuccessIf and FailureIf
 
 Use case: Creating successful or failed Results based on expressions or delegates instead of if/else statements or ternary expressions


### PR DESCRIPTION
- add `Result.Of` methods to start a chain with a successful `Result<T>`
- add tests for `Of` method
- add `Of` examples to README

closes #556 