### PR TITLE
Add CSharpFunctionalExtensions.HttpResults to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -607,6 +607,36 @@ result.Should().SucceedWith(69); // throws
 result.Should().Fail(); // throws
 ```
 
+## Web APIs / HttpResults
+
+### [CSharpFunctionalExtensions.HttpResults](https://github.com/co-IT/CSharpFunctionalExtensions.HttpResults)
+
+This library provides convenient extension methods to seamlessly map Results from [CSharpFunctionalExtensions](https://github.com/vkhorikov/CSharpFunctionalExtensions) to HttpResults. With this, it streamlines your Web API resulting in cleaner, more fluent code.
+
+#### Key Benefits
+
+- ⚙️ **Zero Configuration:** Get started immediately — the mapping works out of the box without any configuration.
+- 🛠️ **Customizable Mappings:** Tailor default mappings or define custom mappings for specific use cases.
+- 🔗 **Fluent API:** Maintain a smooth, railway-oriented flow by chaining HttpResult mappings at the end of your Result chain.
+- 🧱 **Separation of Domain and HTTP Errors:** Keeps domain errors distinct from HTTP errors, improving maintainability and clarity between business logic and web API concerns.
+- ⚡ **Minimal APIs & Controllers Support:** Works with both Minimal APIs and traditional controllers in ASP.NET.
+- 📦 **Full Support for ASP.NET Results:** Supports all built-in HTTP response types in ASP.NET, including `Ok`, `Created`, `NoContent`, `Accepted`, `FileStream`, and more.
+- 🦺 **Typed Results:** Utilizes `TypedResults` for consistent, type-safe API responses.
+- 📑 **OpenAPI Ready:** Ensures accurate OpenAPI generation for clear and reliable API documentation.
+- 🛡️ **RFC Compliance:** Default mappings adhere to the RFC 9457 standard (`ProblemDetails`), ensuring your API errors are standardized and interoperable.
+- 🧑‍💻 **Developer-Friendly:** Includes built-in analyzers and source generators to speed up development and reduce errors.
+
+#### Example
+
+```csharp
+app.MapGet("/books", (BookService service) =>
+    service.Get()       //Result<Book[]>
+      .ToOkHttpResult() //Results<Ok<Book[]>, ProblemHttpResult>
+);
+```
+
+Check the repo out [here](https://github.com/co-IT/CSharpFunctionalExtensions.HttpResults).
+
 ## Analyzers
 
 ### [CSharpFunctionalExtensions.Analyzers](https://github.com/AlmarAubel/CSharpFunctionalExtensions.Analyzers)

--- a/README.md
+++ b/README.md
@@ -585,7 +585,7 @@ Console.WriteLine(bananaInventory.MapError(ErrorEnhancer).ToString()); // "Faile
 
 ## Testing
 
-### CSharpFunctionalExtensions.FluentAssertions
+### [CSharpFunctionalExtensions.FluentAssertions](https://github.com/NitroDevs/CSharpFunctionalExtensions.FluentAssertions)
 
 A small set of extensions to make test assertions more fluent when using CSharpFunctionalExtensions! Check out the [repo for this library](https://github.com/NitroDevs/CSharpFunctionalExtensions.FluentAssertions) more information!
 


### PR DESCRIPTION
I’m developing a satellite library for **CSharpFunctionalExtensions** to integrate `Result` types into ASP.NET Web APIs more seamlessly.

The library, [CSharpFunctionalExtensions.HttpResults](https://github.com/co-IT/CSharpFunctionalExtensions.HttpResults), provides extension methods that map `Result` objects to HttpResults, making Web API development cleaner and more fluent.

Basically you just have to call the mapping method at the end of the Result chain:

```csharp
app.MapGet("/books", (BookService service) =>
    service.Get()       //Result<Book[]>
      .ToOkHttpResult() //Results<Ok<Book[]>, ProblemHttpResult>
);
```

You can find more information in the libraries [README](https://github.com/co-IT/CSharpFunctionalExtensions.HttpResults).

This library is already used in production and has received positive feedback. To help others discover it and simplify their work with Web APIs, I propose adding a reference to it in the README as done with the other two satellite libraries.

Would love to hear your thoughts! 🚀