### PR TITLE
Fail pipeline if test results file is missing

### DIFF
--- a/CSharpFunctionalExtensions.Tests/CSharpFunctionalExtensions.Tests.csproj
+++ b/CSharpFunctionalExtensions.Tests/CSharpFunctionalExtensions.Tests.csproj
@@ -1,8 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <NoWarn>0618</NoWarn>
+    <EnableUnsafeBinaryFormatterSerialization>true</EnableUnsafeBinaryFormatterSerialization>
   </PropertyGroup>
 
   <ItemGroup>

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -44,6 +44,14 @@ stages:
     - script: |
         docker create --name build-container build-image
         docker cp build-container:./app/CSharpFunctionalExtensions.Tests/TestResults ./testresults
+
+        # This will make sure that the pipeline fails if the tests were not executed for any reason
+        if [ ./testresults/testresults.trx ] && [ $(grep -E "<UnitTestResult" ./testresults/testresults.trx -c) -gt 0 ]; then
+          echo "Test results results found"
+        else
+          echo "No test results found"
+          exit 1
+        fi
       displayName: Extract test results
 
     - task: PublishTestResults@2


### PR DESCRIPTION
The changes in this PR will make sure that the build pipeline fails if no tests were run for any reason.
This will prevent issues like #580 in the future.

The PR also fixes the failing tests project.
This also revealed another issue regarding obsolete `BinaryFormatter`.
New issue #587 was opened to address this.

Resolves: #580