### PR TITLE
Add Tap* extensions to Maybe

### DIFF
--- a/CSharpFunctionalExtensions.Tests/MaybeTests/Extensions/TapNoValueTests.Task.Left.cs
+++ b/CSharpFunctionalExtensions.Tests/MaybeTests/Extensions/TapNoValueTests.Task.Left.cs
@@ -1,0 +1,22 @@
+using System.Threading.Tasks;
+using FluentAssertions;
+using Xunit;
+
+namespace CSharpFunctionalExtensions.Tests.MaybeTests.Extensions
+{
+    public class TapNoValueTests_Task_Left : MaybeTestBase
+    {
+        [Fact]
+        public async Task TapNoValue_Task_Left_executes_action_when_no_value()
+        {
+            string property = null;
+
+            Maybe<T> maybe = null;
+
+            var returnedMaybe = await maybe.AsTask().TapNoValue(() => property = "Some value");
+
+            property.Should().Be("Some value");
+            returnedMaybe.Should().BeSameAs(maybe);
+        }
+    }
+}

--- a/CSharpFunctionalExtensions.Tests/MaybeTests/Extensions/TapNoValueTests.Task.Right.cs
+++ b/CSharpFunctionalExtensions.Tests/MaybeTests/Extensions/TapNoValueTests.Task.Right.cs
@@ -1,0 +1,26 @@
+using System.Threading.Tasks;
+using FluentAssertions;
+using Xunit;
+
+namespace CSharpFunctionalExtensions.Tests.MaybeTests.Extensions
+{
+    public class TapNoValueTests_Task_Right : MaybeTestBase
+    {
+        [Fact]
+        public async Task TapNoValue_Task_Right_executes_action_when_no_value()
+        {
+            string property = null;
+
+            Maybe<T> maybe = null;
+
+            var returnedMaybe = await maybe.TapNoValue(() =>
+            {
+                property = "Some value";
+                return Task.CompletedTask;
+            });
+
+            property.Should().Be("Some value");
+            returnedMaybe.Should().BeSameAs(maybe);
+        }
+    }
+}

--- a/CSharpFunctionalExtensions.Tests/MaybeTests/Extensions/TapNoValueTests.Task.cs
+++ b/CSharpFunctionalExtensions.Tests/MaybeTests/Extensions/TapNoValueTests.Task.cs
@@ -1,0 +1,28 @@
+using System.Threading.Tasks;
+using FluentAssertions;
+using Xunit;
+
+namespace CSharpFunctionalExtensions.Tests.MaybeTests.Extensions
+{
+    public class TapNoValueTests_Task : MaybeTestBase
+    {
+        [Fact]
+        public async Task TapNoValue_Task_executes_action_when_no_value()
+        {
+            string property = null;
+
+            Maybe<T> maybe = null;
+
+            var returnedMaybe = await maybe
+                .AsTask()
+                .TapNoValue(() =>
+                {
+                    property = "Some value";
+                    return Task.CompletedTask;
+                });
+
+            property.Should().Be("Some value");
+            returnedMaybe.Should().BeSameAs(maybe);
+        }
+    }
+}

--- a/CSharpFunctionalExtensions.Tests/MaybeTests/Extensions/TapNoValueTests.ValueTask.Left.cs
+++ b/CSharpFunctionalExtensions.Tests/MaybeTests/Extensions/TapNoValueTests.ValueTask.Left.cs
@@ -1,0 +1,23 @@
+using System.Threading.Tasks;
+using CSharpFunctionalExtensions.ValueTasks;
+using FluentAssertions;
+using Xunit;
+
+namespace CSharpFunctionalExtensions.Tests.MaybeTests.Extensions
+{
+    public class TapNoValueTests_ValueTask_Left : MaybeTestBase
+    {
+        [Fact]
+        public async Task TapNoValue_ValueTask_Left_executes_action_when_no_value()
+        {
+            string property = null;
+
+            Maybe<T> maybe = null;
+
+            var returnedMaybe = await maybe.AsValueTask().TapNoValue(() => property = "Some value");
+
+            property.Should().Be("Some value");
+            returnedMaybe.Should().BeSameAs(maybe);
+        }
+    }
+}

--- a/CSharpFunctionalExtensions.Tests/MaybeTests/Extensions/TapNoValueTests.ValueTask.Right.cs
+++ b/CSharpFunctionalExtensions.Tests/MaybeTests/Extensions/TapNoValueTests.ValueTask.Right.cs
@@ -1,0 +1,27 @@
+using System.Threading.Tasks;
+using CSharpFunctionalExtensions.ValueTasks;
+using FluentAssertions;
+using Xunit;
+
+namespace CSharpFunctionalExtensions.Tests.MaybeTests.Extensions
+{
+    public class TapNoValueTests_ValueTask_Right : MaybeTestBase
+    {
+        [Fact]
+        public async Task TapNoValue_ValueTask_Right_executes_action_when_no_value()
+        {
+            string property = null;
+
+            Maybe<T> maybe = null;
+
+            var returnedMaybe = await maybe.TapNoValue(() =>
+            {
+                property = "Some value";
+                return ValueTask.CompletedTask;
+            });
+
+            property.Should().Be("Some value");
+            returnedMaybe.Should().BeSameAs(maybe);
+        }
+    }
+}

