### PR TITLE
Add extensions: Bind optional, ensure not, map, optional, required

### DIFF
--- a/CSharpFunctionalExtensions/Maybe/Extensions/BindOptional.cs
+++ b/CSharpFunctionalExtensions/Maybe/Extensions/BindOptional.cs
@@ -1,0 +1,17 @@
+using System;
+
+namespace CSharpFunctionalExtensions
+{
+    public static partial class MaybeExtensions
+    {
+        /// <summary>
+        /// Convert an optional value into a Result. The result, being optional, is of type Maybe.
+        /// </summary>
+        public static Result<Maybe<TOut>, TError> BindOptional<TIn, TOut, TError>(
+            this Maybe<TIn> maybe,
+            Func<TIn, Result<TOut, TError>> bind)
+        {
+            return maybe.Bind(v => Maybe.From(bind(v))).Optional();
+        }
+    }
+}

--- a/CSharpFunctionalExtensions/Maybe/Extensions/Optional.cs
+++ b/CSharpFunctionalExtensions/Maybe/Extensions/Optional.cs
@@ -1,0 +1,33 @@
+namespace CSharpFunctionalExtensions
+{
+    public static partial class MaybeExtensions
+    {
+        /// <summary>
+        /// Mark the possibly null value as optional. Null is not an error, it's just null.
+        /// </summary>
+        public static Result<Maybe<T>, E> Optional<T, E>(this Maybe<Result<T, E>> maybe)
+        {
+            if (maybe.HasNoValue)
+                return Result.Success<Maybe<T>, E>(Maybe<T>.None);
+
+            if (maybe.Value.IsFailure)
+                return Result.Failure<Maybe<T>, E>(maybe.Value.Error);
+
+            return Result.Success<Maybe<T>, E>(Maybe.From(maybe.Value.Value));
+        }
+        
+        /// <summary>
+        /// Mark the possibly null value as optional. Null is not an error, it's just null.
+        /// </summary>
+        public static Result<Maybe<T>> Optional<T>(this Maybe<Result<T>> maybe)
+        {
+            if (maybe.HasNoValue)
+                return Result.Success<Maybe<T>>(Maybe<T>.None);
+
+            if (maybe.Value.IsFailure)
+                return Result.Failure<Maybe<T>>(maybe.Value.Error);
+
+            return Result.Success<Maybe<T>>(Maybe.From(maybe.Value.Value));
+        }
+    }
+}

--- a/CSharpFunctionalExtensions/Result/Methods/Extensions/BindOptional.cs
+++ b/CSharpFunctionalExtensions/Result/Methods/Extensions/BindOptional.cs
@@ -1,0 +1,25 @@
+using System;
+
+namespace CSharpFunctionalExtensions
+{
+    public static partial class ResultExtensions
+    {
+        /// <summary>
+        /// Change from one result type to another, while staying optional (the return type still contains <see cref="Maybe"/>)
+        /// Even though it's a Result&lt;Maybe&gt;, the mapping function only has to
+        /// operate on the innermost value, and is only called if it's present.
+        /// </summary>
+        public static Result<Maybe<K>, E> BindOptional<T, K, E>(
+            this Result<Maybe<T>, E> result,
+            Func<T, Result<K, E>> bind)
+        {
+            if (result.IsFailure)
+                return Result.Failure<Maybe<K>, E>(result.Error);
+
+            if (result.Value.HasNoValue)
+                return Result.Success<Maybe<K>, E>(Maybe.None);
+            
+            return bind(result.Value.Value).Map(Maybe.From);
+        }
+    }
+}

--- a/CSharpFunctionalExtensions/Result/Methods/Extensions/EnsureNot.cs
+++ b/CSharpFunctionalExtensions/Result/Methods/Extensions/EnsureNot.cs
@@ -1,0 +1,19 @@
+using System;
+
+namespace CSharpFunctionalExtensions
+{
+    public static partial class ResultExtensions
+    {
+        /// <summary>
+        ///     Returns a new failure result if the predicate is true. Otherwise returns the starting result.
+        /// </summary>
+        public static Result<T> EnsureNot<T>(this Result<T> result, Func<T, bool> test, string error) =>
+            result.Ensure(v => !test(v), error);
+        
+        /// <summary>
+        ///     Returns a new failure result if the predicate is true. Otherwise returns the starting result.
+        /// </summary>
+        public static Result<T, E> EnsureNot<T, E>(this Result<T, E> result, Func<T, bool> test, E error) =>
+            result.Ensure(v => !test(v), error);
+    }
+}

--- a/CSharpFunctionalExtensions/Result/Methods/Extensions/Map.cs
+++ b/CSharpFunctionalExtensions/Result/Methods/Extensions/Map.cs
@@ -107,5 +107,25 @@ namespace CSharpFunctionalExtensions
 
             return Result.Success(func(context));
         }
+
+        public static Result<Maybe<K>> Map<T, K>(
+            this Result<Maybe<T>> result,
+            Func<T, K> func)
+        {
+            if (result.IsFailure)
+                return Result.Failure<Maybe<K>>(result.Error);
+
+            return Result.Success<Maybe<K>>(result.Value.Map(func));
+        }
+        
+        public static Result<Maybe<K>, E> Map<T, K, E>(
+            this Result<Maybe<T>, E> result,
+            Func<T, K> func)
+        {
+            if (result.IsFailure)
+                return Result.Failure<Maybe<K>, E>(result.Error);
+
+            return Result.Success<Maybe<K>, E>(result.Value.Map(func));
+        }
     }
 }

--- a/CSharpFunctionalExtensions/Result/Methods/Extensions/Required.cs
+++ b/CSharpFunctionalExtensions/Result/Methods/Extensions/Required.cs
@@ -1,0 +1,17 @@
+namespace CSharpFunctionalExtensions
+{
+    public static partial class ResultExtensions
+    {
+        /// <summary>
+        /// The optional value is required, so convert to a failed result if there's no value.
+        /// </summary>
+        public static Result<T, E> Required<T, E>(this Result<Maybe<T>, E> result, E error) =>
+            result.Bind(value => value.ToResult(error));
+        
+        /// <summary>
+        /// The optional value is required, so convert to a failed result if there's no value.
+        /// </summary>
+        public static Result<T> Required<T>(this Result<Maybe<T>> result, string error) =>
+            result.Bind(value => value.ToResult(error));
+    }
+}


### PR DESCRIPTION
Adds some more extension methods, mostly to make it easier to work with Result<Maybe

This is related to #545
There's probably a lot to go before these can get merged in.
Unit tests? Task and Value task?
But I figured might as well get the ball rolling.