### PR TITLE
ResultAsMaybe

### DIFF
--- a/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/AsMaybeTests.cs
+++ b/CSharpFunctionalExtensions.Tests/ResultTests/Extensions/AsMaybeTests.cs
@@ -1,0 +1,35 @@
+using Xunit;
+using FluentAssertions;
+
+namespace CSharpFunctionalExtensions.Tests.ResultTests.Extensions;
+
+public class AsMaybeTests : TestBase
+{
+    [Fact]
+    public void Error_returns_None()
+    {
+        var result = Result.Failure<T>(ErrorMessage);
+        result.AsMaybe().HasValue.Should().BeFalse();
+    }
+    
+    [Fact]
+    public void Success_returns_Some()
+    {
+        var result = Result.Success(T.Value);
+        var asMaybe = result.AsMaybe();
+        
+        asMaybe.HasValue.Should().BeTrue();
+        asMaybe.Value.Should().Be(T.Value);
+    }
+    
+    [Fact]
+    public void Null_value_returns_None()
+    {
+        var result = Result.Success<T>(null);
+        var asMaybe = result.AsMaybe();
+        
+        asMaybe.HasValue.Should().BeFalse();
+    }
+}
+
+

--- a/CSharpFunctionalExtensions/Result/Methods/Extensions/AsMaybe.cs
+++ b/CSharpFunctionalExtensions/Result/Methods/Extensions/AsMaybe.cs
@@ -1,0 +1,18 @@
+namespace CSharpFunctionalExtensions
+{
+    public static partial class ResultExtensions
+    {
+        /// <summary>
+        /// <para>Converts a <see cref="Result{T}"/> to a <see cref="Maybe{T}"/>:</para>
+        /// <para>Returns <see cref="Maybe{T}.Value"/> if the result is <c>Success</c>.</para>
+        /// Returns <see cref="Maybe{T}.None"/> if the result is <c>Error</c>.
+        /// </summary>
+
+        public static Maybe<T> AsMaybe<T>(this Result<T> result)
+        {
+            return result.IsSuccess 
+                ? Maybe<T>.From(result.Value) 
+                : Maybe<T>.None;
+        }
+    }
+}


### PR DESCRIPTION
This is a pretty simple implementation. I've explored implementations of other features of the repo and I'd need clarification regarding 3 points:

1. Task and ValueTask implementations, should we have them? I will check similar features in depth and try to replicate them, although I'd appreciate some indications.

2. I've seen `#if NET5_0_OR_GREATER` in a few places, I'm not sure if this is something I should take into account and if or how it affects this feature.

3. Result with both Success and null value: Apparently this is possible, which I guess it makes sense if you want to imply that an operation was successful even though the result is null. As far as I understand (in a Maybe), if the Value is `null`, HasValue has to be `false`. I added a test for this but it might not make sense since it is not possible to create a Maybe containing null.

I know there's a lot missing here. Please point me in the right direction and I'll keep working on it.