--- a/CSharpFunctionalExtensions.Tests/MaybeTests/Extensions/TapNoValueTests.ValueTask.cs
+++ b/CSharpFunctionalExtensions.Tests/MaybeTests/Extensions/TapNoValueTests.ValueTask.cs
@@ -1,0 +1,29 @@
+using System.Threading.Tasks;
+using CSharpFunctionalExtensions.ValueTasks;
+using FluentAssertions;
+using Xunit;
+
+namespace CSharpFunctionalExtensions.Tests.MaybeTests.Extensions
+{
+    public class TapNoValueTests_ValueTask : MaybeTestBase
+    {
+        [Fact]
+        public async Task TapNoValue_ValueTask_executes_action_when_no_value()
+        {
+            string property = null;
+
+            Maybe<T> maybe = null;
+
+            var returnedMaybe = await maybe
+                .AsValueTask()
+                .TapNoValue(() =>
+                {
+                    property = "Some value";
+                    return ValueTask.CompletedTask;
+                });
+
+            property.Should().Be("Some value");
+            returnedMaybe.Should().BeSameAs(maybe);
+        }
+    }
+}

--- a/CSharpFunctionalExtensions.Tests/MaybeTests/Extensions/TapNoValueTests.cs
+++ b/CSharpFunctionalExtensions.Tests/MaybeTests/Extensions/TapNoValueTests.cs
@@ -1,0 +1,21 @@
+using FluentAssertions;
+using Xunit;
+
+namespace CSharpFunctionalExtensions.Tests.MaybeTests.Extensions
+{
+    public class TapNoValueTests : MaybeTestBase
+    {
+        [Fact]
+        public void TapNoValue_executes_action_when_no_value()
+        {
+            string property = null;
+
+            Maybe<T> maybe = null;
+
+            var returnedMaybe = maybe.TapNoValue(() => property = "Some value");
+
+            property.Should().Be("Some value");
+            returnedMaybe.Should().BeSameAs(maybe);
+        }
+    }
+}

--- a/CSharpFunctionalExtensions.Tests/MaybeTests/Extensions/TapTests.Task.Left.cs
+++ b/CSharpFunctionalExtensions.Tests/MaybeTests/Extensions/TapTests.Task.Left.cs
@@ -1,0 +1,31 @@
+using System.Threading.Tasks;
+using FluentAssertions;
+using Xunit;
+
+namespace CSharpFunctionalExtensions.Tests.MaybeTests.Extensions
+{
+    public class TapTests_Task_Left : MaybeTestBase
+    {
+        [Fact]
+        public async Task Tap_Task_Lef_does_not_execute_action_if_no_value()
+        {
+            Maybe<T> maybe = null;
+
+            var returnedMaybe = await maybe.AsTask().Tap(value => maybe = T.Value);
+
+            maybe.HasNoValue.Should().BeTrue();
+            returnedMaybe.Should().BeSameAs(maybe);
+        }
+
+        [Fact]
+        public async Task Tap_Task_Lef_executes_action_if_value()
+        {
+            Maybe<T> maybe = T.Value;
+
+            var returnedMaybe = await maybe.AsTask().Tap(value => value.Should().Be(T.Value));
+
+            maybe.Value.Should().Be(T.Value);
+            returnedMaybe.Should().BeSameAs(maybe);
+        }
+    }
+}

--- a/CSharpFunctionalExtensions.Tests/MaybeTests/Extensions/TapTests.Task.Right.cs
+++ b/CSharpFunctionalExtensions.Tests/MaybeTests/Extensions/TapTests.Task.Right.cs
@@ -1,0 +1,40 @@
+using System.Threading.Tasks;
+using FluentAssertions;
+using Xunit;
+
+namespace CSharpFunctionalExtensions.Tests.MaybeTests.Extensions
+{
+    public class TapTests_Task_Right : MaybeTestBase
+    {
+        [Fact]
+        public async Task Tap_Task_Right_does_not_execute_action_if_no_value()
+        {
+            Maybe<T> maybe = null;
+
+            var returnedMaybe = await maybe.Tap(value =>
+            {
+                maybe = T.Value;
+                return Task.CompletedTask;
+            });
+
+            maybe.HasNoValue.Should().BeTrue();
+            returnedMaybe.Should().BeSameAs(maybe);
+        }
+
+        [Fact]
+        public async Task Tap_Task_Right_executes_action_if_value()
+        {
+            Maybe<T> maybe = T.Value;
+
+
+            var returnedMaybe = await maybe.Tap(value =>
+            {
+                value.Should().Be(T.Value);
+                return Task.CompletedTask;
+            });
+
+            maybe.Value.Should().Be(T.Value);
+            returnedMaybe.Should().BeSameAs(maybe);
+        }
+    }
+}

--- a/CSharpFunctionalExtensions.Tests/MaybeTests/Extensions/TapTests.Task.cs
+++ b/CSharpFunctionalExtensions.Tests/MaybeTests/Extensions/TapTests.Task.cs
@@ -1,0 +1,43 @@
+using System.Threading.Tasks;
+using FluentAssertions;
+using Xunit;
+
+namespace CSharpFunctionalExtensions.Tests.MaybeTests.Extensions
+{
+    public class TapTests_Task : MaybeTestBase
+    {
+        [Fact]
+        public async Task Tap_Task_does_not_execute_action_if_no_value()
+        {
+            Maybe<T> maybe = null;
+
+            var returnedMaybe = await maybe
+                .AsTask()
+                .Tap(value =>
+                {
+                    maybe = T.Value;
+                    return Task.CompletedTask;
+                });
+
+            maybe.HasNoValue.Should().BeTrue();
+            returnedMaybe.Should().BeSameAs(maybe);
+        }
+
+        [Fact]
+        public async Task Tap_Task_executes_action_if_value()
+        {
+            Maybe<T> maybe = T.Value;
+
+            var returnedMaybe = await maybe
+                .AsTask()
+                .Tap(value =>
+                {
+                    value.Should().Be(T.Value);
+                    return Task.CompletedTask;
+                });
+
+            maybe.Value.Should().Be(T.Value);
+            returnedMaybe.Should().BeSameAs(maybe);
+        }
+    }
+}

