### PR TITLE
Add allocation-free Maybe.Bind overload

### DIFF
--- a/CSharpFunctionalExtensions.Tests/MaybeTests/Extensions/BindTests.cs
+++ b/CSharpFunctionalExtensions.Tests/MaybeTests/Extensions/BindTests.cs
@@ -35,5 +35,63 @@ namespace CSharpFunctionalExtensions.Tests.MaybeTests.Extensions
             maybe2.HasValue.Should().BeTrue();
             maybe2.Value.Should().Be(T.Value);
         }
+
+        [Fact]
+        public void Bind_provides_context_to_selector()
+        {
+            Maybe<T> maybe = null;
+            var context = 5;
+
+            var maybe2 = maybe.Bind(
+                (value, ctx) =>
+                {
+                    ctx.Should().Be(context);
+                    return Maybe.From(value);
+                },
+                context
+            );
+
+            maybe2.HasValue.Should().BeFalse();
+        }
+
+        [Fact]
+        public void Bind_with_context_returns_no_value_if_initial_maybe_is_null()
+        {
+            Maybe<T> maybe = null;
+
+            var maybe2 = maybe.Bind(
+                (value, _) => ExpectAndReturnMaybe(null, T.Value)(value),
+                context: 5
+            );
+
+            maybe2.HasValue.Should().BeFalse();
+        }
+
+        [Fact]
+        public void Bind_with_context_returns_no_value_if_selector_returns_null()
+        {
+            Maybe<T> maybe = T.Value;
+
+            var maybe2 = maybe.Bind(
+                (value, _) => ExpectAndReturn(T.Value, Maybe<T>.None)(value),
+                context: 5
+            );
+
+            maybe2.HasValue.Should().BeFalse();
+        }
+
+        [Fact]
+        public void Bind_with_context_returns_value_if_selector_returns_value()
+        {
+            Maybe<T> maybe = T.Value;
+
+            var maybe2 = maybe.Bind(
+                (value, _) => ExpectAndReturnMaybe<T>(T.Value, T.Value)(value),
+                5
+            );
+
+            maybe2.HasValue.Should().BeTrue();
+            maybe2.Value.Should().Be(T.Value);
+        }
     }
 }

--- a/CSharpFunctionalExtensions/Maybe/Extensions/Bind.cs
+++ b/CSharpFunctionalExtensions/Maybe/Extensions/Bind.cs
@@ -11,5 +11,17 @@ namespace CSharpFunctionalExtensions
 
             return selector(maybe.GetValueOrThrow());
         }
+
+        public static Maybe<K> Bind<T, K, TContext>(
+            in this Maybe<T> maybe,
+            Func<T, TContext, Maybe<K>> selector,
+            TContext context
+        )
+        {
+            if (maybe.HasNoValue)
+                return Maybe<K>.None;
+
+            return selector(maybe.GetValueOrThrow(), context);
+        }
     }
 }


### PR DESCRIPTION
For now I've added just the Maybe.Bind overload in order for the approach to be validated.
1. Is the naming OK? (`context`)?
2. Is it OK that the logic is duplicated in allocating and non-allocating overloads? Is it possible to not duplicate the code?
3. Are tests alright?

When the approach gets approved, I will be able to create overloads for other extensions.

This PR is the result of https://github.com/vkhorikov/CSharpFunctionalExtensions/discussions/562.