### PR TITLE
added select overload with projection for result

### DIFF
--- a/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/SelectTests.cs
+++ b/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/SelectTests.cs
@@ -1,0 +1,51 @@
+﻿using FluentAssertions;
+using Xunit;
+
+namespace CSharpFunctionalExtensions.Tests.ResultTests.Extensions;
+public class SelectTests
+{
+    [Fact]
+    public void Select_returns_new_result()
+    {
+        Result<MyClass> result = new MyClass { Property = "Some value" };
+
+        Result<string> result2 = result.Select(x => x.Property);
+
+        result2.IsSuccess.Should().BeTrue();
+        result2.GetValueOrDefault().Should().Be("Some value");
+    }
+
+    [Fact]
+    public void Select_returns_no_value_if_no_value_passed_in()
+    {
+        Result<MyClass> result = Result.Failure<MyClass>("error message");
+
+        Result<MyClass> result2 = result.Select(x => x);
+
+        result2.IsSuccess.Should().BeFalse();
+        result2.GetValueOrDefault().Should().Be(default);
+    }
+
+    [Fact]
+    public void Result_Error_Select_from_class_to_struct_retains_Error()
+    {
+        Result.Failure<string>("error message").Select(_ => 42).IsSuccess.Should().BeFalse();
+        Result.Failure<string>("error message").Select(_ => 42).Error.Should().Be("error message");
+    }
+
+    [Fact]
+    public void Result_can_be_used_with_linq_query_syntax()
+    {
+        Result<string> name = "John";
+
+        Result<string> upper = from x in name select x.ToUpper();
+
+        upper.IsSuccess.Should().BeTrue();
+        upper.GetValueOrDefault().Should().Be("JOHN");
+    }
+
+    private class MyClass
+    {
+        public string Property { get; set; }
+    }
+}

--- a/CSharpFunctionalExtensions/Result/Methods/Extensions/Select.cs
+++ b/CSharpFunctionalExtensions/Result/Methods/Extensions/Select.cs
@@ -1,0 +1,15 @@
+﻿using System;
+
+namespace CSharpFunctionalExtensions
+{
+    public static partial class ResultExtensions
+    {
+        /// <summary>
+        ///     This method should be used in linq queries. We recommend using Map method.
+        /// </summary>
+        public static Result<K> Select<T, K>(in this Result<T> result, Func<T, K> selector)
+        {
+            return result.Map(selector);
+        }
+    }
+}


### PR DESCRIPTION
This extension allows you to use the linq query syntax for result as we are currently already able to do using maybe. 

Whereas this code worked before
```csharp
Maybe<string> name = "John";

var upper = from x in name select x.ToUpper();
```

This very similar code would not
```csharp
Result<string> name = "John";

var upper = from x in name select x.ToUpper();
```

Adding an overload to Select with a projection allow for greater flexibility in monadic operations using the linq query syntax which enables the user to pass in values from previous operations down the monadic chain. 

This is related to issue [566](https://github.com/vkhorikov/CSharpFunctionalExtensions/issues/566)