--- a/CSharpFunctionalExtensions.Tests/MaybeTests/Extensions/TapTests.ValueTask.Left.cs
+++ b/CSharpFunctionalExtensions.Tests/MaybeTests/Extensions/TapTests.ValueTask.Left.cs
@@ -1,0 +1,32 @@
+using System.Threading.Tasks;
+using CSharpFunctionalExtensions.ValueTasks;
+using FluentAssertions;
+using Xunit;
+
+namespace CSharpFunctionalExtensions.Tests.MaybeTests.Extensions
+{
+    public class TapTests_ValueTask_Left : MaybeTestBase
+    {
+        [Fact]
+        public async Task Tap_ValueTask_Lef_does_not_execute_action_if_no_value()
+        {
+            Maybe<T> maybe = null;
+
+            var returnedMaybe = await maybe.AsValueTask().Tap(value => maybe = T.Value);
+
+            maybe.HasNoValue.Should().BeTrue();
+            returnedMaybe.Should().BeSameAs(maybe);
+        }
+
+        [Fact]
+        public async Task Tap_ValueTask_Lef_executes_action_if_value()
+        {
+            Maybe<T> maybe = T.Value;
+
+            var returnedMaybe = await maybe.AsValueTask().Tap(value => value.Should().Be(T.Value));
+
+            maybe.Value.Should().Be(T.Value);
+            returnedMaybe.Should().BeSameAs(maybe);
+        }
+    }
+}

--- a/CSharpFunctionalExtensions.Tests/MaybeTests/Extensions/TapTests.ValueTask.Right.cs
+++ b/CSharpFunctionalExtensions.Tests/MaybeTests/Extensions/TapTests.ValueTask.Right.cs
@@ -1,0 +1,40 @@
+using System.Threading.Tasks;
+using CSharpFunctionalExtensions.ValueTasks;
+using FluentAssertions;
+using Xunit;
+
+namespace CSharpFunctionalExtensions.Tests.MaybeTests.Extensions
+{
+    public class TapTests_ValueTask_Right : MaybeTestBase
+    {
+        [Fact]
+        public async Task Tap_ValueTask_Right_does_not_execute_action_if_no_value()
+        {
+            Maybe<T> maybe = null;
+
+            var returnedMaybe = await maybe.Tap(value =>
+            {
+                maybe = T.Value;
+                return ValueTask.CompletedTask;
+            });
+
+            maybe.HasNoValue.Should().BeTrue();
+            returnedMaybe.Should().BeSameAs(maybe);
+        }
+
+        [Fact]
+        public async Task Tap_ValueTask_Right_executes_action_if_value()
+        {
+            Maybe<T> maybe = T.Value;
+
+            var returnedMaybe = await maybe.Tap(value =>
+            {
+                value.Should().Be(T.Value);
+                return ValueTask.CompletedTask;
+            });
+
+            maybe.Value.Should().Be(T.Value);
+            returnedMaybe.Should().BeSameAs(maybe);
+        }
+    }
+}

--- a/CSharpFunctionalExtensions.Tests/MaybeTests/Extensions/TapTests.ValueTask.cs
+++ b/CSharpFunctionalExtensions.Tests/MaybeTests/Extensions/TapTests.ValueTask.cs
@@ -1,0 +1,44 @@
+using System.Threading.Tasks;
+using CSharpFunctionalExtensions.ValueTasks;
+using FluentAssertions;
+using Xunit;
+
+namespace CSharpFunctionalExtensions.Tests.MaybeTests.Extensions
+{
+    public class TapTests_ValueTask : MaybeTestBase
+    {
+        [Fact]
+        public async Task Tap_ValueTask_does_not_execute_action_if_no_value()
+        {
+            Maybe<T> maybe = null;
+
+            var returnedMaybe = await maybe
+                .AsValueTask()
+                .Tap(value =>
+                {
+                    maybe = T.Value;
+                    return ValueTask.CompletedTask;
+                });
+
+            maybe.HasNoValue.Should().BeTrue();
+            returnedMaybe.Should().BeSameAs(maybe);
+        }
+
+        [Fact]
+        public async Task Tap_ValueTask_executes_action_if_value()
+        {
+            Maybe<T> maybe = T.Value;
+
+            var returnedMaybe = await maybe
+                .AsValueTask()
+                .Tap(value =>
+                {
+                    value.Should().Be(T.Value);
+                    return ValueTask.CompletedTask;
+                });
+
+            maybe.Value.Should().Be(T.Value);
+            returnedMaybe.Should().BeSameAs(maybe);
+        }
+    }
+}

--- a/CSharpFunctionalExtensions.Tests/MaybeTests/Extensions/TapTests.cs
+++ b/CSharpFunctionalExtensions.Tests/MaybeTests/Extensions/TapTests.cs
@@ -1,0 +1,27 @@
+namespace CSharpFunctionalExtensions.Tests.MaybeTests.Extensions
+{
+    public class TapTests : MaybeTestBase
+    {
+        [Fact]
+        public void Tap_does_not_execute_action_if_no_value()
+        {
+            Maybe<T> maybe = null;
+
+            var returnedMaybe = maybe.Tap(value => maybe = T.Value);
+
+            maybe.HasNoValue.Should().BeTrue();
+            returnedMaybe.Should().BeSameAs(maybe);
+        }
+
+        [Fact]
+        public void Tap_executes_action_if_value()
+        {
+            Maybe<T> maybe = T.Value;
+
+            var returnedMaybe = maybe.Tap(value => value.Should().Be(T.Value));
+
+            maybe.Value.Should().Be(T.Value);
+            returnedMaybe.Should().BeSameAs(maybe);
+        }
+    }
+}

