### PR TITLE
Drop .NET 6 target (EOL) and add .NET 10

### DIFF
--- a/CSharpFunctionalExtensions.StrongName/CSharpFunctionalExtensions.StrongName.csproj
+++ b/CSharpFunctionalExtensions.StrongName/CSharpFunctionalExtensions.StrongName.csproj
@@ -10,11 +10,11 @@
   <PropertyGroup Condition="'$(TargetFramework)'=='netstandard2.0'">
     <AssemblyTitle>CSharpFunctionalExtensions (with a strong name) .NET Standard 2.0</AssemblyTitle>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(TargetFramework)'=='net6.0'">
-    <AssemblyTitle>CSharpFunctionalExtensions (with a strong name) .NET 6.0</AssemblyTitle>
-  </PropertyGroup>
   <PropertyGroup Condition="'$(TargetFramework)'=='net8.0'">
     <AssemblyTitle>CSharpFunctionalExtensions (with a strong name) .NET 8.0</AssemblyTitle>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(TargetFramework)'=='net10.0'">
+    <AssemblyTitle>CSharpFunctionalExtensions (with a strong name) .NET 10.0</AssemblyTitle>
   </PropertyGroup>
 
   <ItemGroup>

--- a/CSharpFunctionalExtensions.Tests/CSharpFunctionalExtensions.Tests.csproj
+++ b/CSharpFunctionalExtensions.Tests/CSharpFunctionalExtensions.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <NoWarn>0618</NoWarn>
   </PropertyGroup>
 

--- a/CSharpFunctionalExtensions/CSharpFunctionalExtensions.csproj
+++ b/CSharpFunctionalExtensions/CSharpFunctionalExtensions.csproj
@@ -8,11 +8,11 @@
   <PropertyGroup Condition="'$(TargetFramework)'=='netstandard2.0'">
     <AssemblyTitle>CSharpFunctionalExtensions .NET Standard 2.0</AssemblyTitle>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(TargetFramework)'=='net6.0'">
-    <AssemblyTitle>CSharpFunctionalExtensions .NET 6.0</AssemblyTitle>
-  </PropertyGroup>
   <PropertyGroup Condition="'$(TargetFramework)'=='net8.0'">
     <AssemblyTitle>CSharpFunctionalExtensions .NET 8.0</AssemblyTitle>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(TargetFramework)'=='net10.0'">
+    <AssemblyTitle>CSharpFunctionalExtensions .NET 10.0</AssemblyTitle>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Common.Build.props
+++ b/Common.Build.props
@@ -1,6 +1,6 @@
 <Project>
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net8.0;net10.0</TargetFrameworks>
     <Authors>Vladimir Khorikov</Authors>
     <Description>CSharpFunctionalExtensions - functional extensions for C#</Description>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:8.0 as build
+FROM mcr.microsoft.com/dotnet/sdk:10.0 as build
 
 ARG Version
 WORKDIR /app


### PR DESCRIPTION
.NET 6 reached end of support on 2024-11-12; removed from target frameworks. .NET 10 added as a new target alongside netstandard2.0 and net8.0. Tests project bumped to net10.0.
Dockerfile SDK image bumped to dotnet/sdk:10.0.