--- a/CSharpFunctionalExtensions/Maybe/Extensions/Execute.Task.Left.cs
+++ b/CSharpFunctionalExtensions/Maybe/Extensions/Execute.Task.Left.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Threading.Tasks;
 
 namespace CSharpFunctionalExtensions
@@ -12,6 +12,7 @@ namespace CSharpFunctionalExtensions
         /// <param name="action"></param>
         /// <typeparam name="T"></typeparam>
         /// <returns></returns>
+        [Obsolete("Use TapValue instead")]
         public static async Task Execute<T>(this Task<Maybe<T>> maybeTask, Action<T> action)
         {
             var maybe = await maybeTask.DefaultAwait();

--- a/CSharpFunctionalExtensions/Maybe/Extensions/Execute.Task.Right.cs
+++ b/CSharpFunctionalExtensions/Maybe/Extensions/Execute.Task.Right.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Threading.Tasks;
 
 namespace CSharpFunctionalExtensions
@@ -11,6 +11,7 @@ namespace CSharpFunctionalExtensions
         /// <param name="maybe"></param>
         /// <param name="action"></param>
         /// <typeparam name="T"></typeparam>
+        [Obsolete("Use TapValue instead")]
         public static async Task Execute<T>(this Maybe<T> maybe, Func<T, Task> action)
         {
             if (maybe.HasNoValue)

--- a/CSharpFunctionalExtensions/Maybe/Extensions/Execute.Task.cs
+++ b/CSharpFunctionalExtensions/Maybe/Extensions/Execute.Task.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Threading.Tasks;
 
 namespace CSharpFunctionalExtensions
@@ -12,6 +12,7 @@ namespace CSharpFunctionalExtensions
         /// <param name="asyncAction"></param>
         /// <typeparam name="T"></typeparam>
         /// <returns></returns>
+        [Obsolete("Use TapValue instead")]
         public static async Task Execute<T>(this Task<Maybe<T>> maybeTask, Func<T, Task> asyncAction)
         {
             var maybe = await maybeTask.DefaultAwait();

--- a/CSharpFunctionalExtensions/Maybe/Extensions/Execute.ValueTask.Left.cs
+++ b/CSharpFunctionalExtensions/Maybe/Extensions/Execute.ValueTask.Left.cs
@@ -1,4 +1,4 @@
-﻿#if NET5_0_OR_GREATER
+#if NET5_0_OR_GREATER
 using System;
 using System.Threading.Tasks;
 
@@ -13,6 +13,7 @@ namespace CSharpFunctionalExtensions.ValueTasks
         /// <param name="action"></param>
         /// <typeparam name="T"></typeparam>
         /// <returns></returns>
+        [Obsolete("Use TapValue instead")]
         public static async Task Execute<T>(this ValueTask<Maybe<T>> maybeTask, Action<T> action)
         {
             var maybe = await maybeTask;

--- a/CSharpFunctionalExtensions/Maybe/Extensions/Execute.ValueTask.Right.cs
+++ b/CSharpFunctionalExtensions/Maybe/Extensions/Execute.ValueTask.Right.cs
@@ -1,4 +1,4 @@
-﻿#if NET5_0_OR_GREATER
+#if NET5_0_OR_GREATER
 using System;
 using System.Threading.Tasks;
 
@@ -12,6 +12,7 @@ namespace CSharpFunctionalExtensions.ValueTasks
         /// <param name="maybe"></param>
         /// <param name="valueTask"></param>
         /// <typeparam name="T"></typeparam>
+        [Obsolete("Use TapValue instead")]
         public static async Task Execute<T>(this Maybe<T> maybe, Func<T, ValueTask> valueTask)
         {
             if (maybe.HasNoValue)

--- a/CSharpFunctionalExtensions/Maybe/Extensions/Execute.ValueTask.cs
+++ b/CSharpFunctionalExtensions/Maybe/Extensions/Execute.ValueTask.cs
@@ -1,4 +1,4 @@
-﻿#if NET5_0_OR_GREATER
+#if NET5_0_OR_GREATER
 using System;
 using System.Threading.Tasks;
 
@@ -13,6 +13,7 @@ namespace CSharpFunctionalExtensions.ValueTasks
         /// <param name="valueTask"></param>
         /// <typeparam name="T"></typeparam>
         /// <returns></returns>
+        [Obsolete("Use TapValue instead")]
         public static async Task Execute<T>(this ValueTask<Maybe<T>> maybeTask, Func<T, ValueTask> valueTask)
         {
             var maybe = await maybeTask;

--- a/CSharpFunctionalExtensions/Maybe/Extensions/Execute.cs
+++ b/CSharpFunctionalExtensions/Maybe/Extensions/Execute.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 
 namespace CSharpFunctionalExtensions
 {
@@ -10,6 +10,7 @@ namespace CSharpFunctionalExtensions
         /// <param name="maybe"></param>
         /// <param name="action"></param>
         /// <typeparam name="T"></typeparam>
+        [Obsolete("Use TapValue instead")]
         public static void Execute<T>(in this Maybe<T> maybe, Action<T> action)
         {
             if (maybe.HasNoValue)

--- a/CSharpFunctionalExtensions/Maybe/Extensions/ExecuteNoValue.Task.Left.cs
+++ b/CSharpFunctionalExtensions/Maybe/Extensions/ExecuteNoValue.Task.Left.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Threading.Tasks;
 
 namespace CSharpFunctionalExtensions
@@ -11,6 +11,7 @@ namespace CSharpFunctionalExtensions
         /// <param name="maybeTask"></param>
         /// <param name="action"></param>
         /// <typeparam name="T"></typeparam>
+        [Obsolete("Use TapNoValue instead")]
         public static async Task ExecuteNoValue<T>(this Task<Maybe<T>> maybeTask, Action action)
         {
             var maybe = await maybeTask.DefaultAwait();

--- a/CSharpFunctionalExtensions/Maybe/Extensions/ExecuteNoValue.Task.Right.cs
+++ b/CSharpFunctionalExtensions/Maybe/Extensions/ExecuteNoValue.Task.Right.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Threading.Tasks;
 
 namespace CSharpFunctionalExtensions
@@ -11,6 +11,7 @@ namespace CSharpFunctionalExtensions
         /// <param name="maybe"></param>
         /// <param name="action"></param>
         /// <typeparam name="T"></typeparam>
+        [Obsolete("Use TapNoValue instead")]
         public static async Task ExecuteNoValue<T>(this Maybe<T> maybe, Func<Task> action)
         {
             if (maybe.HasValue)

--- a/CSharpFunctionalExtensions/Maybe/Extensions/ExecuteNoValue.Task.cs
+++ b/CSharpFunctionalExtensions/Maybe/Extensions/ExecuteNoValue.Task.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Threading.Tasks;
 
 namespace CSharpFunctionalExtensions
@@ -11,6 +11,7 @@ namespace CSharpFunctionalExtensions
         /// <param name="maybeTask"></param>
         /// <param name="asyncAction"></param>
         /// <typeparam name="T"></typeparam>
+        [Obsolete("Use TapNoValue instead")]
         public static async Task ExecuteNoValue<T>(this Task<Maybe<T>> maybeTask, Func<Task> asyncAction)
         {
             var maybe = await maybeTask.DefaultAwait();

--- a/CSharpFunctionalExtensions/Maybe/Extensions/ExecuteNoValue.ValueTask.Left.cs
+++ b/CSharpFunctionalExtensions/Maybe/Extensions/ExecuteNoValue.ValueTask.Left.cs
@@ -1,4 +1,4 @@
-﻿#if NET5_0_OR_GREATER
+#if NET5_0_OR_GREATER
 using System;
 using System.Threading.Tasks;
 
@@ -12,6 +12,7 @@ namespace CSharpFunctionalExtensions.ValueTasks
         /// <param name="maybeTask"></param>
         /// <param name="action"></param>
         /// <typeparam name="T"></typeparam>
+        [Obsolete("Use TapNoValue instead")]
         public static async Task ExecuteNoValue<T>(this ValueTask<Maybe<T>> maybeTask, Action action)
         {
             var maybe = await maybeTask;

--- a/CSharpFunctionalExtensions/Maybe/Extensions/ExecuteNoValue.ValueTask.Right.cs
+++ b/CSharpFunctionalExtensions/Maybe/Extensions/ExecuteNoValue.ValueTask.Right.cs
@@ -1,4 +1,4 @@
-﻿#if NET5_0_OR_GREATER
+#if NET5_0_OR_GREATER
 using System;
 using System.Threading.Tasks;
 
@@ -12,6 +12,7 @@ namespace CSharpFunctionalExtensions.ValueTasks
         /// <param name="maybe"></param>
         /// <param name="valueTask"></param>
         /// <typeparam name="T"></typeparam>
+        [Obsolete("Use TapNoValue instead")]
         public static async Task ExecuteNoValue<T>(this Maybe<T> maybe, Func<ValueTask> valueTask)
         {
             if (maybe.HasValue)

--- a/CSharpFunctionalExtensions/Maybe/Extensions/ExecuteNoValue.ValueTask.cs
+++ b/CSharpFunctionalExtensions/Maybe/Extensions/ExecuteNoValue.ValueTask.cs
@@ -1,4 +1,4 @@
-﻿#if NET5_0_OR_GREATER
+#if NET5_0_OR_GREATER
 using System;
 using System.Threading.Tasks;
 
@@ -12,6 +12,7 @@ namespace CSharpFunctionalExtensions.ValueTasks
         /// <param name="maybeTask"></param>
         /// <param name="valueTask"></param>
         /// <typeparam name="T"></typeparam>
+        [Obsolete("Use TapNoValue instead")]
         public static async Task ExecuteNoValue<T>(this ValueTask<Maybe<T>> maybeTask, Func<ValueTask> valueTask)
         {
             var maybe = await maybeTask;

--- a/CSharpFunctionalExtensions/Maybe/Extensions/ExecuteNoValue.cs
+++ b/CSharpFunctionalExtensions/Maybe/Extensions/ExecuteNoValue.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 
 namespace CSharpFunctionalExtensions
 {
@@ -10,6 +10,7 @@ namespace CSharpFunctionalExtensions
         /// <param name="maybe"></param>
         /// <param name="action"></param>
         /// <typeparam name="T"></typeparam>
+        [Obsolete("Use TapNoValue instead")]
         public static void ExecuteNoValue<T>(in this Maybe<T> maybe, Action action)
         {
             if (maybe.HasValue)

--- a/CSharpFunctionalExtensions/Maybe/Extensions/Tap.Task.Left.cs
+++ b/CSharpFunctionalExtensions/Maybe/Extensions/Tap.Task.Left.cs
@@ -1,0 +1,28 @@
+using System;
+using System.Threading.Tasks;
+
+namespace CSharpFunctionalExtensions
+{
+    public static partial class MaybeExtensions
+    {
+        /// <summary>
+        ///     Executes the given <paramref name="action" /> if the <paramref name="maybeTask" /> produces a value
+        /// Returns the calling maybe.
+        /// </summary>
+        /// <param name="maybeTask"></param>
+        /// <param name="action"></param>
+        /// <typeparam name="T"></typeparam>
+        /// <returns>The calling maybe</returns>
+        public static async Task<Maybe<T>> Tap<T>(this Task<Maybe<T>> maybeTask, Action<T> action)
+        {
+            var maybe = await maybeTask.DefaultAwait();
+
+            if (maybe.HasValue)
+            {
+                action(maybe.GetValueOrThrow());
+            }
+
+            return maybe;
+        }
+    }
+}

--- a/CSharpFunctionalExtensions/Maybe/Extensions/Tap.Task.Right.cs
+++ b/CSharpFunctionalExtensions/Maybe/Extensions/Tap.Task.Right.cs
@@ -1,0 +1,26 @@
+using System;
+using System.Threading.Tasks;
+
+namespace CSharpFunctionalExtensions
+{
+    public static partial class MaybeExtensions
+    {
+        /// <summary>
+        ///     Executes the given async <paramref name="action" /> if the <paramref name="maybe" /> has a value
+        /// Returns the calling maybe.
+        /// </summary>
+        /// <param name="maybe"></param>
+        /// <param name="action"></param>
+        /// <typeparam name="T"></typeparam>
+        /// <returns>The calling maybe</returns>
+        public static async Task<Maybe<T>> Tap<T>(this Maybe<T> maybe, Func<T, Task> action)
+        {
+            if (maybe.HasValue)
+            {
+                await action(maybe.GetValueOrThrow()).DefaultAwait();
+            }
+
+            return maybe;
+        }
+    }
+}

--- a/CSharpFunctionalExtensions/Maybe/Extensions/Tap.Task.cs
+++ b/CSharpFunctionalExtensions/Maybe/Extensions/Tap.Task.cs
@@ -1,0 +1,31 @@
+using System;
+using System.Threading.Tasks;
+
+namespace CSharpFunctionalExtensions
+{
+    public static partial class MaybeExtensions
+    {
+        /// <summary>
+        ///     Executes the given <paramref name="asyncAction" /> if the <paramref name="maybeTask" /> produces a value
+        /// Returns the calling maybe.
+        /// </summary>
+        /// <param name="maybeTask"></param>
+        /// <param name="asyncAction"></param>
+        /// <typeparam name="T"></typeparam>
+        /// <returns>The calling maybe</returns>
+        public static async Task<Maybe<T>> Tap<T>(
+            this Task<Maybe<T>> maybeTask,
+            Func<T, Task> asyncAction
+        )
+        {
+            var maybe = await maybeTask.DefaultAwait();
+
+            if (maybe.HasValue)
+            {
+                await asyncAction(maybe.GetValueOrThrow()).DefaultAwait();
+            }
+
+            return maybe;
+        }
+    }
+}

--- a/CSharpFunctionalExtensions/Maybe/Extensions/Tap.ValueTask.Left.cs
+++ b/CSharpFunctionalExtensions/Maybe/Extensions/Tap.ValueTask.Left.cs
@@ -1,0 +1,33 @@
+#if NET5_0_OR_GREATER
+using System;
+using System.Threading.Tasks;
+
+namespace CSharpFunctionalExtensions.ValueTasks
+{
+    public static partial class MaybeExtensions
+    {
+        /// <summary>
+        /// Executes the given <paramref name="action" /> if the <paramref name="maybeTask" /> produces a value
+        /// Returns the calling maybe.
+        /// </summary>
+        /// <param name="maybeTask"></param>
+        /// <param name="action"></param>
+        /// <typeparam name="T"></typeparam>
+        /// <returns>The calling maybe</returns>
+        public static async ValueTask<Maybe<T>> Tap<T>(
+            this ValueTask<Maybe<T>> maybeTask,
+            Action<T> action
+        )
+        {
+            var maybe = await maybeTask;
+
+            if (maybe.HasValue)
+            {
+                action(maybe.GetValueOrThrow());
+            }
+
+            return maybe;
+        }
+    }
+}
+#endif

--- a/CSharpFunctionalExtensions/Maybe/Extensions/Tap.ValueTask.Right.cs
+++ b/CSharpFunctionalExtensions/Maybe/Extensions/Tap.ValueTask.Right.cs
@@ -1,0 +1,30 @@
+#if NET5_0_OR_GREATER
+using System;
+using System.Threading.Tasks;
+
+namespace CSharpFunctionalExtensions.ValueTasks
+{
+    public static partial class MaybeExtensions
+    {
+        /// <summary>
+        ///     Executes the given async <paramref name="valueTask" /> if the <paramref name="maybe" /> has a value
+        /// Returns the calling maybe.
+        /// </summary>
+        /// <param name="maybe"></param>
+        /// <param name="valueTask"></param>
+        /// <typeparam name="T"></typeparam>
+        public static async ValueTask<Maybe<T>> Tap<T>(
+            this Maybe<T> maybe,
+            Func<T, ValueTask> valueTask
+        )
+        {
+            if (maybe.HasValue)
+            {
+                await valueTask(maybe.GetValueOrThrow());
+            }
+
+            return maybe;
+        }
+    }
+}
+#endif

--- a/CSharpFunctionalExtensions/Maybe/Extensions/Tap.ValueTask.cs
+++ b/CSharpFunctionalExtensions/Maybe/Extensions/Tap.ValueTask.cs
@@ -1,0 +1,31 @@
+#if NET5_0_OR_GREATER
+using System;
+using System.Threading.Tasks;
+
+namespace CSharpFunctionalExtensions.ValueTasks
+{
+    public static partial class MaybeExtensions
+    {
+        /// <summary>
+        /// Executes the given <paramref name="valueTask" /> if the <paramref name="maybeTask" /> produces a value
+        /// Returns the calling maybe.
+        /// </summary>
+        /// <param name="maybeTask"></param>
+        /// <param name="valueTask"></param>
+        /// <typeparam name="T"></typeparam>
+        /// <returns>The calling maybe</returns>
+        public static async ValueTask<Maybe<T>> Tap<T>(
+            this ValueTask<Maybe<T>> maybeTask,
+            Func<T, ValueTask> valueTask
+        )
+        {
+            var maybe = await maybeTask;
+
+            if (maybe.HasValue)
+                await valueTask(maybe.GetValueOrThrow());
+
+            return maybe;
+        }
+    }
+}
+#endif

--- a/CSharpFunctionalExtensions/Maybe/Extensions/Tap.cs
+++ b/CSharpFunctionalExtensions/Maybe/Extensions/Tap.cs
@@ -1,0 +1,25 @@
+using System;
+
+namespace CSharpFunctionalExtensions
+{
+    public static partial class MaybeExtensions
+    {
+        /// <summary>
+        ///     Executes the given <paramref name="action" /> if the <paramref name="maybe" /> has a value
+        /// Returns the calling maybe.
+        /// </summary>
+        /// <param name="maybe"></param>
+        /// <param name="action"></param>
+        /// <typeparam name="T"></typeparam>
+        /// <returns>The calling maybe</returns>
+        public static Maybe<T> Tap<T>(in this Maybe<T> maybe, Action<T> action)
+        {
+            if (maybe.HasValue)
+            {
+                action(maybe.GetValueOrThrow());
+            }
+
+            return maybe;
+        }
+    }
+}

--- a/CSharpFunctionalExtensions/Maybe/Extensions/TapNoValue.Task.Left.cs
+++ b/CSharpFunctionalExtensions/Maybe/Extensions/TapNoValue.Task.Left.cs
@@ -1,0 +1,30 @@
+using System;
+using System.Threading.Tasks;
+
+namespace CSharpFunctionalExtensions
+{
+    public static partial class MaybeExtensions
+    {
+        /// <summary>
+        ///     Executes the given <paramref name="action" /> if the <paramref name="maybeTask" /> produces no value
+        /// Returns the calling maybe.
+        /// </summary>
+        /// <param name="maybeTask"></param>
+        /// <param name="action"></param>
+        /// <typeparam name="T"></typeparam>
+        /// <returns>The calling maybe</returns>
+        public static async Task<Maybe<T>> TapNoValue<T>(
+            this Task<Maybe<T>> maybeTask,
+            Action action
+        )
+        {
+            var maybe = await maybeTask.DefaultAwait();
+
+            if (maybe.HasNoValue)
+            {
+                action();
+            }
+            return maybe;
+        }
+    }
+}

--- a/CSharpFunctionalExtensions/Maybe/Extensions/TapNoValue.Task.Right.cs
+++ b/CSharpFunctionalExtensions/Maybe/Extensions/TapNoValue.Task.Right.cs
@@ -1,0 +1,26 @@
+using System;
+using System.Threading.Tasks;
+
+namespace CSharpFunctionalExtensions
+{
+    public static partial class MaybeExtensions
+    {
+        /// <summary>
+        ///     Executes the given async <paramref name="action" /> if the <paramref name="maybe" /> has no value
+        /// Returns the calling maybe.
+        /// </summary>
+        /// <param name="maybe"></param>
+        /// <param name="action"></param>
+        /// <typeparam name="T"></typeparam>
+        /// <returns>The calling maybe</returns>
+        public static async Task<Maybe<T>> TapNoValue<T>(this Maybe<T> maybe, Func<Task> action)
+        {
+            if (maybe.HasNoValue)
+            {
+                await action().DefaultAwait();
+            }
+
+            return maybe;
+        }
+    }
+}

--- a/CSharpFunctionalExtensions/Maybe/Extensions/TapNoValue.Task.cs
+++ b/CSharpFunctionalExtensions/Maybe/Extensions/TapNoValue.Task.cs
@@ -1,0 +1,30 @@
+using System;
+using System.Threading.Tasks;
+
+namespace CSharpFunctionalExtensions
+{
+    public static partial class MaybeExtensions
+    {
+        /// <summary>
+        ///     Executes the given <paramref name="asyncAction" /> if the <paramref name="maybeTask" /> produces no value
+        /// Returns the calling maybe.
+        /// </summary>
+        /// <param name="maybeTask"></param>
+        /// <param name="asyncAction"></param>
+        /// <typeparam name="T"></typeparam>
+        public static async Task<Maybe<T>> TapNoValue<T>(
+            this Task<Maybe<T>> maybeTask,
+            Func<Task> asyncAction
+        )
+        {
+            var maybe = await maybeTask.DefaultAwait();
+
+            if (maybe.HasNoValue)
+            {
+                await asyncAction().DefaultAwait();
+            }
+
+            return maybe;
+        }
+    }
+}

--- a/CSharpFunctionalExtensions/Maybe/Extensions/TapNoValue.ValueTask.Left.cs
+++ b/CSharpFunctionalExtensions/Maybe/Extensions/TapNoValue.ValueTask.Left.cs
@@ -1,0 +1,33 @@
+#if NET5_0_OR_GREATER
+using System;
+using System.Threading.Tasks;
+
+namespace CSharpFunctionalExtensions.ValueTasks
+{
+    public static partial class MaybeExtensions
+    {
+        /// <summary>
+        /// Executes the given <paramref name="action" /> if the <paramref name="maybeTask" /> produces no value
+        /// Returns the calling maybe.
+        /// </summary>
+        /// <param name="maybeTask"></param>
+        /// <param name="action"></param>
+        /// <typeparam name="T"></typeparam>
+        /// <returns>The calling maybe</returns>
+        public static async ValueTask<Maybe<T>> TapNoValue<T>(
+            this ValueTask<Maybe<T>> maybeTask,
+            Action action
+        )
+        {
+            var maybe = await maybeTask;
+
+            if (maybe.HasNoValue)
+            {
+                action();
+            }
+
+            return maybe;
+        }
+    }
+}
+#endif

--- a/CSharpFunctionalExtensions/Maybe/Extensions/TapNoValue.ValueTask.Right.cs
+++ b/CSharpFunctionalExtensions/Maybe/Extensions/TapNoValue.ValueTask.Right.cs
@@ -1,0 +1,31 @@
+#if NET5_0_OR_GREATER
+using System;
+using System.Threading.Tasks;
+
+namespace CSharpFunctionalExtensions.ValueTasks
+{
+    public static partial class MaybeExtensions
+    {
+        /// <summary>
+        ///     Executes the given async <paramref name="valueTask" /> if the <paramref name="maybe" /> has no value
+        /// Returns the calling maybe.
+        /// </summary>
+        /// <param name="maybe"></param>
+        /// <param name="valueTask"></param>
+        /// <typeparam name="T"></typeparam>
+        /// <returns>The calling maybe</returns>
+        public static async ValueTask<Maybe<T>> TapNoValue<T>(
+            this Maybe<T> maybe,
+            Func<ValueTask> valueTask
+        )
+        {
+            if (maybe.HasNoValue)
+            {
+                await valueTask();
+            }
+
+            return maybe;
+        }
+    }
+}
+#endif

--- a/CSharpFunctionalExtensions/Maybe/Extensions/TapNoValue.ValueTask.cs
+++ b/CSharpFunctionalExtensions/Maybe/Extensions/TapNoValue.ValueTask.cs
@@ -1,0 +1,33 @@
+#if NET5_0_OR_GREATER
+using System;
+using System.Threading.Tasks;
+
+namespace CSharpFunctionalExtensions.ValueTasks
+{
+    public static partial class MaybeExtensions
+    {
+        /// <summary>
+        /// Executes the given <paramref name="valueTask" /> if the <paramref name="maybeTask" /> produces no value
+        /// Returns the calling maybe.
+        /// </summary>
+        /// <param name="maybeTask"></param>
+        /// <param name="valueTask"></param>
+        /// <typeparam name="T"></typeparam>
+        /// <returns>The calling maybe</returns>
+        public static async Task<Maybe<T>> TapNoValue<T>(
+            this ValueTask<Maybe<T>> maybeTask,
+            Func<ValueTask> valueTask
+        )
+        {
+            var maybe = await maybeTask;
+
+            if (maybe.HasNoValue)
+            {
+                await valueTask();
+            }
+
+            return maybe;
+        }
+    }
+}
+#endif

--- a/CSharpFunctionalExtensions/Maybe/Extensions/TapNoValue.cs
+++ b/CSharpFunctionalExtensions/Maybe/Extensions/TapNoValue.cs
@@ -1,0 +1,25 @@
+using System;
+
+namespace CSharpFunctionalExtensions
+{
+    public static partial class MaybeExtensions
+    {
+        /// <summary>
+        ///     Executes the given <paramref name="action" /> if the <paramref name="maybe" /> has no value
+        /// Returns the calling maybe.
+        /// </summary>
+        /// <param name="maybe"></param>
+        /// <param name="action"></param>
+        /// <typeparam name="T"></typeparam>
+        /// <returns>The calling maybe</returns>
+        public static Maybe<T> TapNoValue<T>(in this Maybe<T> maybe, Action action)
+        {
+            if (maybe.HasNoValue)
+            {
+                action();
+            }
+
+            return maybe;
+        }
+    }
+}


### PR DESCRIPTION
I find the existing `Execute`/`ExecuteNoValue` extensions a bit inconvenient, due to:

1. Naming that could just reuse the established `Tap` nomenclature (used in `Result` already)
2. `void` return type prohibiting fluent method chaining.

With `Execute` the flow looks as follows:

```cs
var maybe = GetMaybe();

maybe.ExecuteNoValue(() => logger.LogWarning("There was no value"));

return maybe.Or(someDefaultValue);
```

With the new `Tap`, it could be:

```cs
return GetMaybe()
   .TapNoValue(() => logger.LogWarning("There was no value"))
   .Or(someDefaultValue);
```

I also added `Obsolete` attribute to `Execute` since I think it's not really needed when `Tap` is there. Please do let me know if that's alright.

The new code is really just a copy of existing `Execute`/`ExecuteNoValue` code with added return functionality. Tests are also mostly copied.